### PR TITLE
Add default index.html for gcp-repo repository

### DIFF
--- a/gcp-repo/src/main/resources/index.html
+++ b/gcp-repo/src/main/resources/index.html
@@ -1,16 +1,14 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
-<HTML>
-<HEAD>
-<TITLE>Cloud Tools for Eclipse p2 repository</TITLE>
-<LINK REL="made" HREF="https://github.com/GoogleCloudPlatform/google-cloud-eclipse/">
-<META HTTP-EQUIV="Refresh" CONTENT="0; url=https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">
-</HEAD>
+<!DOCTYPE html>
+<html>
+<head>
+<title>Cloud Tools for Eclipse p2 repository</title>
+<meta http-equiv="Refresh" content="0; url=https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">
+</head>
 
-<BODY>
-<P>This is a p2 repository for the Google Cloud Tools for Eclipse.
+<body>
+<p>This is a p2 repository for the Google Cloud Tools for Eclipse.
 Please see the <a
 href="https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">instructions</a>
-for configuring your Eclipse.</P>
-
-</BODY>
-</HTML>
+for configuring your Eclipse.</p>
+</body>
+</html>

--- a/gcp-repo/src/main/resources/index.html
+++ b/gcp-repo/src/main/resources/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
+<HTML>
+<HEAD>
+<TITLE>Cloud Tools for Eclipse p2 repository</TITLE>
+<LINK REL="made" HREF="https://github.com/GoogleCloudPlatform/google-cloud-eclipse/">
+<META HTTP-EQUIV="Refresh" CONTENT="0; url=https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">
+</HEAD>
+
+<BODY>
+<P>This is a p2 repository for the Google Cloud Tools for Eclipse.
+Please see the <a
+href="https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">instructions</a>
+for configuring your Eclipse.</P>
+
+</BODY>
+</HTML>


### PR DESCRIPTION
Add default `index.html` that does an immediate meta-redirect to our [installation wiki page](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/)