### PR TITLE
Fix runtime compatibility of App Engine Java Standard faceted project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -33,6 +33,13 @@
     </action>
   </extension>
 
+  <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
+    <supported>
+      <runtime-component any="true" />
+      <facet id="com.google.cloud.tools.eclipse.appengine.facets.standard" />
+    </supported>
+  </extension>
+
   <extension point="org.eclipse.wst.common.project.facet.core.listeners">
     <listener
       class="com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardRuntimeChangeListener"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -32,13 +32,6 @@
       <delegate class="com.google.cloud.tools.eclipse.appengine.facets.StandardFacetUninstallDelegate"/>
     </action>
   </extension>
-  
-  <extension point="org.eclipse.wst.common.project.facet.core.runtimes">
-    <supported>
-      <runtime-component any="true" />
-      <facet id="com.google.cloud.tools.eclipse.appengine.facets.standard" />
-    </supported>
-  </extension>
 
   <extension point="org.eclipse.wst.common.project.facet.core.listeners">
     <listener

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -67,10 +67,6 @@
                id="com.google.cloud.tools.eclipse.appengine.standard.runtime"
                version="1"></runtime-component>
          <facet
-               id="com.google.cloud.tools.eclipse.appengine.facets.standard"
-               version="1">
-         </facet>
-         <facet
                id="jst.web"
                version="2.5">
          </facet>


### PR DESCRIPTION
This may potentially address #883 and #254 by explicitly requiring to use our _App Engine Standard_ runtime for projects that have _App Engine Java Standard_ facet installed.

Runtimes that don't support the Standard facet will show the following error message when selected:

![selection_002](https://cloud.githubusercontent.com/assets/10523105/19901229/cb8e352e-a03c-11e6-82c3-8a6b3d5be8cc.png)

## Details
I think we have had misconfiguration around our facet and runtime. We define the extension `org.eclipse.wst.common.project.facet.core.runtimes` associated with the same facet ID (our Standard facet `com.google.cloud.tools.eclipse.appengine.facets.standard`) in two places:
  1. `.appengine.facet`: [link](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/master/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml#L36)
  2. `.appengine.localserver`: [link](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/master/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml#L56)

It seems weird that they are defined twice while they tell different things. I believe the former one says that any runtime can support our App Engine facet. It looks like the former definition overrides the restriction from the latter. For example, if I just remove

```xml
         <facet
               id="com.google.cloud.tools.eclipse.appengine.facets.standard"
               version="1">
         </facet>
```

from the latter (indicating that our _App Engine Standard_ runtime no longer supports our facet), nothing changes: I can still select and create our runtime for our App Engine projects. However, if I in turn remove the former definition entirely (as in this PR), it will then show the error message that our runtime does not support our facet (as shown in the screenshot above).