### PR TITLE
Fix mismatching server type ID

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
@@ -8,10 +8,10 @@ import org.eclipse.wst.server.ui.ServerLaunchConfigurationTab;
 
 public class AppEngineTabGroup extends AbstractLaunchConfigurationTabGroup {
 
-  private static final String[] SERVER_TYPE_IDS = new String[]{ 
-      "com.google.cloud.tools.eclipse.appengine.localserver.server.apptools"
+  private static final String[] SERVER_TYPE_IDS = new String[]{
+      "com.google.cloud.tools.eclipse.appengine.standard.server"
   };
-  
+
   @Override
   public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
     ILaunchConfigurationTab[] tabs = new ILaunchConfigurationTab[2];
@@ -19,11 +19,11 @@ public class AppEngineTabGroup extends AbstractLaunchConfigurationTabGroup {
     tabs[0].setLaunchConfigurationDialog(dialog);
     tabs[1] = new EnvironmentTab();
     tabs[1].setLaunchConfigurationDialog(dialog);
-    
-    // see 
+
+    // see
     // http://git.eclipse.org/c/jetty/org.eclipse.jetty.wtp.git/tree/org.eclipse.jst.server.jetty.ui/src/org/eclipse/jst/server/jetty/ui/internal/JettyLaunchConfigurationTabGroup.java
     // for examples of other tabs we might want to add
-    
+
     setTabs(tabs);
   }
 


### PR DESCRIPTION
Server type ID defined in plugin.xml is `com.google.cloud.tools.eclipse.appengine.standard.server`.

https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/master/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml#L29

With the correct ID, our App Engine Local Server launch config tab can load server instances properly.