### PR TITLE
Prevent deploy if project has problems

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -7,6 +7,8 @@ bucket.name=Bucket:
 cannot.open.browser=Cannot open browser
 deploy.login.dialog.message=Browser opened to authorize deployment.
 deploy.manual.link=To manually promote a version use the <a href="{0}">Google Cloud Console.</a>
+build.error.dialog.title=Build Error in Project
+build.error.dialog.message=Project has error(s). Try again after fixing the problem.
 deploy.preferences.dialog.title=Deployment configuration
 deploy.preferences.dialog.title.withProject=Deployment configuration for {0}
 deploy.preferences.save.error.title=Could not save preferences

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
@@ -85,7 +85,7 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     try {
       IProject project = helper.getProject(event);
       if (project != null) {
-        if (!checkCompilationError(project)) {
+        if (!checkProjectErrors(project)) {
           MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
                                         Messages.getString("build.error.dialog.title"),
                                         Messages.getString("build.error.dialog.message"));
@@ -106,7 +106,7 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     }
   }
 
-  private static boolean checkCompilationError(IProject project) throws CoreException {
+  private static boolean checkProjectErrors(IProject project) throws CoreException {
     int severity = project.findMaxProblemSeverity(
         IMarker.PROBLEM, true /* includeSubtypes */, IResource.DEPTH_INFINITE);
     return severity != IMarker.SEVERITY_ERROR;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
@@ -26,12 +26,15 @@ import java.util.Locale;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.window.Window;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -59,7 +62,7 @@ import com.google.common.annotations.VisibleForTesting;
 /**
  * Command handler to deploy an App Engine web application project to App Engine Standard.
  * <p>
- * It copies the project's exploded WAR to a staging directory and then executes 
+ * It copies the project's exploded WAR to a staging directory and then executes
  * the staging and deploy operations provided by the App Engine Plugins Core Library.
  */
 public class StandardDeployCommandHandler extends AbstractHandler {
@@ -82,6 +85,13 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     try {
       IProject project = helper.getProject(event);
       if (project != null) {
+        if (!checkCompilationError(project)) {
+          MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
+                                        Messages.getString("build.error.dialog.title"),
+                                        Messages.getString("build.error.dialog.message"));
+          return null;
+        }
+
         Credential credential = loginIfNeeded(event);
         if (credential != null) {
           if (new DeployPreferencesDialog(HandlerUtil.getActiveShell(event), project).open() == Window.OK) {
@@ -96,12 +106,18 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     }
   }
 
-  private void launchDeployJob(IProject project, Credential credential, ExecutionEvent event) 
+  private static boolean checkCompilationError(IProject project) throws CoreException {
+    int severity = project.findMaxProblemSeverity(
+        IMarker.PROBLEM, true /* includeSubtypes */, IResource.DEPTH_INFINITE);
+    return severity != IMarker.SEVERITY_ERROR;
+  }
+
+  private void launchDeployJob(IProject project, Credential credential, ExecutionEvent event)
       throws IOException, ExecutionException {
-    
+
     AnalyticsPingManager.getInstance().sendPing(
         AnalyticsEvents.APP_ENGINE_DEPLOY, AnalyticsEvents.APP_ENGINE_DEPLOY_STANDARD, null);
-    
+
     IPath workDirectory = createWorkDirectory();
 
     DefaultDeployConfiguration deployConfiguration = getDeployConfiguration(project, event);


### PR DESCRIPTION
Fixes #774.

Blocks deploy by showing an error dialog if a project has a "Problem" (i.e., if it has the small red X marker on it, or if there are any errors in the Problems view) when attempting to deploy.