### PR TITLE
remove deployment preferences

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/XmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/XmlTest.java
@@ -39,9 +39,9 @@ public class XmlTest {
   @Test
   public void testLimitedVisibility() {
     NodeList pages = doc.getElementsByTagName("page");
-    Assert.assertEquals(2, pages.getLength());
+    Assert.assertEquals(1, pages.getLength());
     NodeList enabledWhen = doc.getElementsByTagName("enabledWhen");
-    Assert.assertEquals(3, enabledWhen.getLength());
+    Assert.assertEquals(2, enabledWhen.getLength());
     NodeList tests = doc.getElementsByTagName("test");
     Assert.assertEquals(3, tests.getLength());
     NodeList adapts = doc.getElementsByTagName("adapt");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
@@ -66,18 +66,6 @@
        </enabledWhen>
     </page>
   </extension>
-  
-  <extension point="org.eclipse.ui.propertyPages">
-    <page
-        id="com.google.cloud.tools.eclipse.appengine.deploy"
-        name="App Engine Deployment"
-        category="com.google.cloud.tools.eclipse"
-        class="com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployPropertyPage">
-      <enabledWhen>
-        <reference definitionId="com.google.cloud.tools.eclipse.appengine.onlyInGCPProjects" />
-      </enabledWhen>
-    </page>
-  </extension>
 
   <extension point="org.eclipse.core.expressions.definitions">
     <definition id="com.google.cloud.tools.eclipse.appengine.onlyInGCPProjects">


### PR DESCRIPTION
fix #761 @akerekes @chanseokoh 

With this PR deployment preferences are adjusted and stored only when actually deploying the project. reasons to do this:
1. See #761 for different validation requirements in this panel depending on when we bring it up.
2. We always bring this dialog up at deploy. Having an extra preference panel does not add any functionality and adds complexity to the UI. 
