### PR TITLE
Make plugin branding more consistent

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for GCloud for Eclipse App Engine Deployment Support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Cloud Tools for Eclipse App Engine Deployment Support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.ui.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy.ui
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.properties
@@ -1,5 +1,5 @@
 pluginName=Cloud Tools for Eclipse App Engine Deployment UI
-providerName=Google, Inc.
+providerName=Google Inc.
 
 deployStandardCommandDescription=Uploads the project to Google App Engine Standard environment.
 deployStandardCommandName=Deploy to App Engine Standard

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/plugin.properties
@@ -1,2 +1,2 @@
 pluginName=Cloud Tools For Eclipse App Engine Standard Deployment Support
-providerName=Google, Inc.
+providerName=Google Inc.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: App Engine Facet Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.facets.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.facets
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse App Engine Facets
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.facets;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
@@ -1,6 +1,6 @@
 google = Google
 Bundle-Vendor = Google Inc.
-Bundle-Name = Facets for Google Cloud Platform Apps
+Bundle-Name = Cloud Tools for Eclipse Facets
 
 flexFacetName = App Engine Java Flexible Environment
 flexFacetDescription = Supply App Engine Flexible Environment Functionality

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Cloud Tools For Eclipse App Engine Libraries Management
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.libraries.test;singleton:=true
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.libraries
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.properties
@@ -1,2 +1,2 @@
 pluginName=Cloud Tools For Eclipse App Engine Libraries Management
-providerName=Google, Inc.
+providerName=Google Inc.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: App Engine Standard Local Server Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.localserver.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.localserver
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: GCloud for Eclipse App Engine Local Server
+Bundle-Name: Cloud Tools for Eclipse App Engine Local Server
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.localserver;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Activator: com.google.cloud.tools.eclipse.appengine.localserver.Activator

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
@@ -1,5 +1,5 @@
-pluginName=Google App Engine Standard WTP Tools
-providerName=Google, Inc.
+pluginName=Cloud Tools for Eclipse App Engine Standard WTP local server
+providerName=Google Inc.
 
 runtimeTypeDescription=Google App Engine Standard Runtime
 runtimeTypeVendor=Google

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for GCloud for Eclipse Login Support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.login.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.login
 Require-Bundle: org.junit;bundle-version="4.12.0"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: GCloud Login Support
+Bundle-Name: Cloud Tools for Eclipse Login Support
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.login;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/plugin.properties
@@ -1,3 +1,3 @@
-pluginName=Google Cloud Platform Login Support
-providerName=Google, Inc.
+pluginName=Cloud Tools for Eclipse Login Support
+providerName=Google Inc.
 loginIconTooltip=Sign in with your Google Account to access Google services

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: New Maven Project Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.newproject.maven.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.newproject.maven
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Maven-based App Engine Standard Project Generation
+Bundle-Name: Cloud Tools for Eclipse Maven-based App Engine Standard Project Generation
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.newproject.maven;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.eclipse.appengine.newproject;bundle-version="0.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.properties
@@ -1,6 +1,6 @@
 google = Google
 Bundle-Vendor = Google Inc.
-Bundle-Name = Wizards for Google Cloud Platform Apps
+Bundle-Name = Cloud Tools for Eclipse Wizards for Maven App Engine Projects
 
 mavenwizard.name = Maven-based Google App Engine Standard Java Project
 mavenwizard.description = Creates a Maven-based project using the App Engine Standard archetype.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: New Project Wizard Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.newproject.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.newproject
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse App Engine New Project Generation
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.newproject;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.properties
@@ -1,6 +1,6 @@
 google = Google
 Bundle-Vendor = Google Inc.
-Bundle-Name = Wizards for Google Cloud Platform Apps
+Bundle-Name = Cloud Tools for Eclipse App Engine Standard Wizard
 
 gcp.category = Google Cloud Platform
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse Eclipse UI Components Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.ui.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.ui
 Require-Bundle: org.junit,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: GCloud for Eclipse App Engine Shared Resources
+Bundle-Name: Cloud Tools for Eclipse App Engine Shared UI Resources
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.ui;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: com.google.cloud.tools.eclipse.appengine.ui

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
@@ -1,2 +1,9 @@
 pluginName=Cloud Tools for Eclipse User Interface
 providerName=Google Inc.
+googleCloudPlatformAcronym=GCP   
+appEngineAcronym=GAE    
+googleName=Google   
+
+# TODO Why do we have both of these?    
+appEngineName=AppEngine   
+appEngineNameWithSpace=AppEngine

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
@@ -1,20 +1,2 @@
-cloudsdkfacetlabel=Google App Engine Standard
-cloudsdkfacetdescription=Local development support for App Engine Standard Environment for Eclipse WTP
-
-pluginName=Google App Engine Standard WTP Tools
-providerName=Google, Inc.
-
-runtimeTypeDescription=Google App Engine Standard Runtime
-runtimeTypeName=GAE Standard
-runtimeTypeVendor=Google
-
-googleCloudPlatformAcronym=GCP
-appEngineAcronym=GAE
-googleName=Google
-
-# TODO Why do we have both of these?
-appEngineName=AppEngine
-appEngineNameWithSpace=AppEngine
-
-serverTypeName=App Engine Standard
-serverTypeDescription=Local development server for Google App Engine Standard Environment
+pluginName=Cloud Tools for Eclipse User Interface
+providerName=Google Inc.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.whitelist.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.whitelist.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: App Engine Standard Whitelist Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.whitelist.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.whitelist
 Require-Bundle: org.junit,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.whitelist/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.whitelist/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse App Engine JRE Whitelist Checks
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.whitelist;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.core.resources,
   org.eclipse.core.runtime,

--- a/plugins/com.google.cloud.tools.eclipse.preferences.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.preferences.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Google Cloud Platform Preferences
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.preferences.test;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Fragment-Host: com.google.cloud.tools.eclipse.preferences

--- a/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.preferences/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Plugin Preferences
+Bundle-Name: Cloud Tools for Eclipse Preferences
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.preferences;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: com.google.cloud.tools.eclipse.preferences,
  com.google.cloud.tools.eclipse.preferences.areas

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Google Cloud SDK within the Eclipse IDE
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.sdk.test;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Fragment-Host: com.google.cloud.tools.eclipse.sdk

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for UI Support for Google Cloud SDK within the Eclipse IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.sdk.ui.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.sdk.ui
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %Bundle-Name
+Bundle-Name: Cloud Tools for Eclipse User Interface for the Cloud SDK
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.sdk.ui;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: %Bundle-Vendor
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/plugin.properties
@@ -1,4 +1,3 @@
-#Properties file for com.google.cloud.tools.eclipse.sdk.ui
 Bundle-Vendor = Google, Inc.
-Bundle-Name = UI Support for Google Cloud SDK within the Eclipse IDE
+Bundle-Name = Cloud Tools for Eclipse UI Support for Google Cloud SDK
 page.name = Google Cloud SDK Location

--- a/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Support for Google Cloud SDK within the Eclipse IDE
+Bundle-Name: Cloud Tools for Eclipse Support for Google Cloud SDK
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.sdk;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.1.0",

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Test Helpers for SWTBot
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.swtbot
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.swtbot.eclipse.core;bundle-version="2.3.0",
  org.eclipse.swtbot.eclipse.finder;bundle-version="2.3.0",

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse Common Test Dependencies
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.dependencies;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/mockito-core-1.10.19.jar,
  lib/objenesis-2.2.jar

--- a/plugins/com.google.cloud.tools.eclipse.ui.util.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for Cloud Tools for Eclipse Common UI Utilities
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.ui.util.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.ui.util
 Require-Bundle: com.google.guava;bundle-version="15.0.0",

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/plugin.properties
@@ -1,2 +1,2 @@
 pluginName=Cloud Tools for Eclipse Common UI Utilities
-providerName=Google, Inc.
+providerName=Google Inc.

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Cloud Tools for Eclipse Usage Tracker Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.usagetracker.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.usagetracker
 Require-Bundle: org.junit,

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: UsageTracker (common)
+Bundle-Name: Cloud Tools for Eclipse Analytics
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.usagetracker;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: com.google.cloud.tools.eclipse.usagetracker
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.1",

--- a/plugins/com.google.cloud.tools.eclipse.util.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests for GCloud for Eclipse App Engine Common Utilities
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.util.test
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.util
 Require-Bundle: com.google.guava;bundle-version="15.0.0",

--- a/plugins/com.google.cloud.tools.eclipse.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.util/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: GCloud for Eclipse App Engine Common Utilities 
+Bundle-Name: Cloud Tools for Eclipse Common Utilities 
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.util;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Bundle-Vendor: Google, Inc.
+Bundle-Vendor: Google Inc.
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/plugins/com.google.cloud.tools.eclipse.util/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.util/plugin.properties
@@ -1,2 +1,2 @@
-pluginName=Google App Engine Standard Deployment Support
-providerName=Google, Inc.
+pluginName=Cloud Tools for Eclipse shared utility code
+providerName=Google Inc.

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/fragment.properties
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/fragment.properties
@@ -1,2 +1,2 @@
-fragmentName=Modified JDT/Debug socket listener for handling multiple connections
-fragmentProvider=Google, Inc.
+fragmentName=Cloud Tools for Eclipse modified JDT/Debug socket listener for handling multiple connections
+fragmentProvider=Google Inc.


### PR DESCRIPTION
fix #681 
@briandealwis 
@arouzrokh 

Also removed comma after Google per Chicago Manual Of Style:
http://english.stackexchange.com/questions/142620/should-you-use-a-comma-before-the-inc-in-a-company-name