### PR TITLE
Fixes the URL for Objectify javadoc

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/AppEngineLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/AppEngineLibrariesInPluginXmlTest.java
@@ -146,7 +146,7 @@ public class AppEngineLibrariesInPluginXmlTest {
 
     assertThat(objectifyLibrary.getLibraryFiles().size(), is(2));
     LibraryFile objectifyLibraryFile = objectifyLibrary.getLibraryFiles().get(0);
-    assertThat(objectifyLibraryFile.getJavadocUri(), is(new URI("http://www.javadoc.io/doc/com.googlecode.objectify/objectify/")));
+    assertThat(objectifyLibraryFile.getJavadocUri(), is(new URI("http://static.javadoc.io/com.googlecode.objectify/objectify/5.1.13/")));
     assertNull(objectifyLibraryFile.getSourceUri());
     assertTrue("Objectify not exported", objectifyLibraryFile.isExport());
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -39,7 +39,7 @@
           siteUri="https://github.com/objectify/objectify/wiki" >
       <libraryDependency id="appengine-api" />
       <libraryFile
-            javadocUri="http://www.javadoc.io/doc/com.googlecode.objectify/objectify/">
+            javadocUri="http://static.javadoc.io/com.googlecode.objectify/objectify/5.1.13/">
         <mavenCoordinates
               artifactId="objectify"
               groupId="com.googlecode.objectify"


### PR DESCRIPTION
It will still not work because of #932 , but once javadoc.io maintainers change the CloudFlare settings, it will.