### PR TITLE
Removed unused localized message

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
@@ -1,2 +1,1 @@
 AppEngineStandardWizardPage_librariesGroupLabel=Libraries to add to build path
-AppEngineJavaComponentMissing=Cannot create an App Engine Eclipse project because the Cloud SDK App Engine Java component is not installed. Fix by running 'gcloud components install app-engine-java' on the command-line.


### PR DESCRIPTION
The `Message` class does not have a field for that. In fact, the message has been moved to the `....appengine.ui` bundle.