### PR TITLE
reorganize tests along fixture lines

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizardStaticTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizardStaticTest.java
@@ -16,35 +16,24 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import org.eclipse.core.runtime.IStatus;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-public class StandardProjectWizardTest {
+public class StandardProjectWizardStaticTest {
 
-  private StandardProjectWizard wizard;
-
-  @Before
-  public void setUp() {
-    try {
-      wizard = new StandardProjectWizard();
-      // I don't know why this fails the first time and passes the second, but it does.
-    } catch (NullPointerException ex) {
-      wizard = new StandardProjectWizard();
-    }
+  @Test
+  public void testErrorMessage_Exception() {
+    RuntimeException ex = new RuntimeException("testing");
+    IStatus status = StandardProjectWizard.setErrorStatus(this, ex);
+    Assert.assertEquals("Failed to create project: testing", status.getMessage());
   }
 
   @Test
-  public void testTitleSet() {
-    Assert.assertEquals("New App Engine Standard Project", wizard.getWindowTitle());
+  public void testErrorMessage_ExceptionWithoutMessage() {
+    RuntimeException ex = new RuntimeException();
+    IStatus status = StandardProjectWizard.setErrorStatus(this, ex);
+    Assert.assertEquals("Failed to create project", status.getMessage());
   }
-  
-  @Test
-  public void testAddPages() {
-    wizard.addPages();
-    Assert.assertFalse(wizard.canFinish());
-    Assert.assertEquals(1, wizard.getPageCount());
-    Assert.assertNotNull(wizard.getPage("basicNewProjectPage"));
-  }
-  
+
 }


### PR DESCRIPTION
@chanseokoh This should reduce the flakiness in StandardProjectWizard test