### PR TITLE
add properties for hello world

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
@@ -70,6 +70,11 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
     properties.put("appengine-version", appengineArtifactVersion);
     properties.put("gcloud-version", gcloudArtifactVersion);
     properties.put("application-id", appId);
+    properties.put("useJstl", "true");
+    properties.put("useObjectify", "false");
+    properties.put("useEndpoints1", "false");
+    properties.put("useEndpoints2", "false");
+    properties.put("useAppEngineApi", "false");
 
     ProjectImportConfiguration importConfiguration = new ProjectImportConfiguration();
     String packageName = this.packageName == null || this.packageName.isEmpty() 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,10 +61,12 @@ public class CreateMavenBasedAppEngineStandardProject extends WorkspaceModifyOpe
     if (appId == null || appId.trim().isEmpty()) {
       appId = artifactId;
     }
-    String appengineArtifactVersion = MavenUtils.resolveLatestReleasedArtifactVersion(progress.newChild(20),
-        "com.google.appengine", "appengine-api-1.0-sdk", "jar", AppEngineStandardFacet.DEFAULT_APPENGINE_SDK_VERSION);
-    String gcloudArtifactVersion = MavenUtils.resolveLatestReleasedArtifactVersion(progress.newChild(20),
-        "com.google.appengine", "gcloud-maven-plugin", "maven-plugin", AppEngineStandardFacet.DEFAULT_GCLOUD_PLUGIN_VERSION);
+    String appengineArtifactVersion = MavenUtils.resolveLatestReleasedArtifactVersion(
+        progress.newChild(20), "com.google.appengine", "appengine-api-1.0-sdk", "jar",
+        AppEngineStandardFacet.DEFAULT_APPENGINE_SDK_VERSION);
+    String gcloudArtifactVersion = MavenUtils.resolveLatestReleasedArtifactVersion(
+        progress.newChild(20), "com.google.appengine", "gcloud-maven-plugin", "maven-plugin",
+        AppEngineStandardFacet.DEFAULT_GCLOUD_PLUGIN_VERSION);
 
     Properties properties = new Properties();
     properties.put("appengine-version", appengineArtifactVersion);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
@@ -38,7 +38,7 @@ import com.google.common.annotations.VisibleForTesting;
  * UI to select an archetype in creating a new Maven-based App Engine Standard Java project.
  */
 public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
-
+  
   @VisibleForTesting
   static final java.util.List<ArchetypeTuple> PRESET_ARCHETYPES =
       Collections.unmodifiableList(Arrays.asList(
@@ -49,7 +49,8 @@ public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
           new ArchetypeTuple("com.google.appengine.archetypes", //$NON-NLS-1$
               "guestbook-archetype", //$NON-NLS-1$
               Messages.getString("APPENGINE_GUESTBOOK_ARCHETYPE_DISPLAY_NAME"), //$NON-NLS-1$
-              Messages.getString("APPENGINE_GUESTBOOK_ARCHETYPE_DESCRIPTION")))); //$NON-NLS-1$
+              Messages.getString("APPENGINE_GUESTBOOK_ARCHETYPE_DESCRIPTION")  //$NON-NLS-1$
+           )));
 
   // UI components
   private List archetypeList;
@@ -108,7 +109,7 @@ public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
     Archetype archetype;
     String displayName;
     String description;
-
+    
     ArchetypeTuple(String groupId, String artifactId, String displayName, String description) {
       archetype = new Archetype();
       archetype.setGroupId(groupId);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -248,7 +248,6 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
    */
   private boolean validateGeneratedProjectLocation() {
     String artifactId = getArtifactId();
-    // assert !artifactId.isEmpty()
     IPath path = getLocationPath().append(artifactId);
     if (path.toFile().exists()) {
       String errorMessage = MessageFormat.format(Messages.getString("LOCATION_ALREADY_EXISTS"), path);


### PR DESCRIPTION
@lesv @akerekes This is a quick and dirty fix so the plugin (and integration tests) continue to work with the latest version of the Hello world archetype. Suggestions for improvement appreciated, though we may need to get this in sooner rather than later, since otherwise I think our integration tests are about to break. We'll definitely need to do something better when we add library configuration to the maven project wizard. 

