### PR TITLE
getGroupId() --> groupIdField.getText()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -91,11 +91,15 @@ public class MavenArchetypeProjectWizardTest {
   @Test
   public void testSuggestPackageName() {
     assertEquals("aa.bb", MavenAppEngineStandardWizardPage.suggestPackageName("aa.bb"));
+
     assertEquals("aA.Bb", MavenAppEngineStandardWizardPage.suggestPackageName("aA.Bb"));
+
     assertEquals("aa.bb",
         MavenAppEngineStandardWizardPage.suggestPackageName(" a  a\t . b\r b \n"));
+
     assertEquals("aa.bb",
         MavenAppEngineStandardWizardPage.suggestPackageName("....aa....bb..."));
+
     assertEquals("aa._01234bb", MavenAppEngineStandardWizardPage.suggestPackageName(
         "aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb"));
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -120,10 +120,16 @@ public class MavenArchetypeProjectWizardTest {
     page.groupIdField.setText(" a ");
     assertEquals("a", page.javaPackageField.getText());
 
-    page.groupIdField.setText(" a a");
-    assertEquals("aa", page.javaPackageField.getText());
+    page.groupIdField.setText(" a b");
+    assertEquals("a", page.javaPackageField.getText());
 
-    page.groupIdField.setText(" a a ");
-    assertEquals("aa", page.javaPackageField.getText());
+    page.groupIdField.setText(" a ");
+    assertEquals("a", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" a");
+    assertEquals("a", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" ac");
+    assertEquals("ac", page.javaPackageField.getText());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -16,9 +16,14 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
+import org.eclipse.jface.wizard.IWizardContainer;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,15 +31,21 @@ import org.junit.Test;
 public class MavenArchetypeProjectWizardTest {
 
   private MavenArchetypeProjectWizard wizard;
+  private Shell shell;
 
   @Before
   public void setUp() {
     assertNotNull(Display.getDefault());
-
+    shell = new Shell(Display.getDefault());
     wizard = new MavenArchetypeProjectWizard();
     wizard.addPages();
   }
-  
+
+  @After
+  public void tearDown() {
+    shell.dispose();
+  }
+
   @Test
   public void testCanFinish() {
     Assert.assertFalse(wizard.canFinish());
@@ -44,7 +55,7 @@ public class MavenArchetypeProjectWizardTest {
   public void testTwoPages() {
     Assert.assertEquals(2, wizard.getPageCount());
   }
-  
+
   @Test
   public void testGetPageByName() {
     assertNotNull(wizard.getPage("basicNewProjectPage"));
@@ -79,19 +90,36 @@ public class MavenArchetypeProjectWizardTest {
 
   @Test
   public void testSuggestPackageName() {
-    Assert.assertEquals("aa.bb",
-        MavenAppEngineStandardWizardPage.suggestPackageName("aa.bb"));
-
-    Assert.assertEquals("aA.Bb",
-        MavenAppEngineStandardWizardPage.suggestPackageName("aA.Bb"));
-
-    Assert.assertEquals("aa.bb",
+    assertEquals("aa.bb", MavenAppEngineStandardWizardPage.suggestPackageName("aa.bb"));
+    assertEquals("aA.Bb", MavenAppEngineStandardWizardPage.suggestPackageName("aA.Bb"));
+    assertEquals("aa.bb",
         MavenAppEngineStandardWizardPage.suggestPackageName(" a  a\t . b\r b \n"));
-
-    Assert.assertEquals("aa.bb",
+    assertEquals("aa.bb",
         MavenAppEngineStandardWizardPage.suggestPackageName("....aa....bb..."));
-
-    Assert.assertEquals("aa._01234bb", MavenAppEngineStandardWizardPage.suggestPackageName(
+    assertEquals("aa._01234bb", MavenAppEngineStandardWizardPage.suggestPackageName(
         "aa`~!@#$%^&*()-+=[]{}<>\\|:;'\",?/._01234bb"));
+  }
+
+  @Test
+  public void testAutoPackageNameSetterOnGroupIdChange_whitespaceInGroupId() {
+    wizard.setContainer(mock(IWizardContainer.class));
+    wizard.createPageControls(shell);
+    MavenAppEngineStandardWizardPage page =
+        (MavenAppEngineStandardWizardPage) wizard.getPage("basicNewProjectPage");
+
+    page.groupIdField.setText(" ");  // setText() triggers VerifyEvent.
+    assertEquals("", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" a");
+    assertEquals("a", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" a ");
+    assertEquals("a", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" a a");
+    assertEquals("aa", page.javaPackageField.getText());
+
+    page.groupIdField.setText(" a a ");
+    assertEquals("aa", page.javaPackageField.getText());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -60,10 +60,10 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
   private Button useDefaults;
   private Text locationField;
   private Button locationBrowseButton;
-  private Text groupIdField;
+  @VisibleForTesting Text groupIdField;
   private Text artifactIdField;
   private Text versionField;
-  private Text javaPackageField;
+  @VisibleForTesting Text javaPackageField;
   private Text projectIdField;
 
   private boolean canFlipPage;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -16,7 +16,13 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
-import java.text.MessageFormat;
+import com.google.cloud.tools.eclipse.appengine.newproject.JavaPackageValidator;
+import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
+import com.google.cloud.tools.project.ProjectIdValidator;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
@@ -41,13 +47,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 
-import com.google.cloud.tools.eclipse.appengine.newproject.JavaPackageValidator;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
-import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
-import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
-import com.google.cloud.tools.project.ProjectIdValidator;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.CharMatcher;
+import java.text.MessageFormat;
 
 /**
  * UI to collect all information necessary to create a new Maven-based App Engine Standard Java
@@ -352,19 +352,20 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
   }
 
   /**
-   * Auto-fills javaPackageField as groupId when 
-   * 1) javaPackageField is empty; or 
+   * Auto-fills {@link #javaPackageField} as Group ID when
+   * 1) {@link #javaPackageField} is empty; or
    * 2) the field matches previous auto-fill before ID modification.
    */
   private final class AutoPackageNameSetterOnGroupIdChange implements VerifyListener {
     @Override
     public void verifyText(VerifyEvent event) {
+      String groupId = groupIdField.getText();
       // Below explains how to get text after modification:
       // http://stackoverflow.com/questions/32872249/get-text-of-swt-text-component-before-modification
       String newGroupId =
-          getGroupId().substring(0, event.start) + event.text + getGroupId().substring(event.end);
+          groupId.substring(0, event.start) + event.text + groupId.substring(event.end);
 
-      String oldPackageName = suggestPackageName(getGroupId());
+      String oldPackageName = suggestPackageName(groupId);
       String newPackageName = suggestPackageName(newGroupId);
       adjustPackageName(oldPackageName, newPackageName);
     }

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -99,9 +99,12 @@ public class AnalyticsPingManager {
       if (preferences == null) {
         throw new NullPointerException("Preference store cannot be null.");
       }
-      instance = new AnalyticsPingManager(preferences,
-          PlatformUI.getWorkbench().getDisplay(), new ConcurrentLinkedQueue<PingEvent>(),
-          !Platform.inDevelopmentMode() && isTrackingIdDefined());
+
+      boolean analyticsEnabled = !Platform.inDevelopmentMode() && isTrackingIdDefined();
+      Display display = !analyticsEnabled ? null : PlatformUI.getWorkbench().getDisplay();
+
+      instance = new AnalyticsPingManager(preferences, display,
+          new ConcurrentLinkedQueue<PingEvent>(), analyticsEnabled);
     }
     return instance;
   }


### PR DESCRIPTION
Fixes #801.

`getGroupId()` calls `trim()` and doesn't return an actual value typed in the text field.