### PR TITLE
Kokoro doesn't support mvn yet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -x
 
 if [ "$1" == "release" ]; then
   # TODO load keys from internal storage
-  mvn clean install
+  # mvn clean install
 else
-  mvn clean install
+  # mvn clean install
 fi


### PR DESCRIPTION
@chanseokoh New plan is to build the binary manually and use kokoro only to sign it. Once kokoro adds maven support, we can let it build too.