### PR TITLE
fix font in API group

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Library.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Library.java
@@ -7,7 +7,6 @@ import com.google.common.base.Preconditions;
 
 /**
  * Represents a library that can be added to App Engine projects. E.g. AppEngine Endpoints library.
- *
  */
 public class Library {
   private static final String CONTAINER_PATH_PREFIX = "com.google.cloud.tools.eclipse.appengine.libraries";

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
@@ -9,6 +9,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
@@ -86,6 +87,7 @@ public class AppEngineStandardWizardPage extends WizardNewProjectCreationPage {
   private void addManageLibrariesWidgets(Composite container) {
     apiGroup = new Group(container, SWT.NONE);
     apiGroup.setText(Messages.AppEngineStandardWizardPage_librariesGroupLabel);
+    apiGroup.setFont(JFaceResources.getDialogFont());
     GridDataFactory.fillDefaults().span(2, 1).applyTo(apiGroup);
 
     for (Library library : getLibraries()) {


### PR DESCRIPTION
@briandealwis @akerekes Not sure why, but merely calling 

     Dialog.applyDialogFont(container);

does not seem to be enough to set the correct font size on the group label, at least not on the Mac. 