### PR TITLE
Checks for missing App Engine Component

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetInstallDelegate.java
@@ -32,10 +32,10 @@ public abstract class AppEngineFacetInstallDelegate implements IDelegate   {
       IProjectFacetVersion version,
       Object config,
       IProgressMonitor monitor) throws CoreException {
-    validateAppEngineComponent();
+    validateAppEngineJavaComponents();
   }
 
-  private void validateAppEngineComponent() throws CoreException {
+  private void validateAppEngineJavaComponents() throws CoreException {
     CloudSdk cloudSdk = new CloudSdk.Builder().build();
     try {
       cloudSdk.validateAppEngineJavaComponents();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetInstallDelegate.java
@@ -26,7 +26,7 @@ import com.google.cloud.tools.appengine.cloudsdk.AppEngineJavaComponentsNotInsta
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 
-public abstract class FacetInstallDelegate implements IDelegate   {
+public abstract class AppEngineFacetInstallDelegate implements IDelegate   {
   @Override
   public void execute(IProject project,
       IProjectFacetVersion version,
@@ -42,7 +42,7 @@ public abstract class FacetInstallDelegate implements IDelegate   {
     } catch (AppEngineJavaComponentsNotInstalledException ex) {
       // to properly display error in message box
       throw new CoreException(StatusUtil.error(getClass(),
-          Messages.getString("appengine.component.missing"), ex));
+          Messages.getString("appengine.java.component.missing"), ex));
     }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetInstallDelegate.java
@@ -22,12 +22,27 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
-public class FlexFacetUninstallDelegate implements IDelegate {
+import com.google.cloud.tools.appengine.cloudsdk.AppEngineJavaComponentsNotInstalledException;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 
+public abstract class FacetInstallDelegate implements IDelegate   {
   @Override
-  public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)
-      throws CoreException {
-    
+  public void execute(IProject project,
+      IProjectFacetVersion version,
+      Object config,
+      IProgressMonitor monitor) throws CoreException {
+    verifyGcloudAppEngineComponent();
   }
 
+  private void verifyGcloudAppEngineComponent() throws CoreException {
+    CloudSdk cloudSdk = new CloudSdk.Builder().build();
+    try {
+    cloudSdk.validateAppEngineJavaComponents();
+    } catch (AppEngineJavaComponentsNotInstalledException ex) {
+      // to properly display error in message box
+      throw new CoreException(StatusUtil.error(getClass(),
+          Messages.getString("appengine.component.missing"), ex));
+    }
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetInstallDelegate.java
@@ -32,13 +32,13 @@ public abstract class FacetInstallDelegate implements IDelegate   {
       IProjectFacetVersion version,
       Object config,
       IProgressMonitor monitor) throws CoreException {
-    verifyGcloudAppEngineComponent();
+    validateAppEngineComponent();
   }
 
-  private void verifyGcloudAppEngineComponent() throws CoreException {
+  private void validateAppEngineComponent() throws CoreException {
     CloudSdk cloudSdk = new CloudSdk.Builder().build();
     try {
-    cloudSdk.validateAppEngineJavaComponents();
+      cloudSdk.validateAppEngineJavaComponents();
     } catch (AppEngineJavaComponentsNotInstalledException ex) {
       // to properly display error in message box
       throw new CoreException(StatusUtil.error(getClass(),

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
@@ -21,7 +21,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
-public class FlexFacetInstallDelegate extends FacetInstallDelegate {
+public class FlexFacetInstallDelegate extends AppEngineFacetInstallDelegate {
 
   @Override
   public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
@@ -1,17 +1,32 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.eclipse.appengine.facets;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
-public class FlexFacetInstallDelegate implements IDelegate {
+public class FlexFacetInstallDelegate extends FacetInstallDelegate {
 
   @Override
   public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)
       throws CoreException {
-    
+    super.execute(project, facetVersion, config, monitor);
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
@@ -16,17 +16,6 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
-
 public class FlexFacetInstallDelegate extends AppEngineFacetInstallDelegate {
-
-  @Override
-  public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)
-      throws CoreException {
-    super.execute(project, facetVersion, config, monitor);
-  }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/Messages.java
@@ -16,18 +16,22 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.wst.common.project.facet.core.IDelegate;
-import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
-public class FlexFacetUninstallDelegate implements IDelegate {
+public class Messages {
+  private static final String BUNDLE_NAME = "com.google.cloud.tools.eclipse.appengine.facets.messages"; //$NON-NLS-1$
 
-  @Override
-  public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)
-      throws CoreException {
-    
+  private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+  private Messages() {
   }
 
+  public static String getString(String key) {
+    try {
+      return RESOURCE_BUNDLE.getString(key);
+    } catch (MissingResourceException e) {
+      return '!' + key + '!';
+    }
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -30,7 +30,7 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 
-public class StandardFacetInstallDelegate extends FacetInstallDelegate {
+public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate {
   private final static String APPENGINE_WEB_XML = "appengine-web.xml";
   // TODO Change directory for dynamic web module.
   // Differentiate between project with web facets vs 'true' dynamic web modules?

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -25,13 +25,12 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 
-public class StandardFacetInstallDelegate implements IDelegate {
+public class StandardFacetInstallDelegate extends FacetInstallDelegate {
   private final static String APPENGINE_WEB_XML = "appengine-web.xml";
   // TODO Change directory for dynamic web module.
   // Differentiate between project with web facets vs 'true' dynamic web modules?
@@ -43,6 +42,7 @@ public class StandardFacetInstallDelegate implements IDelegate {
                       IProjectFacetVersion version,
                       Object config,
                       IProgressMonitor monitor) throws CoreException {
+    super.execute(project, version, config, monitor);
     createConfigFiles(project, monitor);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -1,1 +1,1 @@
-appengine.java.component.missing=Missing Java App Engine component
+appengine.java.component.missing=The Cloud SDK App Engine Java component is not installed

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -1,1 +1,1 @@
-appengine.java.component.missing=Project setup failed because the Cloud SDK App Engine Java component is not installed. Fix by running 'gcloud components install app-engine-java' on command-line.
+appengine.java.component.missing=Project setup failed because the Cloud SDK App Engine Java component is not installed. Fix by running 'gcloud components install app-engine-java' on the command-line.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -1,1 +1,1 @@
-appengine.component.missing=Missing Java App Engine component
+appengine.java.component.missing=Missing Java App Engine component

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -1,1 +1,1 @@
-appengine.java.component.missing=The Cloud SDK App Engine Java component is not installed
+appengine.java.component.missing=Project setup failed because the Cloud SDK App Engine Java component is not installed. Fix by running 'gcloud components install app-engine-java' on command-line.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -1,0 +1,1 @@
+appengine.component.missing=Missing Java App Engine component


### PR DESCRIPTION
Checks that the App Engine Component is installed during the facet installation. If the App Engine component is not installed, it throws an error (with instructions on how to install the component) and uninstalls the facet. So the only time a project can be flagged to have App Engine functionality is when the App Engine component is installed. 

I originally went the route of creating a builder that puts an error marker on App Engine projects when the App Engine component is missing, but it was seemed confusing because (i) the project themselves did not have any problems, the fix was outside the project (ii) even though it was an incremental builder, the times when there was a change in the project could not be correlated with when the app engine component was installed, so we were basically checking at random times if the app engine component had been installed.

Fix for #367