### PR TITLE
Build with Oxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   - jdk: openjdk7
   - jdk: oraclejdk8
     env: ECLIPSE_TARGET=neon
+  - jdk: oraclejdk8
+    env: ECLIPSE_TARGET=oxygen
 script: mvn -Ptravis --fail-at-end verify ${ECLIPSE_TARGET:+-Declipse.target=${ECLIPSE_TARGET}}
 addons:
   apt:

--- a/eclipse/oxygen/.project
+++ b/eclipse/oxygen/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gcp-eclipse-oxygen</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/eclipse/oxygen/.settings/org.eclipse.core.resources.prefs
+++ b/eclipse/oxygen/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/eclipse/oxygen/.settings/org.eclipse.m2e.core.prefs
+++ b/eclipse/oxygen/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1477510761">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20160915-0230"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20160915-0230"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.1.20160831-1005"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.21.0.v20160707-1856"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
+      <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.9.v20160517"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.9.v20160517"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.9.v20160517"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.9.v20160517"/>
+      <repository location="http://download.eclipse.org/releases/oxygen"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201608191717"/>
+      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
+      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201609051402"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M2-20160920000111/repository"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+    </location>
+  </locations>
+</target>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -1,0 +1,47 @@
+/* 
+ * Target Platform Definition created using Mikael Barbero's TPD editor 
+ * <https://github.com/mbarbero/fr.obeo.releng.targetplatform/>
+ * 
+ * If you make changes to this file, either:
+ * 
+ *    * Right-click in the editor and choose 'Create Target Definition File'
+ *      to update the corresponding .target file.
+ *    * Right-lick in the editor and choose 'Set as Target Platform'
+ *      to update your IDE's target platform (regenerates the .target too)
+ */
+target "GCP for Eclipse Oxygen" with source requirements
+
+location "http://download.eclipse.org/cbi/updates/license" {
+    org.eclipse.license.feature.group    
+}
+
+location "http://download.eclipse.org/releases/oxygen" {
+	org.eclipse.sdk.feature.group
+	org.eclipse.jdt.feature.group
+	org.eclipse.m2e.feature.feature.group
+	org.eclipse.m2e.wtp.feature.feature.group
+	org.eclipse.mylyn.commons.feature.group
+	org.eclipse.jpt.jpa.feature.feature.group
+	org.eclipse.datatools.sdk.feature.feature.group
+	org.eclipse.swtbot.eclipse.feature.group
+	
+	org.eclipse.jetty.http
+	org.eclipse.jetty.servlet
+	org.eclipse.jetty.server
+	org.eclipse.jetty.util
+}
+
+// /webtools/repository/oxygen currently has some issues
+// location "http://download.eclipse.org/webtools/repository/oxygen/" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M2-20160920000111/repository" {
+    org.eclipse.jst.web_sdk.feature.feature.group
+    org.eclipse.jst.server_sdk.feature.feature.group
+    org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
+    org.eclipse.wst.common.fproj.sdk.feature.group
+    org.eclipse.wst.web_sdk.feature.feature.group
+    org.eclipse.wst.server_adapters.sdk.feature.feature.group
+}
+
+location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/" {
+    org.hamcrest
+}

--- a/eclipse/oxygen/pom.xml
+++ b/eclipse/oxygen/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+ <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>gcp-eclipse-oxygen</artifactId>
+  <version>4.7.0-SNAPSHOT</version>
+  <packaging>eclipse-target-definition</packaging>
+</project>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -157,14 +157,13 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
 
   private void setupDebugTarget(ILaunch launch, ILaunchConfiguration configuration, int port,
       IProgressMonitor monitor) throws CoreException {
-    // Attempt to retrieve our socketListenerMultipleConnector first: our fragment versions are
-    // setup to ensure that it will not be installed on 4.7 (Oxygen) or beyond
-    IVMConnector connector = JavaRuntime.getVMConnector(
-        "com.google.cloud.tools.eclipse.jdt.launching.socketListenerMultipleConnector");
-    if (connector == null) {
-      // The 4.7 listen connector supports a connectionLimit
-      connector = JavaRuntime
-          .getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
+    // The 4.7 listen connector supports a connectionLimit
+    IVMConnector connector =
+        JavaRuntime.getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
+    if (connector == null || !connector.getArgumentOrder().contains("connectionLimit")) {
+      // Attempt to retrieve our socketListenerMultipleConnector
+      connector = JavaRuntime.getVMConnector(
+          "com.google.cloud.tools.eclipse.jdt.launching.socketListenerMultipleConnector");
     }
     if (connector == null) {
       abort("Cannot find Socket Listening connector", null, 0);

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,40 @@
     </profile>
 
     <profile>
+      <id>build-eclipse-oxygen</id>
+      <activation>
+        <property>
+          <name>eclipse.target</name> <value>oxygen</value>
+        </property>
+      </activation>
+      <properties>
+         <jettyMinVersion>9.3</jettyMinVersion>
+         <jettyMaxVersion>9.4</jettyMaxVersion>
+      </properties>
+      <!-- build against a known target platform -->
+      <modules>
+        <module>eclipse/oxygen</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <configuration>
+            <target>
+              <artifact>
+                <groupId>com.google.cloud.tools.eclipse</groupId>
+                <artifactId>gcp-eclipse-oxygen</artifactId>
+                <version>4.7.0-SNAPSHOT</version>
+              </artifact>
+            </target>
+           </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <!--
         create a copy of the build target platform, suitable for setting
         as an Eclipse Target Platform

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/META-INF/MANIFEST.MF
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.jdt.launching;singleton:=true
 Bundle-Version: 0.1.0.qualifier
-Fragment-Host: org.eclipse.jdt.launching;bundle-version="[3.7,3.8.200]"
+Fragment-Host: org.eclipse.jdt.launching;bundle-version="3.7"
 Bundle-Vendor: %fragmentProvider
 Bundle-Localization: fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7


### PR DESCRIPTION
Revises the version ranges on our `com.google.cloud.tools.eclipse.jdt.launching` bundle to allow installing in anything from Mars on.  Change our launch configuration to first try using the Eclipse-provided _Socket Listener_ VM connector, providing it supports the _connectionLimit_ argument that was accepted for 4.7M3.  Otherwise uses our _connectionLimit_-supporting VM connector.

We could put the version ranges back into `com.google.cloud.tools.eclipse.jdt.launching`, but we'd need to ship an additional feature.  But as our VM connector won't interfere with future versions, we may as well keep it around until we move our support level to Oxygen.