### PR TITLE
Add Webtools WST+JST dependences

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -18,6 +18,16 @@
       %license.text
    </license>
 
+   <requires>
+      <import feature="org.eclipse.jdt" version="3.11.2.v20160212-1500"/>
+      <import feature="org.eclipse.m2e.wtp.feature" version="1.2.1.20150819-2220" match="greaterOrEqual"/>
+      <import feature="org.eclipse.m2e.feature" version="1.6.2.20150902-0002" match="greaterOrEqual"/>
+      <import feature="org.eclipse.jst.common.fproj.enablement.jdt" version="3.6.3.v201501141810" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.common.fproj" version="3.7.0.v201505072140" match="greaterOrEqual"/>
+      <import feature="org.eclipse.jst.web_ui.feature" version="3.7.1.v201512021921" match="greaterOrEqual"/>
+      <import feature="org.eclipse.wst.web_ui.feature" version="3.7.1.v201602111638" match="greaterOrEqual"/>
+   </requires>
+
    <plugin
          id="com.google.cloud.tools.appengine"
          download-size="0"
@@ -25,21 +35,21 @@
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.deploy"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
- <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.deploy.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.facets"
          download-size="0"
          install-size="0"
@@ -60,7 +70,7 @@
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.login"
          download-size="0"
          install-size="0"
@@ -81,68 +91,68 @@
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.appengine.whitelist"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.preferences"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.sdk"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.sdk.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.ui.util"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.usagetracker"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
+   <plugin
          id="com.google.cloud.tools.eclipse.util"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
-  <plugin
-        id="com.google.cloud.tools.eclipse.jdt.launching"
-        download-size="0"
-        install-size="0"
-        version="0.0.0"
-        fragment="true"
-        unpack="false"/>
+   <plugin
+         id="com.google.cloud.tools.eclipse.jdt.launching"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
 
 </feature>

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -19,7 +19,7 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.jdt" version="3.11.2.v20160212-1500"/>
+      <import feature="org.eclipse.jdt" version="3.11.2.v20160212-1500" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.wtp.feature" version="1.2.1.20150819-2220" match="greaterOrEqual"/>
       <import feature="org.eclipse.m2e.feature" version="1.6.2.20150902-0002" match="greaterOrEqual"/>
       <import feature="org.eclipse.jst.common.fproj.enablement.jdt" version="3.6.3.v201501141810" match="greaterOrEqual"/>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/META-INF/MANIFEST.MF
@@ -29,5 +29,4 @@ Import-Package: com.google.cloud.tools.eclipse.appengine.libraries.model,
  org.eclipse.swt.layout,
  org.eclipse.swt.widgets,
  org.eclipse.ui.plugin
-Require-Bundle: com.google.cloud.tools.eclipse.usagetracker,
- org.eclipse.osgi
+Require-Bundle: com.google.cloud.tools.eclipse.usagetracker


### PR DESCRIPTION
With these dependencies, I can install our feature in the bare-bones Eclipse Platform (no JDT, no PDE), and create new projects and launch in the debugger with _Run on Server_/_Debug on Server_.

Fixes #981 