### PR TITLE
Improve Standard Deployment dialog spacing and title

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -120,7 +120,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
 
     Dialog.applyDialogFont(this);
 
-    GridLayoutFactory.fillDefaults().spacing(0, 0).generateLayout(this);
+    GridLayoutFactory.fillDefaults().generateLayout(this);
 
     loadPreferences(project);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -9,7 +9,7 @@ deploy=Deploy
 deploy.login.dialog.message=Browser opened to authorize deployment.
 deploy.manual.link=To manually promote a version use the <a href="{0}">Google Cloud Console.</a>
 deploy.preferences.dialog.title=Deploy to App Engine Standard
-deploy.preferences.dialog.title.withProject=Deployment parameters for {0}
+deploy.preferences.dialog.title.withProject=Deployment parameters for "{0}"
 deploy.preferences.dialog.label.selectAccount=Account:
 deploy.preferences.dialog.accountSelector.login=<Add a new account...>
 build.error.dialog.title=Build Error in Project


### PR DESCRIPTION
- removes the `spacing(0,0)` in `StandardDeployPreferencePanel`
- adds quotes around project name in _Deploy to App Engine Standard_ dialog

![deploydialog](https://cloud.githubusercontent.com/assets/202851/20108761/260b0374-a5ab-11e6-9f4a-2951bedd2320.png)
