### PR TITLE
Connection limit

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -163,7 +163,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     IVMConnector connector = JavaRuntime.getVMConnector(
         "com.google.cloud.tools.eclipse.jdt.launching.socketListenerMultipleConnector");
     if (connector == null) {
-      // The 4.7 listen connector supports an connectionLimit
+      // The 4.7 listen connector supports a connectionLimit
       connector = JavaRuntime
           .getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -163,7 +163,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     IVMConnector connector = JavaRuntime.getVMConnector(
         "com.google.cloud.tools.eclipse.jdt.launching.socketListenerMultipleConnector");
     if (connector == null) {
-      // The 4.7 listen connector supports an acceptCount
+      // The 4.7 listen connector supports an connectionLimit
       connector = JavaRuntime
           .getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
     }
@@ -179,7 +179,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     connectionParameters.put("hostname", DEBUGGER_HOST);
     connectionParameters.put("port", Integer.toString(port));
     connectionParameters.put("timeout", Integer.toString(timeout));
-    connectionParameters.put("acceptCount", "0");
+    connectionParameters.put("connectionLimit", "0");
     connector.connect(connectionParameters, monitor, launch);
   }
 

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdi/internal/connect/SocketListeningMultiConnectorImpl.java
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdi/internal/connect/SocketListeningMultiConnectorImpl.java
@@ -84,7 +84,7 @@ public class SocketListeningMultiConnectorImpl extends ConnectorImpl implements 
 
 		// FIXME: this doesn't feel like the right place, but
 		// IntegerArgumentImpl is package restricted
-		intArg = new _IntegerArgumentImpl("acceptCount", //$NON-NLS-1$
+		intArg = new _IntegerArgumentImpl("connectionLimit", //$NON-NLS-1$
 				"Limit incoming connections (0 = no limit)", "Connection limit:", false, 0,
 				Integer.MAX_VALUE);
 		intArg.setValue(1); // mimics previous behaviour

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdt/internal/launching/SocketListenMultiConnector.java
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdt/internal/launching/SocketListenMultiConnector.java
@@ -40,7 +40,7 @@ import java.util.Map;
 
 /**
  * Fork of {@link org.eclipse.jdt.internal.launching.SocketListenConnector}.
- * This connector knows how to interpret the "acceptCount" parameter.
+ * This connector knows how to interpret the "connectionLimit" parameter.
  * 
  * A standard socket listening connector. Starts a launch that waits for a VM to
  * connect at a specific port.
@@ -108,9 +108,9 @@ public class SocketListenMultiConnector implements IVMConnector {
 		}
 
 		// retain default behaviour to accept 1 connection only
-		int acceptCount = 1;
-		if (arguments.containsKey("acceptCount")) {
-			acceptCount = Integer.valueOf(arguments.get("acceptCount"));
+		int connectionLimit = 1;
+		if (arguments.containsKey("connectionLimit")) {
+			connectionLimit = Integer.valueOf(arguments.get("connectionLimit"));
 		}
 
 		Map<String, Connector.Argument> acceptArguments = connector.defaultArguments();
@@ -122,7 +122,7 @@ public class SocketListenMultiConnector implements IVMConnector {
 			monitor.subTask(NLS.bind(LaunchingMessages.SocketListenConnector_3, new String[] { portNumberString }));
 			connector.startListening(acceptArguments);
 			SocketListenMultiConnectorProcess process = new SocketListenMultiConnectorProcess(launch, portNumberString,
-					acceptCount);
+					connectionLimit);
 			process.waitForConnection(connector, acceptArguments);
 		} catch (IOException e) {
 			abort(LaunchingMessages.SocketListenConnector_4, e,
@@ -158,7 +158,7 @@ public class SocketListenMultiConnector implements IVMConnector {
 	public List<String> getArgumentOrder() {
 		List<String> list = new ArrayList<String>(1);
 		list.add("port"); //$NON-NLS-1$
-		list.add("acceptCount"); //$NON-NLS-1$
+		list.add("connectionLimit"); //$NON-NLS-1$
 		return list;
 	}
 

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdt/internal/launching/SocketListenMultiConnectorProcess.java
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/src/com/google/cloud/tools/eclipse/jdt/internal/launching/SocketListenMultiConnectorProcess.java
@@ -49,7 +49,7 @@ import java.util.Map;
 /**
  * Fork of
  * {@link org.eclipse.jdt.internal.launching.SocketListenConnectorProcess}.
- * Knows how to handle "acceptCount" count.
+ * Knows how to handle "connectionLimit" count.
  * 
  * A process that represents a VM listening connector that is waiting for a VM
  * to remotely connect. Allows the user to see the status of the connection and
@@ -66,7 +66,7 @@ public class SocketListenMultiConnectorProcess implements IProcess {
 	 * The number of incoming connections to accept (0 = unlimited). Setting to
 	 * 1 mimics previous behaviour.
 	 */
-	private int fAcceptCount;
+	private int fConnectionLimit;
 
 	/** The number of connections accepted so far. */
 	private int fAccepted = 0;
@@ -99,13 +99,13 @@ public class SocketListenMultiConnectorProcess implements IProcess {
      *            the launch this process belongs to
      * @param port
      *            the port the connector will wait on
-     * @param acceptCount
+     * @param connectionLimit
      *            the number of incoming connections to accept (0 = unlimited)
      */
-    public SocketListenMultiConnectorProcess(ILaunch launch, String port, int acceptCount) {
+    public SocketListenMultiConnectorProcess(ILaunch launch, String port, int connectionLimit) {
         fLaunch = launch;
         fPort = port;
-		fAcceptCount = acceptCount;
+		fConnectionLimit = connectionLimit;
     }
     
     /**
@@ -130,10 +130,10 @@ public class SocketListenMultiConnectorProcess implements IProcess {
         // If the connector does not support multiple connections, accept a single connection
         try {
             if (!connector.supportsMultipleConnections()) {
-				fAcceptCount = 1;
+				fConnectionLimit = 1;
             }
         } catch (IOException | IllegalConnectorArgumentsException ex) {
-			fAcceptCount = 1;
+			fConnectionLimit = 1;
         }
         fLaunch.addProcess(this);
         fWaitForConnectionJob = new WaitForConnectionJob(connector, arguments);
@@ -163,7 +163,7 @@ public class SocketListenMultiConnectorProcess implements IProcess {
 	 * connections.
 	 */
 	protected boolean continueListening() {
-		return !isTerminated() && (fAcceptCount <= 0 || fAcceptCount - fAccepted > 0);
+		return !isTerminated() && (fConnectionLimit <= 0 || fConnectionLimit - fAccepted > 0);
 	}
 
 	/**
@@ -429,7 +429,7 @@ public class SocketListenMultiConnectorProcess implements IProcess {
                 }
             }
             StringBuffer buffer = new StringBuffer(name);
-			if (fAcceptCount != 1) {
+			if (fConnectionLimit != 1) {
 				// if we're accepting multiple incoming connections,
 				// append the time when each connection was accepted
 				buffer.append("<").append(getRunningTime()).append(">");

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/tests/com/google/cloud/tools/eclipse/jdt/launching/MultipleConnectionsTest.java
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/tests/com/google/cloud/tools/eclipse/jdt/launching/MultipleConnectionsTest.java
@@ -61,8 +61,8 @@ public class MultipleConnectionsTest {
 	public void testDefaultSettings() throws CoreException {
 		connector = new SocketListenMultiConnector();
 		Map<String, Connector.Argument> defaults = connector.getDefaultArguments();
-		assertTrue(defaults.containsKey("acceptCount"));
-		assertEquals(1, ((Connector.IntegerArgument) defaults.get("acceptCount")).intValue());
+		assertTrue(defaults.containsKey("connectionLimit"));
+		assertEquals(1, ((Connector.IntegerArgument) defaults.get("connectionLimit")).intValue());
 	}
 
 	/**
@@ -93,7 +93,7 @@ public class MultipleConnectionsTest {
 		connector = new SocketListenMultiConnector();
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("port", Integer.toString(port));
-		arguments.put("acceptCount", "1");
+		arguments.put("connectionLimit", "1");
 		connector.connect(arguments, new NullProgressMonitor(), launch);
 		Thread.sleep(200);
 
@@ -112,7 +112,7 @@ public class MultipleConnectionsTest {
 		connector = new SocketListenMultiConnector();
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("port", Integer.toString(port));
-		arguments.put("acceptCount", "2");
+		arguments.put("connectionLimit", "2");
 		connector.connect(arguments, new NullProgressMonitor(), launch);
 		Thread.sleep(200);
 
@@ -131,7 +131,7 @@ public class MultipleConnectionsTest {
 		connector = new SocketListenMultiConnector();
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("port", Integer.toString(port));
-		arguments.put("acceptCount", "0");
+		arguments.put("connectionLimit", "0");
 		connector.connect(arguments, new NullProgressMonitor(), launch);
 		Thread.sleep(200);
 

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/tests/com/google/cloud/tools/eclipse/jdt/launching/MultipleConnectionsTest.java
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/tests/com/google/cloud/tools/eclipse/jdt/launching/MultipleConnectionsTest.java
@@ -76,7 +76,6 @@ public class MultipleConnectionsTest {
 		connector = new SocketListenMultiConnector();
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("port", Integer.toString(port));
-		arguments.put("acceptCount", "1");
 		connector.connect(arguments, new NullProgressMonitor(), launch);
 		Thread.sleep(200);
 


### PR DESCRIPTION
Sync up with changes requested in [the Eclipse connection patch](https://git.eclipse.org/r/79579) for #609
  - `MultipleConnectionsTest#testDefaultBehaviour()` shouldn't specify "acceptCount" (now "connectionLimit")
  - Rename "acceptCount" -> "connectionLimit"
