### PR TITLE
Include intro/ directory in binary build

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.welcome/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.welcome/build.properties
@@ -1,6 +1,7 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               intro/
 javacSource=1.7
 javacTarget=1.7


### PR DESCRIPTION
I think we need to include `intro/` (icon, CSS, and Welcome link contents) in the binary build, right?