### PR TITLE
Enable setting arbitrary host for local runs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -34,7 +34,7 @@
             runtime="true"
             runtimeTypeId="com.google.cloud.tools.eclipse.appengine.standard.runtime"
             startBeforePublish="false"
-            supportsRemoteHosts="false">
+            supportsRemoteHosts="true">
       </serverType>
    </extension>
    <extension

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -130,14 +130,14 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
    * Starts the development server.
    *
    * @param runnables the path to directories that contain configuration files like appengine-web.xml
-   * @param stream the stream to send development server process output to
-   * @param host
+   * @param console the stream (Eclipse console) to send development server process output to
+   * @param host the host name to which application modules should bind
    */
-  void startDevServer(List<File> runnables, MessageConsoleStream stream, String host) {
+  void startDevServer(List<File> runnables, MessageConsoleStream console, String host) {
     setServerState(IServer.STATE_STARTING);
 
     // Create dev app server instance
-    initializeDevServer(stream);
+    initializeDevServer(console);
 
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
@@ -161,15 +161,16 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
    * Starts the development server in debug mode.
    *
    * @param runnables the path to directories that contain configuration files like appengine-web.xml
-   * @param stream the stream to send development server process output to
+   * @param console the stream (Eclipse console) to send development server process output to
+   * @param host the host name to which application modules should bind
    * @param debugPort the port to attach a debugger to if launch is in debug mode
    */
-  void startDebugDevServer(List<File> runnables, MessageConsoleStream stream,
+  void startDebugDevServer(List<File> runnables, MessageConsoleStream console,
                            String host, int debugPort) {
     setServerState(IServer.STATE_STARTING);
 
     // Create dev app server instance
-    initializeDevServer(stream);
+    initializeDevServer(console);
 
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
@@ -202,9 +203,9 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     }
   }
 
-  private void initializeDevServer(MessageConsoleStream stream) {
+  private void initializeDevServer(MessageConsoleStream console) {
     MessageConsoleWriterOutputLineListener outputListener =
-        new MessageConsoleWriterOutputLineListener(stream);
+        new MessageConsoleWriterOutputLineListener(console);
 
     // dev_appserver output goes to stderr
     CloudSdk cloudSdk = new CloudSdk.Builder()

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -131,8 +131,9 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
    *
    * @param runnables the path to directories that contain configuration files like appengine-web.xml
    * @param stream the stream to send development server process output to
+   * @param host
    */
-  void startDevServer(List<File> runnables, MessageConsoleStream stream) {
+  void startDevServer(List<File> runnables, MessageConsoleStream stream, String host) {
     setServerState(IServer.STATE_STARTING);
 
     // Create dev app server instance
@@ -141,6 +142,7 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
     devServerRunConfiguration.setAppYamls(runnables);
+    devServerRunConfiguration.setHost(host);
 
     // FIXME: workaround bug when running on a Java8 JVM
     // https://github.com/GoogleCloudPlatform/gcloud-eclipse-tools/issues/181
@@ -162,7 +164,8 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
    * @param stream the stream to send development server process output to
    * @param debugPort the port to attach a debugger to if launch is in debug mode
    */
-  void startDebugDevServer(List<File> runnables, MessageConsoleStream stream, int debugPort) {
+  void startDebugDevServer(List<File> runnables, MessageConsoleStream stream,
+                           String host, int debugPort) {
     setServerState(IServer.STATE_STARTING);
 
     // Create dev app server instance
@@ -171,6 +174,7 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate {
     // Create run configuration
     DefaultRunConfiguration devServerRunConfiguration = new DefaultRunConfiguration();
     devServerRunConfiguration.setAppYamls(runnables);
+    devServerRunConfiguration.setHost(host);
 
     // todo: make this a configurable option, but default to
     // 1 instance to simplify debugging

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -107,11 +107,12 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     if (ILaunchManager.DEBUG_MODE.equals(mode)) {
       int debugPort = getDebugPort();
       setupDebugTarget(launch, configuration, debugPort, monitor);
-      serverBehaviour.startDebugDevServer(runnables, console.newMessageStream(), debugPort);
+      serverBehaviour.startDebugDevServer(
+          runnables, console.newMessageStream(), server.getHost(), debugPort);
     } else {
       // A launch must have at least one debug target or process, or it otherwise becomes a zombie
       LocalAppEngineServerDebugTarget.addTarget(launch, serverBehaviour);
-      serverBehaviour.startDevServer(runnables, console.newMessageStream());
+      serverBehaviour.startDevServer(runnables, console.newMessageStream(), server.getHost());
     }
   }
 


### PR DESCRIPTION
Fixes #775.

Of course, attempting to use non-local hosts and IP addresses except for 0.0.0.0 will fail, which is expected.