### PR TITLE
Ensure projects added to local server have unique Service IDs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -26,15 +26,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.wst.common.componentcore.ComponentCore;
-import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
-import org.eclipse.wst.common.componentcore.resources.IVirtualFolder;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
 public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate {
-  private final static String DEFAULT_WEB_PATH = "src/main/webapp";
-
-  private final static String WEB_INF = "WEB-INF/";
   private final static String APPENGINE_WEB_XML = "appengine-web.xml";
 
   @Override
@@ -55,7 +49,7 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
 
     // The virtual component model is very flexible, but we assume that
     // the WEB-INF/appengine-web.xml isn't a virtual file remapped elsewhere
-    IFolder webInfDir = getWebInfDirectory(project);
+    IFolder webInfDir = WebProjectUtil.getWebInfDirectory(project);
     IFile appEngineWebXml = webInfDir.getFile(APPENGINE_WEB_XML);
 
     if (appEngineWebXml.exists()) {
@@ -70,20 +64,5 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
         configFileLocation, AppEngineTemplateUtility.APPENGINE_WEB_XML_TEMPLATE,
         Collections.<String, String>emptyMap());
     progress.worked(6);
-  }
-
-  private IFolder getWebInfDirectory(IProject project) {
-    // Try to obtain the directory as if it was a Dynamic Web Project
-    IVirtualComponent component = ComponentCore.createComponent(project);
-    if (component != null && component.exists()) {
-      IVirtualFolder root = component.getRootFolder();
-      // the root should exist, but the WEB-INF may not yet exist
-      if (root.exists()) {
-        return (IFolder) root.getFolder(WEB_INF).getUnderlyingFolder();
-      }
-    }
-    // Otherwise it's seemingly fair game
-    return project.getFolder(DEFAULT_WEB_PATH).getFolder(WEB_INF);
-
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
@@ -35,10 +35,10 @@ public class WebProjectUtil {
   private final static String WEB_INF = "WEB-INF/";
 
   /**
-   * Return the project's <tt>WEB-INF</tt> directory. There is no guarantee that the contents are
-   * actually published.
+   * Return the project's <code>WEB-INF</code> directory. There is no guarantee that the contents
+   * are actually published.
    * 
-   * @return the <tt>IFolder</tt> or null if not present
+   * @return the <code>IFolder</code> or null if not present
    */
   public static IFolder getWebInfDirectory(IProject project) {
     // Try to obtain the directory as if it was a Dynamic Web Project
@@ -59,7 +59,7 @@ public class WebProjectUtil {
   }
 
   /**
-   * Attempt to resolve the given file within the project's <tt>WEB-INF</tt>.
+   * Attempt to resolve the given file within the project's <code>WEB-INF</code>.
    * 
    * @return the file location or {@code null} if not found
    */

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.facets;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.wst.common.componentcore.ComponentCore;
+import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
+import org.eclipse.wst.common.componentcore.resources.IVirtualFolder;
+
+/**
+ * Utility classes for processing WTP Web Projects (jst.web and jst.utility)
+ *
+ */
+public class WebProjectUtil {
+  private final static String DEFAULT_WEB_PATH = "src/main/webapp";
+
+  private final static String WEB_INF = "WEB-INF/";
+
+  /**
+   * Return the project's <tt>WEB-INF</tt> directory. There is no guarantee that the contents are
+   * actually published.
+   * 
+   * @return the <tt>IFolder</tt> or null if not present
+   */
+  public static IFolder getWebInfDirectory(IProject project) {
+    // Try to obtain the directory as if it was a Dynamic Web Project
+    IVirtualComponent component = ComponentCore.createComponent(project);
+    if (component != null && component.exists()) {
+      IVirtualFolder root = component.getRootFolder();
+      // the root should exist, but the WEB-INF may not yet exist
+      if (root.exists()) {
+        return (IFolder) root.getFolder(WEB_INF).getUnderlyingFolder();
+      }
+    }
+    // Otherwise it's seemingly fair game
+    IFolder defaultLocation = project.getFolder(DEFAULT_WEB_PATH).getFolder(WEB_INF);
+    if (defaultLocation.exists()) {
+      return defaultLocation;
+    }
+    return null;
+  }
+
+  /**
+   * Attempt to resolve the given file within the project's <tt>WEB-INF</tt>.
+   * 
+   * @return the file location or {@code null} if not found
+   */
+  public static IResource findInWebInf(IProject project, IPath filePath) {
+    IFolder webInfFolder = getWebInfDirectory(project);
+    if (webInfFolder == null) {
+      return null;
+    }
+    IFile file = webInfFolder.getFile(filePath);
+    return file.exists() ? file : null;
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
@@ -108,8 +108,8 @@ public class LocalAppEngineServerDelegateTest {
     Function<IModule, String> alwaysDefault = new Function<IModule, String>() {
       @Override
       public String apply(IModule module) {
-        assertNotNull(module);
-        return module != null ? module.getName() : null;
+        Preconditions.checkNotNull(module);
+        return module.getName();
       }
     };
     when(module1.getName()).thenReturn("module1");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
@@ -59,28 +61,61 @@ public class LocalAppEngineServerDelegateTest {
                                                                     AppEngineStandardFacet.APPENGINE_STANDARD_VERSION));
 
   @Test
-  public void testCanModifyModules() {
+  public void testCanModifyModules() throws CoreException {
+    delegate = getDelegateWithServer();
     IModule[] remove = new IModule[0];
     IModule[] add = new IModule[0];
     Assert.assertEquals(Status.OK_STATUS, delegate.canModifyModules(add, remove));
   }
 
   @Test
-  public void testCanModifyModules_NoAppEngineStandardFacet() throws CoreException  {
-    delegate = getDelegatewithServer();
-    IModule[] remove = new IModule[0];
+  public void testCheckProjectFacets_NoAppEngineStandardFacet() throws CoreException {
+    delegate = getDelegateWithServer();
     IModule[] add = new IModule[]{ module1 };
     when(module1.getProject()).thenReturn(dynamicWebProject.getProject());
-    Assert.assertEquals(Status.ERROR, delegate.canModifyModules(add, remove).getSeverity());
+    Assert.assertEquals(Status.ERROR, delegate.checkProjectFacets(add).getSeverity());
   }
 
   @Test
-  public void testCanModifyModules_appEngineStandardFacet() throws CoreException {
-    delegate = getDelegatewithServer();
-    IModule[] remove = new IModule[0];
+  public void testCheckProjectFacets_appEngineStandardFacet() throws CoreException {
+    delegate = getDelegateWithServer();
     IModule[] add = new IModule[]{ module1 };
     when(module1.getProject()).thenReturn(appEngineStandardProject.getProject());
-    Assert.assertEquals(Status.OK_STATUS, delegate.canModifyModules(add, remove));
+    Assert.assertEquals(Status.OK_STATUS, delegate.checkProjectFacets(add));
+  }
+
+  @Test
+  public void testCheckConflictingId_defaultServiceIds() throws CoreException {
+    delegate = getDelegateWithServer();
+    Function<IModule, String> alwaysDefault = new Function<IModule, String>() {
+      @Override
+      public String apply(IModule module) {
+        return "default";
+      }
+    };
+
+    Assert.assertEquals(Status.ERROR, delegate.checkConflictingServiceIds(new IModule[] {module1},
+        new IModule[] {module2}, null, alwaysDefault).getSeverity());
+
+    // should be ok if we remove module1 and add module2
+    Assert.assertEquals(Status.OK, delegate.checkConflictingServiceIds(new IModule[] {module1},
+        new IModule[] {module2}, new IModule[] {module1}, alwaysDefault).getSeverity());
+  }
+
+  @Test
+  public void testCheckConflictingId_differentServiceIds() throws CoreException {
+    delegate = getDelegateWithServer();
+    Function<IModule, String> alwaysDefault = new Function<IModule, String>() {
+      @Override
+      public String apply(IModule module) {
+        assertNotNull(module);
+        return module != null ? module.getName() : null;
+      }
+    };
+    when(module1.getName()).thenReturn("module1");
+    when(module2.getName()).thenReturn("module2");
+    Assert.assertEquals(Status.OK, delegate.checkConflictingServiceIds(
+        new IModule[] {module1}, new IModule[] {module2}, null, alwaysDefault).getSeverity());
   }
 
   @Test
@@ -138,7 +173,7 @@ public class LocalAppEngineServerDelegateTest {
     Assert.assertEquals("module1", rootModules[0].getId());
   }
 
-  private LocalAppEngineServerDelegate getDelegatewithServer() throws CoreException {
+  private LocalAppEngineServerDelegate getDelegateWithServer() throws CoreException {
     IServerWorkingCopy serverWorkingCopy =
         ServerCore.findServerType("com.google.cloud.tools.eclipse.appengine.standard.server")
           .createServer("testServer", null, null);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.server;
+
+import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.util.AppEngineDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.wst.server.core.IModule;
+
+/**
+ * A set of utility methods for dealing with WTP {@link IModule}s.
+ */
+public class ModuleUtils {
+  private static final Logger logger = Logger.getLogger(ModuleUtils.class.getName());
+
+  /**
+   * Retrieve the &lt;service&gt; or &lt;module&gt; identifier from the <tt>appengine-web.xml</tt>.
+   * If an identifier is not found, or <tt>appengine-web.xml</tt> is not found, then returns
+   * "default".
+   * 
+   * @return the identifier, defaulting to "default" if not found
+   */
+  public static String getServiceId(IModule module) {
+    IResource descriptorFile =
+        WebProjectUtil.findInWebInf(module.getProject(), new Path("appengine-web.xml"));
+    if (!(descriptorFile instanceof IFile)) {
+      return null;
+    }
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    String serviceId = null;
+    try (InputStream contents = ((IFile) descriptorFile).getContents()) {
+      descriptor.parse(contents);
+      serviceId = descriptor.getServiceId();
+    } catch (CoreException | IOException ex) {
+      logger.log(Level.WARNING, "Unable to read " + descriptorFile.getFullPath(), ex);
+    }
+    return serviceId != null ? serviceId : "default";
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import org.eclipse.core.runtime.CoreException;
+import org.junit.Test;
+
+public class AppEngineDescriptorTest {
+
+  private static final String TEST_VERSION = "fooVersion";
+  private static final String TEST_ID = "fooId";
+
+  private static final String XML_SUFFIX = "</appengine-web-app>";
+  private static final String XML_DECLARATION = "<?xml version='1.0' encoding='utf-8'?>"
+                                              + "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>";
+  private static final String XML_DECLARATION_WITH_INVALID_NS =
+      "<?xml version='1.0' encoding='utf-8'?><appengine-web-app xmlns='http://foo.bar.com/ns/42'>";
+  private static final String PROJECT_ID = "<application>" + TEST_ID + "</application>";
+  private static final String VERSION = "<version>" + TEST_VERSION + "</version>";
+  private static final String COMMENT = "<!-- this is a test comment -->";
+  private static final String COMMENT_AFTER_VERSION = "<version>" + TEST_VERSION + COMMENT + "</version>";
+  private static final String COMMENT_BEFORE_VERSION = "<version>" + COMMENT + TEST_VERSION + "</version>";
+  private static final String SERVICE = "<service>" + TEST_ID + "</service>";
+  private static final String MODULE = "<module>" + TEST_ID + "</module>";
+  
+  private static final String XML_WITHOUT_PROJECT_ID = XML_DECLARATION + XML_SUFFIX;
+  private static final String XML_WITHOUT_VERSION = XML_DECLARATION + PROJECT_ID + XML_SUFFIX;
+  private static final String XML_WITH_VERSION_AND_PROJECT_ID = XML_DECLARATION + PROJECT_ID + VERSION + XML_SUFFIX;
+  private static final String XML_WITH_COMMENT_BEFORE_VERSION =
+      XML_DECLARATION + PROJECT_ID + COMMENT_BEFORE_VERSION + XML_SUFFIX;
+  private static final String XML_WITH_COMMENT_AFTER_VERSION =
+      XML_DECLARATION + PROJECT_ID + COMMENT_AFTER_VERSION + XML_SUFFIX;
+  private static final String XML_WITH_VERSION_AND_PROJECT_ID_WRONG_NS =
+      XML_DECLARATION_WITH_INVALID_NS + PROJECT_ID + VERSION + XML_SUFFIX;
+
+  @Test
+  public void testParse_noProjectId() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITHOUT_PROJECT_ID);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertNull(descriptor.getProjectId());
+  }
+
+  @Test
+  public void testParse_noVersion() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITHOUT_VERSION);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getProjectId(), is(TEST_ID));
+    assertNull(descriptor.getProjectVersion());
+  }
+
+  @Test
+  public void testParse_properXml() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITH_VERSION_AND_PROJECT_ID);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getProjectId(), is(TEST_ID));
+    assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
+  }
+
+  @Test
+  public void testParse_xmlWithCommentBeforeValue() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITH_COMMENT_BEFORE_VERSION);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getProjectId(), is(TEST_ID));
+    assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
+  }
+
+  @Test
+  public void testParse_xmlWithCommentAfterValue() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITH_COMMENT_AFTER_VERSION);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getProjectId(), is(TEST_ID));
+    assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
+  }
+
+  
+  @Test
+  public void testParse_xmlWithInvalidNamespace() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_WITH_VERSION_AND_PROJECT_ID_WRONG_NS);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertNull(descriptor.getProjectId());
+    assertNull(descriptor.getProjectVersion());
+  }
+
+  public void testService_noContent() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_DECLARATION + XML_SUFFIX);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertNull(descriptor.getServiceId());
+  }
+
+  public void testService_service() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_DECLARATION + SERVICE + XML_SUFFIX);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getServiceId(), is(TEST_VERSION));
+  }
+
+  public void testService_module() throws IOException, CoreException {
+    File xml = createFileWithContent(XML_DECLARATION + MODULE + XML_SUFFIX);
+
+    AppEngineDescriptor descriptor = new AppEngineDescriptor();
+    descriptor.parse(xml);
+    assertThat(descriptor.getServiceId(), is(TEST_VERSION));
+  }
+
+  private File createFileWithContent(String xmlWithoutProjectId) throws IOException {
+    File tempFile = File.createTempFile(getClass().getName(), null);
+    tempFile.deleteOnExit();
+    try (OutputStreamWriter streamWriter = new OutputStreamWriter(new FileOutputStream(tempFile))) {
+      streamWriter.write(xmlWithoutProjectId);
+    }
+    return tempFile;
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptorTest.java
@@ -20,10 +20,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import org.eclipse.core.runtime.CoreException;
 import org.junit.Test;
 
@@ -32,7 +31,7 @@ public class AppEngineDescriptorTest {
   private static final String TEST_VERSION = "fooVersion";
   private static final String TEST_ID = "fooId";
 
-  private static final String XML_SUFFIX = "</appengine-web-app>";
+  private static final String XML_END_TAG = "</appengine-web-app>";
   private static final String XML_DECLARATION = "<?xml version='1.0' encoding='utf-8'?>"
                                               + "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>";
   private static final String XML_DECLARATION_WITH_INVALID_NS =
@@ -45,107 +44,85 @@ public class AppEngineDescriptorTest {
   private static final String SERVICE = "<service>" + TEST_ID + "</service>";
   private static final String MODULE = "<module>" + TEST_ID + "</module>";
   
-  private static final String XML_WITHOUT_PROJECT_ID = XML_DECLARATION + XML_SUFFIX;
-  private static final String XML_WITHOUT_VERSION = XML_DECLARATION + PROJECT_ID + XML_SUFFIX;
-  private static final String XML_WITH_VERSION_AND_PROJECT_ID = XML_DECLARATION + PROJECT_ID + VERSION + XML_SUFFIX;
+  private static final String XML_WITHOUT_PROJECT_ID = XML_DECLARATION + XML_END_TAG;
+  private static final String XML_WITHOUT_VERSION = XML_DECLARATION + PROJECT_ID + XML_END_TAG;
+  private static final String XML_WITH_VERSION_AND_PROJECT_ID =
+      XML_DECLARATION + PROJECT_ID + VERSION + XML_END_TAG;
   private static final String XML_WITH_COMMENT_BEFORE_VERSION =
-      XML_DECLARATION + PROJECT_ID + COMMENT_BEFORE_VERSION + XML_SUFFIX;
+      XML_DECLARATION + PROJECT_ID + COMMENT_BEFORE_VERSION + XML_END_TAG;
   private static final String XML_WITH_COMMENT_AFTER_VERSION =
-      XML_DECLARATION + PROJECT_ID + COMMENT_AFTER_VERSION + XML_SUFFIX;
+      XML_DECLARATION + PROJECT_ID + COMMENT_AFTER_VERSION + XML_END_TAG;
   private static final String XML_WITH_VERSION_AND_PROJECT_ID_WRONG_NS =
-      XML_DECLARATION_WITH_INVALID_NS + PROJECT_ID + VERSION + XML_SUFFIX;
+      XML_DECLARATION_WITH_INVALID_NS + PROJECT_ID + VERSION + XML_END_TAG;
 
   @Test
   public void testParse_noProjectId() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITHOUT_PROJECT_ID);
+    AppEngineDescriptor descriptor = parse(XML_WITHOUT_PROJECT_ID);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertNull(descriptor.getProjectId());
   }
 
   @Test
   public void testParse_noVersion() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITHOUT_VERSION);
+    AppEngineDescriptor descriptor = parse(XML_WITHOUT_VERSION);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getProjectId(), is(TEST_ID));
     assertNull(descriptor.getProjectVersion());
   }
 
   @Test
   public void testParse_properXml() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITH_VERSION_AND_PROJECT_ID);
+    AppEngineDescriptor descriptor = parse(XML_WITH_VERSION_AND_PROJECT_ID);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getProjectId(), is(TEST_ID));
     assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
   }
 
   @Test
   public void testParse_xmlWithCommentBeforeValue() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITH_COMMENT_BEFORE_VERSION);
+    AppEngineDescriptor descriptor = parse(XML_WITH_COMMENT_BEFORE_VERSION);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getProjectId(), is(TEST_ID));
     assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
   }
 
   @Test
   public void testParse_xmlWithCommentAfterValue() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITH_COMMENT_AFTER_VERSION);
+    AppEngineDescriptor descriptor = parse(XML_WITH_COMMENT_AFTER_VERSION);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getProjectId(), is(TEST_ID));
     assertThat(descriptor.getProjectVersion(), is(TEST_VERSION));
   }
-
   
   @Test
   public void testParse_xmlWithInvalidNamespace() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_WITH_VERSION_AND_PROJECT_ID_WRONG_NS);
+    AppEngineDescriptor descriptor = parse(XML_WITH_VERSION_AND_PROJECT_ID_WRONG_NS);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertNull(descriptor.getProjectId());
     assertNull(descriptor.getProjectVersion());
   }
 
   public void testService_noContent() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_DECLARATION + XML_SUFFIX);
+    AppEngineDescriptor descriptor = parse(XML_DECLARATION + XML_END_TAG);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertNull(descriptor.getServiceId());
   }
 
   public void testService_service() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_DECLARATION + SERVICE + XML_SUFFIX);
+    AppEngineDescriptor descriptor = parse(XML_DECLARATION + SERVICE + XML_END_TAG);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getServiceId(), is(TEST_VERSION));
   }
 
   public void testService_module() throws IOException, CoreException {
-    File xml = createFileWithContent(XML_DECLARATION + MODULE + XML_SUFFIX);
+    AppEngineDescriptor descriptor = parse(XML_DECLARATION + MODULE + XML_END_TAG);
 
-    AppEngineDescriptor descriptor = new AppEngineDescriptor();
-    descriptor.parse(xml);
     assertThat(descriptor.getServiceId(), is(TEST_VERSION));
   }
 
-  private File createFileWithContent(String xmlWithoutProjectId) throws IOException {
-    File tempFile = File.createTempFile(getClass().getName(), null);
-    tempFile.deleteOnExit();
-    try (OutputStreamWriter streamWriter = new OutputStreamWriter(new FileOutputStream(tempFile))) {
-      streamWriter.write(xmlWithoutProjectId);
-    }
-    return tempFile;
+  private AppEngineDescriptor parse(String xmlString) throws CoreException {
+    return AppEngineDescriptor
+        .parse(new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8)));
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptor.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.eclipse.util;
 
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -41,23 +39,16 @@ public class AppEngineDescriptor {
   private static final String WEB_XML_NS_URI = "http://appengine.google.com/ns/1.0";
   private Document document;
 
-  public void parse(File appEngineXml) throws CoreException {
-    try (InputStream contents = new FileInputStream(appEngineXml)) {
-      parse(contents);
-    } catch (IOException exception) {
-      throw new CoreException(StatusUtil.error(getClass(),
-          "Cannot parse appengine-web.xml", exception));
-    }
-  }
-
-  public void parse(InputStream appEngineXmlContents) throws CoreException {
+  public static AppEngineDescriptor parse(InputStream appEngineXmlContents) throws CoreException {
     try {
+      AppEngineDescriptor instance = new AppEngineDescriptor();
       DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
       documentBuilderFactory.setNamespaceAware(true);
-      document = documentBuilderFactory.newDocumentBuilder().parse(appEngineXmlContents);
+      instance.document = documentBuilderFactory.newDocumentBuilder().parse(appEngineXmlContents);
+      return instance;
     } catch (IOException | SAXException | ParserConfigurationException exception) {
       throw new CoreException(
-          StatusUtil.error(getClass(), "Cannot parse appengine-web.xml", exception));
+          StatusUtil.error(AppEngineDescriptor.class, "Cannot parse appengine-web.xml", exception));
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/AppEngineDescriptor.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.util;
+
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.osgi.framework.FrameworkUtil;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Utilities to obtain information from appengine-web.xml
+ */
+public class AppEngineDescriptor {
+
+  private static final String WEB_XML_NS_URI = "http://appengine.google.com/ns/1.0";
+  private Document document;
+
+  public void parse(File appEngineXml) throws CoreException {
+    try (InputStream contents = new FileInputStream(appEngineXml)) {
+      parse(contents);
+    } catch (IOException exception) {
+      throw new CoreException(StatusUtil.error(getClass(),
+          "Cannot parse appengine-web.xml", exception));
+    }
+  }
+
+  public void parse(InputStream appEngineXmlContents) throws CoreException {
+    try {
+      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+      documentBuilderFactory.setNamespaceAware(true);
+      document = documentBuilderFactory.newDocumentBuilder().parse(appEngineXmlContents);
+    } catch (IOException | SAXException | ParserConfigurationException exception) {
+      throw new CoreException(
+          StatusUtil.error(getClass(), "Cannot parse appengine-web.xml", exception));
+    }
+  }
+
+  /**
+   * @return project ID parsed from the &lt;application&gt; element of the appengine-web.xml or null
+   *         if it is missing
+   * @throws CoreException if parsing the value fails
+   */
+  public String getProjectId() throws CoreException {
+    return getTopLevelValue(document, "appengine-web-app", "application"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+
+  /**
+   * @return project version parsed from the &lt;version&gt; element of the appengine-web.xml or
+   *         null if it is missing
+   * @throws CoreException if parsing the value fails
+   */
+  public String getProjectVersion() throws CoreException {
+    return getTopLevelValue(document, "appengine-web-app", "version"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+
+  /**
+   * @return service ID parsed from the &lt;application&gt; element of the appengine-web.xml, or
+   *         null if it is missing. Will also look at module ID.
+   * @throws CoreException if parsing the value fails
+   */
+  public String getServiceId() throws CoreException {
+    String serviceID = getTopLevelValue(document, "appengine-web-app", "service"); //$NON-NLS-1$ //$NON-NLS-2$
+    if (serviceID != null) {
+      return serviceID;
+    }
+    return getTopLevelValue(document, "appengine-web-app", "module"); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+
+
+  private String getTopLevelValue(Document doc, String parentTagName, String childTagName)
+      throws CoreException {
+    try {
+      NodeList parentElements = doc.getElementsByTagNameNS(WEB_XML_NS_URI, parentTagName);
+      if (parentElements.getLength() > 0) {
+        Node parent = parentElements.item(0);
+        if (parent.hasChildNodes()) {
+          for (int i = 0; i < parent.getChildNodes().getLength(); ++i) {
+            Node child = parent.getChildNodes().item(i);
+            if (child.getNodeName().equals(childTagName)) {
+              return child.getTextContent();
+            }
+          }
+        }
+      }
+      return null;
+    } catch (DOMException exception) {
+      throw new CoreException(
+          new Status(IStatus.ERROR, FrameworkUtil.getBundle(getClass()).getSymbolicName(),
+              "Missing appengine-web element: " + childTagName, exception));
+    }
+  }
+}


### PR DESCRIPTION
- split LocalAppEngineServerDelegate#canModify() into separate methods
  to simplify testing
- extract utility class for obtaining the Service ID for a WTP IModule
- extract utility class for resolving web module locations files within a
  IProject
- resurrect AppEngineDeployInfo as AppEngineDescriptor for parsing and
  extracting information from an appengine-web.xml; left <project>
  and <version> accessors as they will be useful for warnings

Fixes #926 