### PR TITLE
Fix stack overflow in LocalAppEngineServerDelegate#getChildModules()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -35,8 +35,10 @@ public class LocalAppEngineServerDelegateTest {
 
   private LocalAppEngineServerDelegate delegate = new LocalAppEngineServerDelegate();
   private @Mock IModule module1;
+  private @Mock IWebModule webModule1;
   private @Mock IModule module2;
-  private @Mock IWebModule webModule;
+  private @Mock IWebModule webModule2;
+  private @Mock IModule module3;
 
   @Test
   public void testCanModifyModules() {
@@ -68,17 +70,27 @@ public class LocalAppEngineServerDelegateTest {
   }
 
   @Test
-  public void testGetChildModules_webModuleType(){
+  public void testGetChildModules_webModuleType() {
     ModuleType webModuleType = new ModuleType("jst.web", "1.0");
     when(module1.getModuleType()).thenReturn(webModuleType);
     when(module1.getId()).thenReturn("module1");
+    when(module1.loadAdapter(IWebModule.class, null)).thenReturn(webModule1);
+    when(webModule1.getModules()).thenReturn(new IModule[] {module2});
+    when(module2.getModuleType()).thenReturn(webModuleType);
     when(module2.getId()).thenReturn("module2");
-    when(webModule.getModules()).thenReturn(new IModule[]{module2});
-    when(module1.loadAdapter(IWebModule.class, null)).thenReturn(webModule);
+    when(module2.loadAdapter(IWebModule.class, null)).thenReturn(webModule2);
+    when(webModule2.getModules()).thenReturn(new IModule[] {module3});
+    when(module3.getModuleType()).thenReturn(webModuleType);
+    when(module3.getId()).thenReturn("module3");
 
-    IModule[] childModules = delegate.getChildModules(new IModule[]{module1});
+    IModule[] childModules;
+    childModules = delegate.getChildModules(new IModule[] {module1});
     Assert.assertEquals(1, childModules.length);
     Assert.assertEquals("module2", childModules[0].getId());
+
+    childModules = delegate.getChildModules(new IModule[] {module1, module2});
+    Assert.assertEquals(1, childModules.length);
+    Assert.assertEquals("module3", childModules[0].getId());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -32,6 +31,7 @@ import org.eclipse.wst.server.core.model.ServerDelegate;
 
 @SuppressWarnings("restriction") // For FacetUtil
 public class LocalAppEngineServerDelegate extends ServerDelegate {
+  private static final IModule[] EMPTY_MODULES = new IModule[0];
   private static final String SERVLET_MODULE_FACET = "jst.web";
   private static final String ATTR_APP_ENGINE_SERVER_MODULES = "app-engine-server-modules-list";
 
@@ -72,13 +72,18 @@ public class LocalAppEngineServerDelegate extends ServerDelegate {
   }
 
   /**
-   * If the module is a web module returns the utility modules contained within its
-   * WAR, otherwise returns an empty list.
+   * If the module is a web module returns the utility modules contained within its WAR, otherwise
+   * returns an empty list.
+   * 
+   * @param module the module path traversed to this point
    */
   @Override
   public IModule[] getChildModules(IModule[] module) {
-    if ((module != null) && (module.length > 0) && (module[0] != null) && (module[0].getModuleType() != null)) {
-      IModule thisModule = module[0];
+    if (module == null || module.length == 0) {
+      return EMPTY_MODULES;
+    }
+    IModule thisModule = module[module.length - 1];
+    if (thisModule != null && thisModule.getModuleType() != null) {
       IModuleType moduleType = thisModule.getModuleType();
       if (moduleType != null && SERVLET_MODULE_FACET.equals(moduleType.getId())) { //$NON-NLS-1$
         IWebModule webModule = (IWebModule) thisModule.loadAdapter(IWebModule.class, null);
@@ -88,7 +93,7 @@ public class LocalAppEngineServerDelegate extends ServerDelegate {
         }
       }
     }
-    return new IModule[0];
+    return EMPTY_MODULES;
   }
 
   @Override


### PR DESCRIPTION
`ServerDelegate#getChildModules(IModule[])` takes an array of modules which is actually the current path down the module hierarchy.  The root module is the first module in the array, and the actual module in question is the last object in the array.

Fixes #914 