### PR TITLE
Save and validate account selection

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesDialog.java
@@ -66,7 +66,7 @@ public class DeployPreferencesDialog extends TitleAreaDialog {
 
     Composite container = new Composite(dialogArea, SWT.NONE);
     content = new StandardDeployPreferencesPanel(container, project, loginService,
-        getLayoutChangedHandler(), false /* allowEmptyProjectId */);
+        getLayoutChangedHandler(), true /* requireProjectId */, true /* requireAccount */);
     GridDataFactory.fillDefaults().grab(true, false).applyTo(content);
 
     // we pull in Dialog's content margins which are zeroed out by TitleAreaDialog

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesDialog.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesDialog.java
@@ -66,7 +66,7 @@ public class DeployPreferencesDialog extends TitleAreaDialog {
 
     Composite container = new Composite(dialogArea, SWT.NONE);
     content = new StandardDeployPreferencesPanel(container, project, loginService,
-        getLayoutChangedHandler(), true /* requireProjectId */, true /* requireAccount */);
+        getLayoutChangedHandler(), true /* requireValues */);
     GridDataFactory.fillDefaults().grab(true, false).applyTo(content);
 
     // we pull in Dialog's content margins which are zeroed out by TitleAreaDialog

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
@@ -9,6 +9,7 @@ public class DeployPreferencesModel {
 
   private StandardDeployPreferences preferences;
 
+  private String accountEmail;
   private String projectId;
   private boolean overrideDefaultVersioning;
   private String version;
@@ -23,6 +24,7 @@ public class DeployPreferencesModel {
   }
 
   private void applyPreferences(StandardDeployPreferences preferences) {
+    setAccountEmail(preferences.getAccountEmail());
     setProjectId(preferences.getProjectId());
     setOverrideDefaultVersioning(preferences.isOverrideDefaultVersioning());
     setVersion(preferences.getVersion());
@@ -37,6 +39,7 @@ public class DeployPreferencesModel {
   }
 
   public void savePreferences() throws BackingStoreException {
+    preferences.setAccountEmail(getAccountEmail());
     preferences.setProjectId(getProjectId());
     preferences.setOverrideDefaultVersioning(isOverrideDefaultVersioning());
     preferences.setVersion(getVersion());
@@ -45,6 +48,14 @@ public class DeployPreferencesModel {
     preferences.setOverrideDefaultBucket(isOverrideDefaultBucket());
     preferences.setBucket(getBucket());
     preferences.save();
+  }
+
+  public String getAccountEmail() {
+    return accountEmail;
+  }
+
+  public void setAccountEmail(String accountEmail) {
+    this.accountEmail = accountEmail;
   }
 
   public String getProjectId() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
@@ -116,7 +116,7 @@ public class DeployPropertyPage extends PropertyPage {
 
     if (AppEngineStandardFacet.hasAppEngineFacet(facetedProject)) {
       return new StandardDeployPreferencesPanel(container, project, loginService,
-          getLayoutChangedHandler(),  true /* allowEmptyProjectId */);
+          getLayoutChangedHandler(), false /* requireProjectId */, false /* requireAccount */);
     } else if (AppEngineFlexFacet.hasAppEngineFacet(facetedProject)) {
       return new FlexDeployPreferencesPanel(container);
     } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
@@ -116,7 +116,7 @@ public class DeployPropertyPage extends PropertyPage {
 
     if (AppEngineStandardFacet.hasAppEngineFacet(facetedProject)) {
       return new StandardDeployPreferencesPanel(container, project, loginService,
-          getLayoutChangedHandler(), false /* requireProjectId */, false /* requireAccount */);
+          getLayoutChangedHandler(), false /* requireValues */);
     } else if (AppEngineFlexFacet.hasAppEngineFacet(facetedProject)) {
       return new FlexDeployPreferencesPanel(container);
     } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -99,17 +99,14 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private DataBindingContext bindingContext;
 
   private Runnable layoutChangedHandler;
-  private boolean requireProjectId = true;
-  private boolean requireAccount = true;
+  private boolean requireValues = true;
 
   public StandardDeployPreferencesPanel(Composite parent, IProject project,
-      IGoogleLoginService loginService, Runnable layoutChangedHandler,
-      boolean requireProjectId, boolean requireAccount) {
+      IGoogleLoginService loginService, Runnable layoutChangedHandler, boolean requireValues) {
     super(parent, SWT.NONE);
 
     this.layoutChangedHandler = layoutChangedHandler;
-    this.requireProjectId = requireProjectId;
-    this.requireAccount = requireAccount;
+    this.requireValues = requireValues;
 
     createCredentialSection(loginService);
 
@@ -147,7 +144,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     final IObservableValue accountEmailModel = PojoProperties.value("accountEmail").observe(model);
     context.bindValue(new AccountSelectorObservableValue(accountSelector), accountEmailModel);
 
-    if (requireAccount) {
+    if (requireValues) {
       context.addValidationStatusProvider(new FixedMultiValidator() {
         @Override
         protected IStatus validate() {
@@ -169,8 +166,8 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     IObservableValue projectIdModel = PojoProperties.value("projectId").observe(model);
 
     context.bindValue(projectIdField, projectIdModel,
-                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireProjectId)),
-                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireProjectId)));
+                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireValues)),
+                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireValues)));
   }
 
   private void setupProjectVersionDataBinding(DataBindingContext context) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -56,6 +56,7 @@ import org.osgi.service.prefs.BackingStoreException;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.tools.eclipse.appengine.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.appengine.login.ui.AccountSelector;
+import com.google.cloud.tools.eclipse.appengine.login.ui.AccountSelectorObservableValue;
 import com.google.cloud.tools.eclipse.ui.util.FontUtil;
 import com.google.cloud.tools.eclipse.ui.util.databinding.BucketNameValidator;
 import com.google.cloud.tools.eclipse.ui.util.databinding.ProjectIdInputValidator;
@@ -75,7 +76,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private static Logger logger = Logger.getLogger(DeployPropertyPage.class.getName());
 
   private AccountSelector accountSelector;
-  
+
   private Label projectIdLabel;
   private Text projectId;
 
@@ -98,14 +99,17 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private DataBindingContext bindingContext;
 
   private Runnable layoutChangedHandler;
-  private boolean allowEmptyProjectId = false;
+  private boolean requireProjectId = true;
+  private boolean requireAccount = true;
 
   public StandardDeployPreferencesPanel(Composite parent, IProject project,
-      IGoogleLoginService loginService, Runnable layoutChangedHandler, boolean allowEmptyProjectId) {
+      IGoogleLoginService loginService, Runnable layoutChangedHandler,
+      boolean requireProjectId, boolean requireAccount) {
     super(parent, SWT.NONE);
 
     this.layoutChangedHandler = layoutChangedHandler;
-    this.allowEmptyProjectId = allowEmptyProjectId;
+    this.requireProjectId = requireProjectId;
+    this.requireAccount = requireAccount;
 
     createCredentialSection(loginService);
 
@@ -129,6 +133,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private void setupDataBinding() {
     bindingContext = new DataBindingContext();
 
+    setupAccountEmailDataBinding(bindingContext);
     setupProjectIdDataBinding(bindingContext);
     setupProjectVersionDataBinding(bindingContext);
     setupAutoPromoteDataBinding(bindingContext);
@@ -138,14 +143,34 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     observables.addObservablesFromContext(bindingContext, true, true);
   }
 
+  private void setupAccountEmailDataBinding(DataBindingContext context) {
+    final IObservableValue accountEmailModel = PojoProperties.value("accountEmail").observe(model);
+    context.bindValue(new AccountSelectorObservableValue(accountSelector), accountEmailModel);
+
+    if (requireAccount) {
+      context.addValidationStatusProvider(new FixedMultiValidator() {
+        @Override
+        protected IStatus validate() {
+          String email = (String) accountEmailModel.getValue();
+          // It's possible that no account is selected while a valid email has been saved in the
+          // model (if the corresponding account is signed out), so check the actual selection too.
+          if (email.isEmpty() || accountSelector.getSelectedEmail().isEmpty()) {
+            return ValidationStatus.error(Messages.getString("error.account.missing"));
+          }
+          return ValidationStatus.ok();
+        }
+      });
+    }
+  }
+
   private void setupProjectIdDataBinding(DataBindingContext context) {
     ISWTObservableValue projectIdField = WidgetProperties.text(SWT.Modify).observe(projectId);
 
     IObservableValue projectIdModel = PojoProperties.value("projectId").observe(model);
 
     context.bindValue(projectIdField, projectIdModel,
-                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(allowEmptyProjectId)),
-                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(allowEmptyProjectId)));
+                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireProjectId)),
+                      new UpdateValueStrategy().setAfterGetValidator(new ProjectIdInputValidator(requireProjectId)));
   }
 
   private void setupProjectVersionDataBinding(DataBindingContext context) {
@@ -214,6 +239,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
                                                               new BucketNameValidator()));
   }
 
+  @Override
   public boolean savePreferences() {
     try {
       model.savePreferences();
@@ -238,7 +264,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
 
   private void createCredentialSection(IGoogleLoginService loginService) {
     Composite accountComposite = new Composite(this, SWT.NONE);
-    
+
     new Label(accountComposite, SWT.LEFT).setText(
         Messages.getString("deploy.preferences.dialog.label.selectAccount"));
 
@@ -351,7 +377,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
    * </ol>
    *
    */
-  private static class OverrideValidator extends MultiValidator {
+  private static class OverrideValidator extends FixedMultiValidator {
 
     private ISWTObservableValue selectionObservable;
     private ISWTObservableValue textObservable;
@@ -363,7 +389,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
      * @param validator must be a validator for String values, will be applied to <code>text.getValue()</code>
      */
     public OverrideValidator(ISWTObservableValue selection, ISWTObservableValue text, IValidator validator) {
-      super(selection.getRealm());
+      super();
       Preconditions.checkArgument(text.getWidget() instanceof Text,
                                   "text is an observable for {0}, should be for {1}",
                                   text.getWidget().getClass().getName(),
@@ -386,23 +412,25 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
       }
       return validator.validate(textObservable.getValue());
     }
+  }
 
+  // BUGFIX: https://bugs.eclipse.org/bugs/show_bug.cgi?id=312785
+  private abstract static class FixedMultiValidator extends MultiValidator {
     @Override
     public IObservableList getTargets() {
-      /**
-       * BUGFIX: https://bugs.eclipse.org/bugs/show_bug.cgi?id=312785
-       */
-      if( isDisposed() ) {
+      if (isDisposed()) {
         return Observables.emptyObservableList();
       }
       return super.getTargets();
     }
-  }
+  };
 
+  @Override
   public DataBindingContext getDataBindingContext() {
     return bindingContext;
   }
 
+  @Override
   public void resetToDefaults() {
     model.resetToDefaults();
     bindingContext.updateTargets();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -386,7 +386,6 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
      * @param validator must be a validator for String values, will be applied to <code>text.getValue()</code>
      */
     public OverrideValidator(ISWTObservableValue selection, ISWTObservableValue text, IValidator validator) {
-      super();
       Preconditions.checkArgument(text.getWidget() instanceof Text,
                                   "text is an observable for {0}, should be for {1}",
                                   text.getWidget().getClass().getName(),

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -16,6 +16,7 @@ build.error.dialog.title=Build Error in Project
 build.error.dialog.message=Project has error(s). Try again after fixing the problem.
 deploy.preferences.save.error.title=Could not save preferences
 deploy.preferences.save.error.message=Error while saving the preferences: {0}
+error.account.missing=Select an account.
 error.projectId.missing=Project ID must be set for deploy.
 project.id=Project ID:
 project.version=Version:
@@ -37,7 +38,3 @@ use.config.values=Use these values during deployment
 action.stop=Stop
 action.remove=Remove
 job.terminated.template=<terminated> {0}
-
-# TODO(chanseok): remove after fixing https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/759.)
-deploy.account.missing.dialog.title=Account Required for Deploy
-deploy.account.missing.dialog.message=Try again after selecting an account.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
@@ -95,18 +95,8 @@ public class StandardDeployCommandHandler extends AbstractHandler {
         IGoogleLoginService loginService = ServiceUtils.getService(event, IGoogleLoginService.class);
         DeployPreferencesDialog dialog =
             new DeployPreferencesDialog(HandlerUtil.getActiveShell(event), project, loginService);
-        // TODO(chanseok): remove the condition (dialog.getCredential() != null) after fixing
-        // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/759. The fix will
-        // make the condition redundant. Also remove the stopgap message dialog.
         if (dialog.open() == Window.OK) {
-          if (dialog.getCredential() != null) {
-            launchDeployJob(project, dialog.getCredential(), event);
-          } else {
-            // Stopgap (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/759)
-            MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
-                Messages.getString("deploy.account.missing.dialog.title"),
-                Messages.getString("deploy.account.missing.dialog.message"));
-          }
+          launchDeployJob(project, dialog.getCredential(), event);
         }
       }
       // return value must be null, reserved for future use

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/DeployPreferenceInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/DeployPreferenceInitializer.java
@@ -9,6 +9,7 @@ public class DeployPreferenceInitializer extends AbstractPreferenceInitializer {
   private static final String PREFERENCE_STORE_DEFAULTS_QUALIFIER =
       "com.google.cloud.tools.eclipse.appengine.deploy.defaults";
 
+  static final String DEFAULT_ACCOUNT_EMAIL = "";
   static final String DEFAULT_PROJECT_ID = "";
   static final boolean DEFAULT_OVERRIDE_DEFAULT_VERSIONING = false;
   static final String DEFAULT_CUSTOM_VERSION = "";
@@ -21,6 +22,7 @@ public class DeployPreferenceInitializer extends AbstractPreferenceInitializer {
   public void initializeDefaultPreferences() {
     IEclipsePreferences preferences =
         DefaultScope.INSTANCE.getNode(PREFERENCE_STORE_DEFAULTS_QUALIFIER);
+    preferences.put(StandardDeployPreferences.PREF_ACCOUNT_EMAIL, DEFAULT_ACCOUNT_EMAIL);
     preferences.put(StandardDeployPreferences.PREF_PROJECT_ID,
                     DEFAULT_PROJECT_ID);
     preferences.putBoolean(StandardDeployPreferences.PREF_OVERRIDE_DEFAULT_VERSIONING,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployPreferences.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployPreferences.java
@@ -11,6 +11,7 @@ public class StandardDeployPreferences {
 
   public static final String PREFERENCE_STORE_QUALIFIER = "com.google.cloud.tools.eclipse.appengine.deploy";
 
+  static final String PREF_ACCOUNT_EMAIL = "account.email";
   static final String PREF_PROJECT_ID = "project.id";
   static final String PREF_OVERRIDE_DEFAULT_VERSIONING = "project.version.overrideDefault"; // boolean
   static final String PREF_CUSTOM_VERSION = "project.version";
@@ -37,6 +38,15 @@ public class StandardDeployPreferences {
 
   public void save() throws BackingStoreException {
     preferenceStore.flush();
+  }
+
+  public String getAccountEmail() {
+    return preferenceStore.get(PREF_ACCOUNT_EMAIL,
+                               DeployPreferenceInitializer.DEFAULT_ACCOUNT_EMAIL);
+  }
+
+  public void setAccountEmail(String accountEmail) {
+    preferenceStore.put(PREF_ACCOUNT_EMAIL, accountEmail);
   }
 
   public String getProjectId() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.login.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -40,7 +41,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -87,6 +87,7 @@ public class AccountSelectorTest {
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertNull(selector.getSelectedCredential());
+    assertTrue(selector.getSelectedEmail().isEmpty());
     assertEquals(1, selector.combo.getItemCount());
     assertEquals("<select this to login>", selector.combo.getItem(0));
   }
@@ -98,6 +99,7 @@ public class AccountSelectorTest {
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertNull(selector.getSelectedCredential());
+    assertTrue(selector.getSelectedEmail().isEmpty());
     assertEquals(2, selector.combo.getItemCount());
     assertEquals("some-email-1@example.com", selector.combo.getItem(0));
     assertEquals("<select this to login>", selector.combo.getItem(1));
@@ -111,6 +113,7 @@ public class AccountSelectorTest {
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertNull(selector.getSelectedCredential());
+    assertTrue(selector.getSelectedEmail().isEmpty());
     assertEquals(4, selector.combo.getItemCount());
     String allEmails =
         selector.combo.getItem(0) + selector.combo.getItem(1) + selector.combo.getItem(2);
@@ -125,20 +128,46 @@ public class AccountSelectorTest {
     when(loginService.getAccounts())
         .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
-    HashMap<String, Credential> credentialMap = new HashMap<>();
-    credentialMap.put("some-email-1@example.com", credential1);
-    credentialMap.put("some-email-2@example.com", credential2);
-    credentialMap.put("some-email-3@example.com", credential3);
 
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertNull(selector.getSelectedCredential());
-    String emailAtIndex1 = selector.combo.getItem(1);
 
-    simulateSelect(selector, 1);
+    int index = selector.combo.indexOf("some-email-2@example.com");
+    simulateSelect(selector, index);
 
-    assertEquals(1, selector.combo.getSelectionIndex());
-    assertEquals(emailAtIndex1, selector.combo.getItem(1));
-    assertEquals(credentialMap.get(emailAtIndex1), selector.getSelectedCredential());
+    assertEquals(index, selector.combo.getSelectionIndex());
+    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+    assertEquals("some-email-2@example.com", selector.combo.getItem(index));
+    assertEquals(credential2, selector.getSelectedCredential());
+  }
+
+  @Test
+  public void testSelectAccount() {
+    when(loginService.getAccounts())
+        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+
+    selector.selectAccount("some-email-2@example.com");
+
+    assertNotEquals(-1, selector.combo.getSelectionIndex());
+    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+  }
+
+  @Test
+  public void testSelectAccount_nonExistingEmail() {
+    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+
+    selector.selectAccount("non-existing-email@example.com");
+
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
   }
 
   @Test
@@ -152,6 +181,7 @@ public class AccountSelectorTest {
     simulateSelect(selector, 2);
 
     assertEquals(4, selector.combo.getItemCount());
+    assertEquals("some-email-3@example.com", selector.getSelectedEmail());
     assertEquals("some-email-3@example.com", selector.combo.getItem(0));
     assertEquals(0, selector.combo.getSelectionIndex());
     assertEquals(credential3, selector.getSelectedCredential());
@@ -172,6 +202,7 @@ public class AccountSelectorTest {
 
     assertEquals(4, selector.combo.getItemCount());
     assertNotEquals(-1, selector.combo.getSelectionIndex());
+    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
     assertEquals("some-email-1@example.com", selector.combo.getText());
     assertEquals(credential1, selector.getSelectedCredential());
   }
@@ -186,6 +217,7 @@ public class AccountSelectorTest {
     simulateSelect(selector, 1);
     assertEquals(1, selector.combo.getSelectionIndex());
     assertNotNull(selector.getSelectedCredential());
+    assertFalse(selector.getSelectedEmail().isEmpty());
 
     assertEquals("<select this to login>", selector.combo.getItem(2));
     selector.combo.select(2);
@@ -194,6 +226,7 @@ public class AccountSelectorTest {
     assertEquals(3, selector.combo.getItemCount());
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertNull(selector.getSelectedCredential());
+    assertTrue(selector.getSelectedEmail().isEmpty());
     assertEquals("<select this to login>", selector.combo.getItem(2));
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -149,11 +149,13 @@ public class AccountSelectorTest {
 
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertTrue(selector.getSelectedEmail().isEmpty());
+    assertNull(selector.getSelectedCredential());
 
     selector.selectAccount("some-email-2@example.com");
 
     assertNotEquals(-1, selector.combo.getSelectionIndex());
     assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+    assertEquals(credential2, selector.getSelectedCredential());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
@@ -32,4 +32,6 @@ Import-Package: com.google.cloud.tools.eclipse.ui.util,
  com.google.cloud.tools.eclipse.usagetracker,
  javax.servlet.http;version="3.1.0",
  org.eclipse.core.expressions,
+ org.eclipse.core.databinding.observable,
+ org.eclipse.core.databinding.observable.value,
  org.osgi.service.component

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Export-Package: com.google.api.client.auth.oauth2;x-friends:="com.google.cloud.t
 Import-Package: com.google.cloud.tools.eclipse.ui.util,
  com.google.cloud.tools.eclipse.usagetracker,
  javax.servlet.http;version="3.1.0",
- org.eclipse.core.expressions,
  org.eclipse.core.databinding.observable,
  org.eclipse.core.databinding.observable.value,
+ org.eclipse.core.expressions,
+ org.eclipse.jface.databinding.swt,
  org.osgi.service.component

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
@@ -72,11 +72,12 @@ public class AccountSelector extends Composite {
     return combo.getText();
   }
 
-  public void selectAccount(String email) {
+  public int selectAccount(String email) {
     int index = combo.indexOf(email);
     if (index != -1) {
       combo.select(index);
     }
+    return index;
   }
 
   @VisibleForTesting

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 
@@ -67,6 +68,17 @@ public class AccountSelector extends Composite {
     return selectedCredential;
   }
 
+  public String getSelectedEmail() {
+    return combo.getText();
+  }
+
+  public void selectAccount(String email) {
+    int index = combo.indexOf(email);
+    if (index != -1) {
+      combo.select(index);
+    }
+  }
+
   @VisibleForTesting
   class LogInOnSelect extends SelectionAdapter {
     @Override
@@ -76,7 +88,7 @@ public class AccountSelector extends Composite {
         if (account != null) {
           addAndSelectAccount(account);
         } else {
-          combo.deselect(combo.getSelectionIndex());
+          combo.deselectAll();
         }
       }
 
@@ -100,5 +112,13 @@ public class AccountSelector extends Composite {
       combo.setData(account.getEmail(), account.getOAuth2Credential());
       combo.select(0);
     }
+  }
+
+  public void addSelectionListener(SelectionListener listener) {
+    combo.addSelectionListener(listener);
+  }
+
+  public void removeSelectionListener(SelectionListener listener) {
+    combo.removeSelectionListener(listener);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
@@ -103,11 +103,8 @@ public class AccountSelector extends Composite {
 
     private void addAndSelectAccount(Account account) {
       // If the combo already has the email, just select it.
-      for (int i = 0; i < combo.getItemCount(); i++) {
-        if (combo.getItem(i).equals(account.getEmail())) {
-          combo.select(i);
-          return;
-        }
+      if (selectAccount(account.getEmail()) != -1) {
+        return;
       }
       combo.add(account.getEmail(), 0 /* place at top */);
       combo.setData(account.getEmail(), account.getOAuth2Credential());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
@@ -76,6 +76,7 @@ public class AccountSelector extends Composite {
     int index = combo.indexOf(email);
     if (index != -1) {
       combo.select(index);
+      selectedCredential = (Credential) combo.getData(email);
     }
     return index;
   }
@@ -93,12 +94,7 @@ public class AccountSelector extends Composite {
         }
       }
 
-      int selectedIndex = combo.getSelectionIndex();
-      if (selectedIndex == -1) {
-        selectedCredential = null;
-      } else {
-        selectedCredential = (Credential) combo.getData(combo.getItem(selectedIndex));
-      }
+      selectedCredential = (Credential) combo.getData(getSelectedEmail());
     }
 
     private void addAndSelectAccount(Account account) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorObservableValue.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorObservableValue.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.eclipse.appengine.login.ui;
+
+import org.eclipse.core.databinding.observable.Diffs;
+import org.eclipse.core.databinding.observable.value.AbstractObservableValue;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+
+/**
+ * An object that represents and binds to the email value of an {@link AccountSelector}, whose
+ * changes (i.e., account selection changes in the combo box) can be tracked by value change
+ * listeners.
+ */
+public class AccountSelectorObservableValue extends AbstractObservableValue {
+
+  private String oldValue;
+  private AccountSelector accountSelector;
+
+  public AccountSelectorObservableValue(final AccountSelector accountSelector) {
+    this.accountSelector = accountSelector;
+
+    accountSelector.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent event) {
+        String newValue = accountSelector.getSelectedEmail();
+        fireValueChange(Diffs.createValueDiff(oldValue, newValue));
+        oldValue = newValue;
+      }
+    });
+  }
+
+  @Override
+  public Object getValueType() {
+    return String.class;
+  }
+
+  @Override
+  protected Object doGetValue() {
+    return accountSelector.getSelectedEmail();
+  }
+
+  @Override
+  protected void doSetValue(final Object value) {
+    accountSelector.selectAccount((String) value);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorObservableValue.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorObservableValue.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.login.ui;
 
 import org.eclipse.core.databinding.observable.Diffs;
 import org.eclipse.core.databinding.observable.value.AbstractObservableValue;
+import org.eclipse.jface.databinding.swt.DisplayRealm;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 
@@ -32,6 +33,7 @@ public class AccountSelectorObservableValue extends AbstractObservableValue {
   private AccountSelector accountSelector;
 
   public AccountSelectorObservableValue(final AccountSelector accountSelector) {
+    super(DisplayRealm.getRealm(accountSelector.getDisplay()));
     this.accountSelector = accountSelector;
 
     accountSelector.addSelectionListener(new SelectionAdapter() {

--- a/plugins/com.google.cloud.tools.eclipse.ui.util.test/src/com/google/cloud/tools/eclipse/ui/util/databinding/ProjectIdInputValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util.test/src/com/google/cloud/tools/eclipse/ui/util/databinding/ProjectIdInputValidatorTest.java
@@ -10,61 +10,61 @@ public class ProjectIdInputValidatorTest {
 
   @Test
   public void testValidate_nonStringInput() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate(new Object()).getSeverity(), is(IStatus.ERROR));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate(new Object()).getSeverity(), is(IStatus.ERROR));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate(new Object()).getSeverity(), is(IStatus.ERROR));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate(new Object()).getSeverity(), is(IStatus.ERROR));
   }
 
   @Test
   public void testValidate_emptyString() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("").getSeverity(),is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("").getSeverity(),is(IStatus.ERROR));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("").getSeverity(),is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("").getSeverity(),is(IStatus.ERROR));
   }
 
   @Test
   public void testValidate_upperCaseLetter() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("asdfghijK").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("asdfghijK").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("asdfghijK").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("asdfghijK").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_startWithNumber() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("1asdfghij").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("1asdfghij").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("1asdfghij").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("1asdfghij").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_startWithHyphen() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("-asdfghij").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("-asdfghij").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("-asdfghij").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("-asdfghij").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_endWithHyphen() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("asdfghij-").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("asdfghij-").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("asdfghij-").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("asdfghij-").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_validName() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("asdf-1ghij-2").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("asdf-1ghij-2").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("asdf-1ghij-2").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("asdf-1ghij-2").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_maxLengthName() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("a23456789012345678901234567890").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("a23456789012345678901234567890").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("a23456789012345678901234567890").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("a23456789012345678901234567890").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_tooLongName() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("a234567890123456789012345678901").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("a234567890123456789012345678901").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("a234567890123456789012345678901").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("a234567890123456789012345678901").getSeverity(), is(IStatus.OK));
   }
 
   @Test
   public void testValidate_tooShortName() {
-    assertThat(new ProjectIdInputValidator(true /* allowEmptyProjectId*/).validate("a2345").getSeverity(), is(IStatus.OK));
-    assertThat(new ProjectIdInputValidator(false /* allowEmptyProjectId*/).validate("a2345").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(false /* requireProjectId */).validate("a2345").getSeverity(), is(IStatus.OK));
+    assertThat(new ProjectIdInputValidator(true /* requireProjectId */).validate("a2345").getSeverity(), is(IStatus.OK));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/databinding/ProjectIdInputValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/databinding/ProjectIdInputValidator.java
@@ -8,10 +8,10 @@ import com.google.cloud.tools.eclipse.ui.util.Messages;
 import com.google.cloud.tools.project.ProjectIdValidator;
 
 public class ProjectIdInputValidator implements IValidator {
-  private boolean allowEmptyProjectId = false;
+  private boolean requireProjectId = true;
 
-  public ProjectIdInputValidator(boolean allowEmptyProjectId) {
-    this.allowEmptyProjectId = allowEmptyProjectId;
+  public ProjectIdInputValidator(boolean requireProjectId) {
+    this.requireProjectId = requireProjectId;
   }
 
   @Override
@@ -25,8 +25,9 @@ public class ProjectIdInputValidator implements IValidator {
 
   private IStatus validateString(String value) {
     if (value.isEmpty()) {
-      return allowEmptyProjectId ? ValidationStatus.ok() :
-        ValidationStatus.error(Messages.getString("project.id.empty")); //$NON-NLS-1$
+      return requireProjectId ?
+          ValidationStatus.error(Messages.getString("project.id.empty")) : //$NON-NLS-1$
+          ValidationStatus.ok();
     } else if (ProjectIdValidator.validate(value)) {
       return ValidationStatus.ok();
     } else {


### PR DESCRIPTION
@akerekes @briandealwis

Fixes #759.

- Saves and loads an account selection choice (email address) into deploy preferences .
  - `AccountSelectorObservableValue` defined for databinding.
- Validates the deploy dialog. (The _Deploy_ button is disabled if no account is selected.) Subsequently, the stopgap error popup dialog is removed.
- However, this is an optional preference setting (like project ID), so no validation in the preference page.


Misc:
- `OverrideValidator` constructor: I removed `super(Realm)`, as calling the default constructor (which passes the default realm) seems working fine. @akerekes, is there a reason that we should pass a specific realm?
- `allowedEmptyProjctId` --> `!requireValues`