### PR TITLE
Better display setup / better combo selection simulation in tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/TestProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/TestProject.java
@@ -35,10 +35,6 @@ public final class TestProject extends ExternalResource {
   private IJavaProject javaProject;
   private String containerPath;
 
-  public TestProject() {
-    super();
-  }
-
   public TestProject withClasspathContainerPath(String containerPath) {
     this.containerPath = containerPath;
     return this;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -33,6 +33,7 @@ import com.google.cloud.tools.ide.login.Account;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +47,6 @@ import java.util.HashSet;
 public class AccountSelectorTest {
 
   @Mock private IGoogleLoginService loginService;
-  private Display display;
   private Shell shell;
 
   @Mock private Account account1;
@@ -58,8 +58,7 @@ public class AccountSelectorTest {
 
   @Before
   public void setUp() {
-    display = Display.getDefault();
-    shell = new Shell(display);
+    shell = new Shell(Display.getDefault());
 
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
     when(account1.getOAuth2Credential()).thenReturn(credential1);
@@ -69,9 +68,14 @@ public class AccountSelectorTest {
     when(account3.getOAuth2Credential()).thenReturn(credential3);
   }
 
+  @After
+  public void tearDown() {
+    shell.dispose();
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testConstructor_nullLoginMessage() {
-    new AccountSelector(new Shell(display), loginService, null);
+    new AccountSelector(shell, loginService, null);
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -33,7 +33,6 @@ import com.google.cloud.tools.ide.login.Account;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,7 +58,7 @@ public class AccountSelectorTest {
 
   @Before
   public void setUp() {
-    display = new Display();
+    display = Display.getDefault();
     shell = new Shell(display);
 
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
@@ -68,11 +67,6 @@ public class AccountSelectorTest {
     when(account2.getOAuth2Credential()).thenReturn(credential2);
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
     when(account3.getOAuth2Credential()).thenReturn(credential3);
-  }
-
-  @After
-  public void tearDown() {
-    display.dispose();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -30,8 +30,9 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.tools.eclipse.appengine.login.IGoogleLoginService;
 import com.google.cloud.tools.ide.login.Account;
 
-import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.After;
 import org.junit.Before;
@@ -220,8 +221,7 @@ public class AccountSelectorTest {
     assertFalse(selector.getSelectedEmail().isEmpty());
 
     assertEquals("<select this to login>", selector.combo.getItem(2));
-    selector.combo.select(2);
-    selector.logInOnSelect.widgetSelected(mock(SelectionEvent.class));
+    simulateSelect(selector, 2);
 
     assertEquals(3, selector.combo.getItemCount());
     assertEquals(-1, selector.combo.getSelectionIndex());
@@ -232,6 +232,6 @@ public class AccountSelectorTest {
 
   private void simulateSelect(AccountSelector selector, int index) {
     selector.combo.select(index);
-    selector.logInOnSelect.widgetSelected(mock(SelectionEvent.class));
+    selector.combo.notifyListeners(SWT.Selection, mock(Event.class));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelectorTest.java
@@ -31,11 +31,10 @@ import com.google.cloud.tools.eclipse.appengine.login.IGoogleLoginService;
 import com.google.cloud.tools.ide.login.Account;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -47,9 +46,10 @@ import java.util.HashSet;
 @RunWith(MockitoJUnitRunner.class)
 public class AccountSelectorTest {
 
-  @Mock private IGoogleLoginService loginService;
+  @Rule public ShellTestResource shellTestResource = new ShellTestResource();
   private Shell shell;
 
+  @Mock private IGoogleLoginService loginService;
   @Mock private Account account1;
   @Mock private Account account2;
   @Mock private Account account3;
@@ -59,19 +59,13 @@ public class AccountSelectorTest {
 
   @Before
   public void setUp() {
-    shell = new Shell(Display.getDefault());
-
+    shell = shellTestResource.getShell();
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
     when(account1.getOAuth2Credential()).thenReturn(credential1);
     when(account2.getEmail()).thenReturn("some-email-2@example.com");
     when(account2.getOAuth2Credential()).thenReturn(credential2);
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
     when(account3.getOAuth2Credential()).thenReturn(credential3);
-  }
-
-  @After
-  public void tearDown() {
-    shell.dispose();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.tools.ide.login.Account;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +43,7 @@ import java.util.List;
 public class AccountsPanelTest {
 
   @Mock private IGoogleLoginService loginService;
-  private Display display;
+  private Shell shell;
 
   @Mock private Account account1;
   @Mock private Account account2;
@@ -50,10 +51,15 @@ public class AccountsPanelTest {
 
   @Before
   public void setUp() {
-    display = Display.getDefault();
+    shell = new Shell(Display.getDefault());
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
     when(account2.getEmail()).thenReturn("some-email-2@example.com");
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
+  }
+
+  @After
+  public void tearDown() {
+    shell.dispose();
   }
 
   @Test
@@ -61,7 +67,7 @@ public class AccountsPanelTest {
     setUpLoginService();
 
     AccountsPanel panel = new AccountsPanel(null, loginService);
-    panel.createDialogArea(new Shell(display));
+    panel.createDialogArea(shell);
 
     assertNull(panel.logOutButton);
   }
@@ -71,7 +77,7 @@ public class AccountsPanelTest {
     setUpLoginService(Arrays.asList(account1));
 
     AccountsPanel panel = new AccountsPanel(null, loginService);
-    panel.createDialogArea(new Shell(display));
+    panel.createDialogArea(shell);
 
     assertNotNull(panel.logOutButton);
   }
@@ -81,7 +87,7 @@ public class AccountsPanelTest {
     setUpLoginService();
 
     AccountsPanel panel = new AccountsPanel(null, loginService);
-    panel.createDialogArea(new Shell(display));
+    panel.createDialogArea(shell);
 
     assertTrue(panel.accountLabels.isEmpty());
   }
@@ -91,7 +97,7 @@ public class AccountsPanelTest {
     setUpLoginService(Arrays.asList(account1));
 
     AccountsPanel panel = new AccountsPanel(null, loginService);
-    panel.createDialogArea(new Shell(display));
+    panel.createDialogArea(shell);
 
     assertEquals(1, panel.accountLabels.size());
     panel.accountLabels.get(0).getText().contains(account2.getEmail());
@@ -102,7 +108,7 @@ public class AccountsPanelTest {
     setUpLoginService(Arrays.asList(account1, account2, account3));
 
     AccountsPanel panel = new AccountsPanel(null, loginService);
-    panel.createDialogArea(new Shell(display));
+    panel.createDialogArea(shell);
 
     assertEquals(3, panel.accountLabels.size());
     String text1 = panel.accountLabels.get(0).getText();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
@@ -25,10 +25,9 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.tools.eclipse.appengine.login.IGoogleLoginService;
 import com.google.cloud.tools.ide.login.Account;
 
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -42,24 +41,20 @@ import java.util.List;
 @RunWith(MockitoJUnitRunner.class)
 public class AccountsPanelTest {
 
-  @Mock private IGoogleLoginService loginService;
+  @Rule public ShellTestResource shellTestResource = new ShellTestResource();
   private Shell shell;
 
+  @Mock private IGoogleLoginService loginService;
   @Mock private Account account1;
   @Mock private Account account2;
   @Mock private Account account3;
 
   @Before
   public void setUp() {
-    shell = new Shell(Display.getDefault());
+    shell = shellTestResource.getShell();
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
     when(account2.getEmail()).thenReturn("some-email-2@example.com");
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
-  }
-
-  @After
-  public void tearDown() {
-    shell.dispose();
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountsPanelTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.ide.login.Account;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,15 +50,10 @@ public class AccountsPanelTest {
 
   @Before
   public void setUp() {
-    display = new Display();
+    display = Display.getDefault();
     when(account1.getEmail()).thenReturn("some-email-1@example.com");
     when(account2.getEmail()).thenReturn("some-email-2@example.com");
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
-  }
-
-  @After
-  public void tearDown() {
-    display.dispose();
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/ShellTestResource.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login.test/src/com/google/cloud/tools/eclipse/appengine/login/ui/ShellTestResource.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.eclipse.appengine.login.ui;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.junit.rules.ExternalResource;
+
+public class ShellTestResource extends ExternalResource {
+
+  private Shell shell;
+
+  public Shell getShell() {
+    return shell;
+  }
+
+  @Override
+  protected void before() {
+    shell = new Shell(Display.getDefault());
+  }
+
+  @Override
+  protected void after() {
+    shell.dispose();
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenArchetypeProjectWizardTest.java
@@ -35,8 +35,12 @@ public class MavenArchetypeProjectWizardTest {
 
   @Before
   public void setUp() {
+    // TODO(chanseok): use ShellTestResource (see AccountPanelTest) after fixing
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/771.
+    // (Remove shell.dispose() in tearDown() too.)
     assertNotNull(Display.getDefault());
     shell = new Shell(Display.getDefault());
+
     wizard = new MavenArchetypeProjectWizard();
     wizard.addPages();
   }


### PR DESCRIPTION
1. Doing `new Display()` and `display.dispose()` didn't allow running JUnit Plug-in Test inside Eclipse. We should use `Display.getDefault()`.
  - As part of this change, I created `ShellTestResoruce` (a JUnit rule) as suggested in https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/805#discussion_r83248790.
2. Call `notifyListeners()` instead of directly calling the combo selection listener implementation.

@akerekes PTAL