### PR TITLE
Force dialog re-validation for account email

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModelTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardDeployPreferences;
+
+import org.junit.Test;
+import org.osgi.service.prefs.BackingStoreException;
+
+public class DeployPreferencesModelTest {
+
+  @Test
+  public void testSavePreferences_ignoreRevalidationTrickEmail() throws BackingStoreException {
+    StandardDeployPreferences preferences = mock(StandardDeployPreferences.class);
+    DeployPreferencesModel model = new DeployPreferencesModel(preferences);
+    model.setAccountEmail(DeployPreferencesModel.REVALIDATION_TRICK_EMAIL_VALUE);
+
+    model.savePreferences();
+    verify(preferences, never()).setAccountEmail(anyString());
+    verify(preferences, times(1)).setProjectId(anyString());
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
@@ -1,11 +1,33 @@
+/*******************************************************************************
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
 package com.google.cloud.tools.eclipse.appengine.deploy.ui;
 
 import org.eclipse.core.resources.IProject;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardDeployPreferences;
+import com.google.common.annotations.VisibleForTesting;
 
 public class DeployPreferencesModel {
+
+  // We set the email in this model to this value right after the associated control is sync'ed
+  // (through databinding) with the actual email. By doing this, we can always force dialog
+  // validation whenever a value in the associated control is changed.
+  public static final String REVALIDATION_TRICK_EMAIL_VALUE = "Marker: don't save this value";
 
   private StandardDeployPreferences preferences;
 
@@ -19,7 +41,12 @@ public class DeployPreferencesModel {
   private String bucket;
 
   public DeployPreferencesModel(IProject project) {
-    preferences = new StandardDeployPreferences(project);
+    this(new StandardDeployPreferences(project));
+  }
+
+  @VisibleForTesting
+  DeployPreferencesModel(StandardDeployPreferences preferences) {
+    this.preferences = preferences;
     applyPreferences(preferences);
   }
 
@@ -39,7 +66,9 @@ public class DeployPreferencesModel {
   }
 
   public void savePreferences() throws BackingStoreException {
-    preferences.setAccountEmail(getAccountEmail());
+    if (!REVALIDATION_TRICK_EMAIL_VALUE.equals(getAccountEmail())) {
+      preferences.setAccountEmail(getAccountEmail());
+    }
     preferences.setProjectId(getProjectId());
     preferences.setOverrideDefaultVersioning(isOverrideDefaultVersioning());
     preferences.setVersion(getVersion());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPreferencesModel.java
@@ -16,17 +16,17 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy.ui;
 
-import org.eclipse.core.resources.IProject;
-import org.osgi.service.prefs.BackingStoreException;
-
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardDeployPreferences;
 import com.google.common.annotations.VisibleForTesting;
 
+import org.eclipse.core.resources.IProject;
+import org.osgi.service.prefs.BackingStoreException;
+
 public class DeployPreferencesModel {
 
-  // We set the email in this model to this value right after the associated control is sync'ed
-  // (through databinding) with the actual email. By doing this, we can always force dialog
-  // validation whenever a value in the associated control is changed.
+  // After the Account Selector is set up with a correct email, we set the email value in this
+  // model to this special value. By doing this, we can always force dialog validation whenever
+  // an email value in the Account Selector is changed.
   public static final String REVALIDATION_TRICK_EMAIL_VALUE = "Marker: don't save this value";
 
   private StandardDeployPreferences preferences;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -145,6 +145,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     context.bindValue(new AccountSelectorObservableValue(accountSelector), accountEmailModel);
 
     if (requireValues) {
+      model.setAccountEmail(DeployPreferencesModel.REVALIDATION_TRICK_EMAIL_VALUE);
       context.addValidationStatusProvider(new FixedMultiValidator() {
         @Override
         protected IStatus validate() {


### PR DESCRIPTION
Fixes #831.

Currently, we have 3 objects being sync'ed through databinding for saving and loading deploy preferences:

Standard Java Preferences <--> Model Object <--> Account Selector

This PR employs a trick that invalidates the email value in the model (by setting a special value) right after sync'ing it with the Account Selector. As a result, databinding will always trigger dialog re-validation whenever the value in the Account Selector changes.