### PR TITLE
Remove unnecessary dependencies from integration tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
@@ -21,11 +21,11 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>false</useUIThread>
-          <product>org.eclipse.sdk.ide</product>
+          <product>org.eclipse.platform.ide</product>
           <dependencies>
             <dependency>
               <type>p2-installable-unit</type>
-              <artifactId>org.eclipse.sdk.feature.group</artifactId>
+              <artifactId>org.eclipse.platform.feature.group</artifactId>
             </dependency>
           </dependencies>
         </configuration>
@@ -39,31 +39,6 @@
               <requirement>
                 <type>eclipse-feature</type>
                 <id>com.google.cloud.tools.eclipse.suite.e45.feature</id>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <type>eclipse-feature</type>
-                <id>org.eclipse.m2e.feature</id>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <type>eclipse-feature</type>
-                <id>org.eclipse.jst.web_sdk.feature</id>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <type>eclipse-feature</type>
-                <id>org.eclipse.jst.common.fproj.enablement.jdt.sdk</id>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <type>eclipse-feature</type>
-                <id>org.eclipse.wst.common.fproj.sdk</id>
-                <versionRange>0.0.0</versionRange>
-              </requirement>
-              <requirement>
-                <type>eclipse-feature</type>
-                <id>org.eclipse.wst.server_adapters.sdk.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
             </extraRequirements>


### PR DESCRIPTION
These dependencies should now be pulled from our `.suite` feature with #986.  Our integration tests should now ensure that we include the necessary dependencies (#981).