### PR TITLE
Make `jgit.dirtyWorkingTree` a configurable property and default to `warning`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,8 @@
      <!-- OS-specific JVM flags, empty for the default case but redefined below -->
      <os-jvm-flags/>
      <org.eclipse.swtbot.search.timeout>10000</org.eclipse.swtbot.search.timeout>
+
+     <jgit.dirtyWorkingTree>warning</dirtyWorkingTree>
   </properties>
 
   <!--
@@ -217,6 +219,7 @@
         </dependencies>
         <configuration>
           <timestampProvider>jgit</timestampProvider>
+          <jgit.dirtyWorkingTree>${jgit.dirtyWorkingTree}</jgit.dirtyWorkingTree>
           <jgit.ignore>
             pom.xml
           </jgit.ignore>
@@ -443,6 +446,7 @@
         <tycho.toolchains>SYSTEM</tycho.toolchains>
         <!-- Ensure we don't resolve previous versions of our artifacts -->
         <tycho.localArtifacts>ignore</tycho.localArtifacts>
+        <jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
       </properties>
       <modules>
         <module>eclipse/ide-target-platform</module>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
      <os-jvm-flags/>
      <org.eclipse.swtbot.search.timeout>10000</org.eclipse.swtbot.search.timeout>
 
-     <jgit.dirtyWorkingTree>warning</dirtyWorkingTree>
+     <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
   </properties>
 
   <!--


### PR DESCRIPTION
Otherwise the Maven build aborts if there are uncommitted files.