### PR TITLE
save project ID preference in Maven projects too

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Library.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Library.java
@@ -26,7 +26,7 @@ import org.eclipse.core.runtime.Path;
 import com.google.common.base.Preconditions;
 
 /**
- * A library that can be added to App Engine projects, e.g. AppEngine Endpoints library.
+ * A library that can be added to App Engine projects, e.g. App Engine Endpoints library.
  *
  */
 public final class Library {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/config/LibraryBuilder.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/config/LibraryBuilder.java
@@ -135,7 +135,7 @@ public class LibraryBuilder {
       case ELMT_INCLUSION_FILTER:
         filters.add(Filter.inclusionFilter(childElement.getAttribute(ATTR_PATTERN)));
       default:
-        logger.warning("Unexpected element among filter elements");
+        logger.warning("Unexpected element among filter elements: " + childElement.getName());
         break;
       }
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-version="0.1.0",
  com.google.cloud.tools.eclipse.appengine.ui,
+ com.google.guava,
  javax.servlet;bundle-version="2.5.0",
  javax.servlet.jsp;bundle-version="2.2.0",
  org.eclipse.core.resources,
@@ -17,11 +18,11 @@ Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-versi
  org.eclipse.core.jobs,
  org.eclipse.m2e.core;bundle-version="1.6.2",
  org.eclipse.m2e.core.ui;bundle-version="1.6.2",
- com.google.guava,
  org.eclipse.m2e.maven.runtime
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.cloud.tools.eclipse.appengine.ui,
+ com.google.cloud.tools.eclipse.preferences,
  com.google.cloud.tools.eclipse.usagetracker,
  com.google.cloud.tools.eclipse.util,
  com.google.cloud.tools.project;version="0.1.9",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
@@ -20,6 +35,7 @@ import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.preferences.PreferenceUtil;
 import com.google.cloud.tools.eclipse.util.MavenUtils;
 
 public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOperation {
@@ -40,8 +56,7 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
     SubMonitor progress = SubMonitor.convert(monitor);
     monitor.beginTask("Creating Maven AppEngine archetype", 100);
 
-    // todo: verify whether project ID is necessary during creation. The
-    // archetype seems to require it so we use the artifact if unspecified.
+    // The project ID is currently necessary due to tool bugs.
     String appId = appEngineProjectId;
     if (appId == null || appId.trim().isEmpty()) {
       appId = artifactId;
@@ -69,6 +84,7 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
           project, true, loopMonitor.newChild(1));
       AppEngineStandardFacet.installAppEngineFacet(facetedProject, true /* installDependentFacets */, loopMonitor.newChild(1));
       AppEngineStandardFacet.installAllAppEngineRuntimes(facetedProject, true /* force */, loopMonitor.newChild(1));
+      PreferenceUtil.setProjectIdPreference(project, appId);
     }
     
     /*

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
 import java.text.MessageFormat;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
 import static org.junit.Assert.assertNotNull;
@@ -9,12 +25,10 @@ import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
@@ -55,18 +69,6 @@ public class CreateAppEngineStandardWtpProjectTest {
   @Test
   public void testConstructor() {
     new CreateAppEngineStandardWtpProject(config, adaptable);
-  }
-  
-  @Test
-  public void testSetProjectIdPreference() {
-    config.setAppEngineProjectId("MyProjectId");
-    CreateAppEngineStandardWtpProject creator = new CreateAppEngineStandardWtpProject(config, adaptable);
-    
-    creator.setProjectIdPreference(project);
-    
-    IEclipsePreferences preferences = new ProjectScope(project)
-        .getNode("com.google.cloud.tools.eclipse.appengine.deploy");
-    Assert.assertEquals("MyProjectId", preferences.get("project.id", "fail"));
   }
   
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.1.0",
  com.google.cloud.tools.eclipse.sdk.ui;bundle-version="0.1.0"
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.cloud.tools.eclipse.appengine.libraries,
+ com.google.cloud.tools.eclipse.preferences,
  com.google.cloud.tools.eclipse.usagetracker,
  com.google.cloud.tools.eclipse.util.templates.appengine,
  com.google.common.annotations;version="15.0.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
 import java.lang.reflect.InvocationTargetException;
@@ -9,13 +25,11 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -31,7 +45,7 @@ import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.libraries.Library;
-import com.google.common.annotations.VisibleForTesting;
+import com.google.cloud.tools.eclipse.preferences.PreferenceUtil;
 
 /**
 * Utility to make a new Eclipse project with the App Engine Standard facets in the workspace.  
@@ -74,7 +88,7 @@ class CreateAppEngineStandardWtpProject extends WorkspaceModifyOperation {
         facetedProject, true /* installDependentFacets */, monitor);
     AppEngineStandardFacet.installAllAppEngineRuntimes(facetedProject, true /* force */, monitor);
     
-    setProjectIdPreference(newProject);
+    PreferenceUtil.setProjectIdPreference(newProject, config.getAppEngineProjectId());
 
     addAppEngineLibrariesToBuildPath(newProject, config.getAppEngineLibraries(), monitor);
 
@@ -112,16 +126,6 @@ class CreateAppEngineStandardWtpProject extends WorkspaceModifyOperation {
     IClasspathEntry[] newRawClasspath = Arrays.copyOf(rawClasspath, rawClasspath.length + 1);
     newRawClasspath[newRawClasspath.length - 1] = junit4Container;
     javaProject.setRawClasspath(newRawClasspath, monitor);
-  }
-
-  @VisibleForTesting
-  void setProjectIdPreference(IProject project) {
-    String projectId = config.getAppEngineProjectId();
-    if (projectId != null && !projectId.isEmpty()) {
-      IEclipsePreferences preferences = new ProjectScope(project)
-          .getNode("com.google.cloud.tools.eclipse.appengine.deploy");
-      preferences.put("project.id", projectId);
-    }
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.preferences.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.preferences.test/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-ActivationPolicy: lazy
 Fragment-Host: com.google.cloud.tools.eclipse.preferences
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",
  org.junit;bundle-version="4.12.0"
-Import-Package: org.eclipse.jface.preference,
+Import-Package: org.eclipse.core.resources,
+ org.eclipse.jface.preference,
  org.mockito;provider=google;version="1.10.19",
  org.mockito.runners;provider=google;version="1.10.19",
  org.mockito.stubbing;provider=google;version="1.10.19",

--- a/plugins/com.google.cloud.tools.eclipse.preferences.test/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences.test/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtilTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PreferenceUtilTest {
+
+  private IProject project;
+  
+  @Before
+  public void setUp() {
+    IWorkspace workspace = ResourcesPlugin.getWorkspace();
+    project = workspace.getRoot().getProject("testproject" + Math.random());
+  }
+  
+  @Test
+  public void testSetProjectIdPreference() {
+    PreferenceUtil.setProjectIdPreference(project, "MyProjectId");
+    
+    IEclipsePreferences preferences = new ProjectScope(project)
+        .getNode("com.google.cloud.tools.eclipse.appengine.deploy");
+    Assert.assertEquals("MyProjectId", preferences.get("project.id", "fail"));
+  }
+  
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences.test/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences.test/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtilTest.java
@@ -20,7 +20,10 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +36,11 @@ public class PreferenceUtilTest {
   public void setUp() {
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     project = workspace.getRoot().getProject("testproject" + Math.random());
+  }
+  
+  @After
+  public void tearDown() throws CoreException {
+    project.delete(true, new NullProgressMonitor());
   }
   
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Bundle-Activator: com.google.cloud.tools.eclipse.preferences.Activator
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
+Import-Package: org.eclipse.core.resources

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.preferences;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ProjectScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+
+public class PreferenceUtil {
+
+  public static void setProjectIdPreference(IProject project, String projectId) {
+    if (projectId != null && !projectId.isEmpty()) {
+      IEclipsePreferences preferences = new ProjectScope(project)
+          .getNode("com.google.cloud.tools.eclipse.appengine.deploy");
+      preferences.put("project.id", projectId);
+    }
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/src/com/google/cloud/tools/eclipse/preferences/PreferenceUtil.java
@@ -22,10 +22,11 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 public class PreferenceUtil {
 
+  private static final String DEPLOY = "com.google.cloud.tools.eclipse.appengine.deploy";
+
   public static void setProjectIdPreference(IProject project, String projectId) {
     if (projectId != null && !projectId.isEmpty()) {
-      IEclipsePreferences preferences = new ProjectScope(project)
-          .getNode("com.google.cloud.tools.eclipse.appengine.deploy");
+      IEclipsePreferences preferences = new ProjectScope(project).getNode(DEPLOY);
       preferences.put("project.id", projectId);
     }
   }


### PR DESCRIPTION
@nbashirbello @akerekes fix #731 

This also moves some now common code into the preferences package. Going forward, we may be able to move some more code here, including constants for various preference IDs.