### PR TITLE
Configure the WTP/JST Generic Source computer

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -117,13 +117,17 @@
             typeIds="com.google.cloud.tools.eclipse.appengine.standard.server">
       </publishTask>
    </extension>
+   
+   
    <extension
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
-            delegate="com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerLaunchConfigurationDelegate"
             id="com.google.cloud.tools.eclipse.appengine.AppToolsLaunchConfigurationType"
+            name="%apptoolsServerTypeName"
+            delegate="com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerLaunchConfigurationDelegate"
             modes="run, debug"
-            name="%apptoolsServerTypeName">
+            sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector"
+            sourcePathComputerId="org.eclipse.jst.server.generic.core.sourcePathComputer">
       </launchConfigurationType>
    </extension>
    <extension

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -106,6 +106,8 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     LocalAppEngineServerBehaviour serverBehaviour = (LocalAppEngineServerBehaviour) server
         .loadAdapter(LocalAppEngineServerBehaviour.class, null);
 
+    setDefaultSourceLocator(launch, configuration);
+
     List<File> runnables = new ArrayList<File>();
     for (IModule module : modules) {
       IPath deployPath = serverBehaviour.getModuleDeployDirectory(module);


### PR DESCRIPTION
Associate the generic WTP/JST source computer with our launch types.  This source computer knows how to process the web modules to build up a classpath for resolving source files.

Steps to verify:
  1. Close all editors.
  1. Create new native CT4E project.
  2. Put a breakpoint in HelloAppEngine#doGet()
  3. _Debug As Server_
  4. Fetch the servlet, see breakpoint trigger.
  5. Source code for `#doGet` should appear.

Fixes #887