### PR TITLE
Ensure we include our modified JDT launching classes

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -137,4 +137,12 @@
          version="0.0.0"
          unpack="false"/>
 
+  <plugin
+        id="com.google.cloud.tools.eclipse.jdt.launching"
+        download-size="0"
+        install-size="0"
+        version="0.0.0"
+        fragment="true"
+        unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Updated the `com.google.cloud.tools.eclipse.suite.e45.feature` to include the `.jdt.launching` bundle.  Verified now included in the built repository.