### PR TITLE
Ensure internal browser editors show the location, and toolbar.

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/console/BrowserSupportBasedHyperlink.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/console/BrowserSupportBasedHyperlink.java
@@ -20,7 +20,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.eclipse.swt.program.Program;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -52,7 +51,10 @@ public class BrowserSupportBasedHyperlink implements IHyperlink {
   public void linkActivated() {
     try {
       IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
-      browserSupport.createBrowser(null).openURL(new URL(url));
+      int style = IWorkbenchBrowserSupport.LOCATION_BAR | IWorkbenchBrowserSupport.NAVIGATION_BAR
+          | IWorkbenchBrowserSupport.STATUS;
+      browserSupport.createBrowser(style, null, null, null).openURL(new URL(url));
+
     } catch (PartInitException partInitException) {
       logger.log(Level.SEVERE, "Cannot open hyperlink using browser support, will try SWT's Program.launch(String)",
                  partInitException);

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/console/BrowserSupportBasedHyperlink.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/console/BrowserSupportBasedHyperlink.java
@@ -53,7 +53,10 @@ public class BrowserSupportBasedHyperlink implements IHyperlink {
       IWorkbenchBrowserSupport browserSupport = PlatformUI.getWorkbench().getBrowserSupport();
       int style = IWorkbenchBrowserSupport.LOCATION_BAR | IWorkbenchBrowserSupport.NAVIGATION_BAR
           | IWorkbenchBrowserSupport.STATUS;
-      browserSupport.createBrowser(style, null, null, null).openURL(new URL(url));
+      String browserId = null;
+      String title = null;
+      String tooltip = null;
+      browserSupport.createBrowser(style, browserId, title, tooltip).openURL(new URL(url));
 
     } catch (PartInitException partInitException) {
       logger.log(Level.SEVERE, "Cannot open hyperlink using browser support, will try SWT's Program.launch(String)",


### PR DESCRIPTION
Cause `BrowserSupportBasedHyperlink` to configure the opened browser window with location and toolbar.  It's otherwise a bit hard to use:

![screen shot 2016-10-31 at 1 50 13 pm](https://cloud.githubusercontent.com/assets/202851/19865027/f918519a-9f70-11e6-9fd2-965671afd3e5.PNG)