### PR TITLE
Implements _Launch on App Engine_

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandlerTest.java
@@ -20,25 +20,19 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-
+import com.google.cloud.tools.eclipse.test.util.ui.ExecutionEventBuilder;
+import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.ISources;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import com.google.cloud.tools.eclipse.appengine.deploy.ui.standard.StandardDeployCommandHandler;
-import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StandardDeployCommandHandlerTest {
@@ -50,7 +44,8 @@ public class StandardDeployCommandHandlerTest {
     StandardDeployCommandHandler handler = new StandardDeployCommandHandler(facetedProjectHelper);
 
     when(facetedProjectHelper.getFacetedProject(isA(IProject.class))).thenThrow(getFakeCoreException());
-    ExecutionEvent event = getTestExecutionEvent(mock(IProject.class));
+    ExecutionEvent event = new ExecutionEventBuilder().withCurrentSelection(mock(IProject.class))
+        .withActiveShell(mock(Shell.class)).build();
 
     handler.execute(event);
   }
@@ -63,13 +58,4 @@ public class StandardDeployCommandHandlerTest {
     return new Status(IStatus.ERROR, "fakePluginId", "test exception");
   }
 
-  private ExecutionEvent getTestExecutionEvent(Object project) {
-    IEvaluationContext context = mock(IEvaluationContext.class);
-    IStructuredSelection selection = mock(IStructuredSelection.class);
-    when(selection.size()).thenReturn(1);
-    when(selection.getFirstElement()).thenReturn(project);
-    when(context.getVariable(ISources.ACTIVE_CURRENT_SELECTION_NAME)).thenReturn(selection);
-    when(context.getVariable(ISources.ACTIVE_SHELL_NAME)).thenReturn(mock(Shell.class));
-    return new ExecutionEvent(null /*command */, Collections.EMPTY_MAP, null /* trigger */, context);
-  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Require-Bundle: org.hamcrest;bundle-version="1.1.0",
  org.eclipse.jst.j2ee.web
 Import-Package: com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,
+ com.google.cloud.tools.eclipse.util.io,
  org.mockito;provider=google;version="1.10.19",
  org.mockito.runners;provider=google;version="1.10.19",
  org.mockito.stubbing;provider=google;version="1.10.19",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/EclipseContextHolder.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/EclipseContextHolder.java
@@ -18,11 +18,10 @@ package com.google.cloud.tools.eclipse.appengine.localserver;
 
 import org.eclipse.e4.core.contexts.EclipseContextFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.junit.Rule;
 import org.junit.rules.ExternalResource;
 
 /**
- * Helper class to be used with {@link Rule} to make tests easier that depend on
+ * Helper class to be used with {@link org.junit.Rule} to make tests easier that depend on
  * {@link IEclipseContext}. It provides an empty context that can be filled with object needed for
  * the test using the {@link #set(Class, Object)} method.
  * <p>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -31,6 +31,7 @@ import org.eclipse.jst.server.core.IWebModule;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IModuleType;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IRuntimeWorkingCopy;
 import org.eclipse.wst.server.core.IServer;
@@ -154,7 +155,7 @@ public class LocalAppEngineServerDelegateTest {
 
   @Test
   public void testGetChildModules_nonWebModuleType(){
-    ModuleType nonWebModuleType = new ModuleType("non-web", "1.0");
+    IModuleType nonWebModuleType = ModuleType.getModuleType("non-web", "1.0");
     when(module1.getModuleType()).thenReturn(nonWebModuleType);
 
     IModule[] childModules = delegate.getChildModules(new IModule[]{module1});
@@ -163,7 +164,7 @@ public class LocalAppEngineServerDelegateTest {
 
   @Test
   public void testGetChildModules_webModuleType() {
-    ModuleType webModuleType = new ModuleType("jst.web", "1.0");
+    IModuleType webModuleType = ModuleType.getModuleType("jst.web", "1.0");
     when(module1.getModuleType()).thenReturn(webModuleType);
     when(module1.getId()).thenReturn("module1");
     when(module1.loadAdapter(IWebModule.class, null)).thenReturn(webModule1);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.ui;
+
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.test.util.ui.ExecutionEventBuilder;
+import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.internal.ModuleType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests for the {@link LaunchAppEngineStandardHandler}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LaunchAppEngineStandardHandlerTest {
+  private static final IProjectFacetVersion APPENGINE_STANDARD_FACET_VERSION_1 =
+      ProjectFacetsManager.getProjectFacet(AppEngineStandardFacet.ID).getVersion("1");
+
+  @Rule
+  public ServerTracker tracker = new ServerTracker();
+
+  private LaunchAppEngineStandardHandler handler;
+
+  @Rule
+  public TestProjectCreator appEngineStandardProject1 =
+      new TestProjectCreator().withFacetVersions(Lists.newArrayList(JavaFacet.VERSION_1_7,
+          WebFacetUtils.WEB_25, APPENGINE_STANDARD_FACET_VERSION_1));
+  @Rule
+  public TestProjectCreator appEngineStandardProject2 =
+      new TestProjectCreator().withFacetVersions(Lists.newArrayList(JavaFacet.VERSION_1_7,
+          WebFacetUtils.WEB_25, APPENGINE_STANDARD_FACET_VERSION_1));
+
+  private IModule module1;
+  private IModule module2;
+
+  @Before
+  public void setUp() throws CoreException {
+    handler = new LaunchAppEngineStandardHandler();
+    handler.mockLaunch = true;
+
+    // Must provide a real project as validators fail.
+    module1 = mockAppEngineStandardModule("default", appEngineStandardProject1.getProject());
+    module2 = mockAppEngineStandardModule("other", appEngineStandardProject2.getProject());
+  }
+
+  private static IModule mockAppEngineStandardModule(String serviceId, IProject project)
+      throws CoreException {
+    ModuleType webModuleType = new ModuleType("jst.web", "2.5");
+    IModule module = mock(IModule.class);
+
+    when(module.getName()).thenReturn(serviceId);
+    when(module.getModuleType()).thenReturn(webModuleType);
+    when(module.getProject()).thenReturn(project);
+
+    IFolder webinf = WebProjectUtil.getWebInfDirectory(project);
+    IFile descriptorFile = webinf.getFile("appengine-web.xml");
+    assertTrue(descriptorFile.exists());
+    descriptorFile.setContents(appEngineForService(serviceId), IFile.FORCE, null);
+
+    return module;
+  }
+
+  private static InputStream appEngineForService(String serviceId) {
+    StringBuilder contents = new StringBuilder();
+    contents.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+    contents.append("<appengine-web-app xmlns=\"http://appengine.google.com/ns/1.0\">\n");
+    contents.append("<service>").append(serviceId).append("</service>\n");
+    contents.append("</appengine-web-app>\n");
+    return new ByteArrayInputStream(contents.toString().getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testWithOneModule() throws ExecutionException {
+    ExecutionEvent event = new ExecutionEventBuilder().withCurrentSelection(module1).build();
+    handler.execute(event);
+    assertEquals("new server should have been created", 1, tracker.getServers().size());
+
+    handler.execute(event);
+    assertEquals("no new server should be created", 1, tracker.getServers().size());
+  }
+
+  @Test
+  public void testWithTwoModules() throws ExecutionException {
+    ExecutionEvent event =
+        new ExecutionEventBuilder().withCurrentSelection(module1, module2).build();
+    handler.execute(event);
+    assertEquals("new server should have been created", 1, tracker.getServers().size());
+
+    handler.execute(event);
+    assertEquals("no new server should be created", 1, tracker.getServers().size());
+
+    event = new ExecutionEventBuilder().withCurrentSelection(module2, module1).build();
+    handler.execute(event);
+    assertEquals("no new server should be created", 1, tracker.getServers().size());
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -93,8 +93,9 @@ public class LaunchAppEngineStandardHandlerTest {
     handler.execute(event);
     assertEquals("no new server should be created", 1, tracker.getServers().size());
 
-    event = new ExecutionEventBuilder().withCurrentSelection(module2, module1).build();
-    handler.execute(event);
+    ExecutionEvent swappedEvent =
+        new ExecutionEventBuilder().withCurrentSelection(module2, module1).build();
+    handler.execute(swappedEvent);
     assertEquals("no new server should be created", 1, tracker.getServers().size());
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -16,6 +16,11 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -76,12 +76,9 @@ public class LaunchAppEngineStandardHandlerTest {
   public void setUp() throws CoreException {
     handler = new LaunchAppEngineStandardHandler();
     handler.mockLaunch = true;
-
-    // Must provide a real project as validators fail.
-    module1 = mockAppEngineStandardModule("default", appEngineStandardProject1.getProject());
-    module2 = mockAppEngineStandardModule("other", appEngineStandardProject2.getProject());
   }
 
+  /** Must provide a real project as validators fail. */
   private static IModule mockAppEngineStandardModule(String serviceId, IProject project)
       throws CoreException {
     ModuleType webModuleType = new ModuleType("jst.web", "2.5");
@@ -109,7 +106,9 @@ public class LaunchAppEngineStandardHandlerTest {
   }
 
   @Test
-  public void testWithOneModule() throws ExecutionException {
+  public void testWithOneModule() throws ExecutionException, CoreException {
+    module1 = mockAppEngineStandardModule("default", appEngineStandardProject1.getProject());
+
     ExecutionEvent event = new ExecutionEventBuilder().withCurrentSelection(module1).build();
     handler.execute(event);
     assertEquals("new server should have been created", 1, tracker.getServers().size());
@@ -119,7 +118,10 @@ public class LaunchAppEngineStandardHandlerTest {
   }
 
   @Test
-  public void testWithTwoModules() throws ExecutionException {
+  public void testWithTwoModules() throws ExecutionException, CoreException {
+    module1 = mockAppEngineStandardModule("default", appEngineStandardProject1.getProject());
+    module2 = mockAppEngineStandardModule("other", appEngineStandardProject2.getProject());
+
     ExecutionEvent event =
         new ExecutionEventBuilder().withCurrentSelection(module1, module2).build();
     handler.execute(event);
@@ -131,5 +133,15 @@ public class LaunchAppEngineStandardHandlerTest {
     event = new ExecutionEventBuilder().withCurrentSelection(module2, module1).build();
     handler.execute(event);
     assertEquals("no new server should be created", 1, tracker.getServers().size());
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void failsWithClashingServiceIds() throws ExecutionException, CoreException {
+    module1 = mockAppEngineStandardModule("other", appEngineStandardProject1.getProject());
+    module2 = mockAppEngineStandardModule("other", appEngineStandardProject2.getProject());
+
+    ExecutionEvent event =
+        new ExecutionEventBuilder().withCurrentSelection(module1, module2).build();
+    handler.execute(event);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -82,7 +82,6 @@ public class LaunchAppEngineStandardHandlerTest {
         }
         return super.findExistingServer(modules, progress);
       }
-
     };
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandlerTest.java
@@ -67,7 +67,7 @@ public class LaunchAppEngineStandardHandlerTest {
 
 
   @Before
-  public void setUp() throws CoreException {
+  public void setUp() {
     handler = new LaunchAppEngineStandardHandler() {
       @Override
       protected void launch(IServer server, String launchMode, SubMonitor progress)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerTracker.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerTracker.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
@@ -26,7 +27,7 @@ import org.junit.rules.ExternalResource;
 
 /** Track creation of WTP {@link IServer} instances and ensure they are deleted. */
 public class ServerTracker extends ExternalResource {
-  private List<IServer> servers = new ArrayList<>();
+  private List<IServer> servers = Collections.synchronizedList(new ArrayList<IServer>());
 
   private IServerLifecycleListener lifecycleListener = new IServerLifecycleListener() {
     @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerTracker.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerTracker.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.IServerLifecycleListener;
+import org.eclipse.wst.server.core.ServerCore;
+import org.junit.rules.ExternalResource;
+
+/** Track creation of WTP {@link IServer} instances and ensure they are deleted. */
+public class ServerTracker extends ExternalResource {
+  private List<IServer> servers = new ArrayList<>();
+
+  private IServerLifecycleListener lifecycleListener = new IServerLifecycleListener() {
+    @Override
+    public void serverAdded(IServer server) {
+      servers.add(server);
+    }
+
+    @Override
+    public void serverChanged(IServer server) {}
+
+    @Override
+    public void serverRemoved(IServer server) {
+      servers.remove(server);
+    }
+  };
+
+  @Override
+  protected void before() {
+    ServerCore.addServerLifecycleListener(lifecycleListener);
+  }
+
+  public List<IServer> getServers() {
+    return servers;
+  }
+
+  @Override
+  protected void after() {
+    ServerCore.removeServerLifecycleListener(lifecycleListener);
+    for (IServer server : servers) {
+      try {
+        server.delete();
+      } catch (CoreException ex) {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -222,4 +222,46 @@
             typeIds="com.google.cloud.tools.eclipse.appengine.standard.server">
       </fragment>
    </extension>
+   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            description="Launch on App Engine development server"
+            id="com.google.cloud.tools.eclipse.appengine.localserver.launch"
+            name="Launch on App Engine">
+         <commandParameter
+               id="launchMode"
+               name="Launch mode"
+               optional="true"
+               values="com.google.cloud.tools.eclipse.appengine.localserver.ui.LaunchModes">
+         </commandParameter>
+      </command>
+   </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="com.google.cloud.tools.eclipse.appengine.localserver.ui.LaunchAppEngineStandardHandler"
+            commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch">
+         <enabledWhen>
+            <or>
+               <iterate
+                     ifEmpty="false">
+                  <or>
+                     <adapt
+                           type="org.eclipse.wst.server.core.IModule">
+                     </adapt>
+                     <test
+                           property="org.eclipse.wst.server.ui.isRunnable">
+                     </test>
+                  </or>
+               </iterate>
+               <with
+                     variable="activeEditor">
+                  <adapt
+                        type="org.eclipse.ui.IEditorPart">
+                  </adapt>
+               </with>
+            </or>
+         </enabledWhen>
+      </handler>
+   </extension>
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
@@ -41,6 +41,11 @@ import org.eclipse.wst.server.core.model.ServerDelegate;
 
 @SuppressWarnings("restriction") // For FacetUtil
 public class LocalAppEngineServerDelegate extends ServerDelegate {
+  public static final String RUNTIME_TYPE_ID =
+      "com.google.cloud.tools.eclipse.appengine.standard.runtime";
+  public static final String SERVER_TYPE_ID =
+      "com.google.cloud.tools.eclipse.appengine.standard.server";
+
   private static final IModule[] EMPTY_MODULES = new IModule[0];
   private static final String SERVLET_MODULE_FACET = "jst.web"; //$NON-NLS-1$
   private static final String ATTR_APP_ENGINE_SERVER_MODULES = "app-engine-server-modules-list"; //$NON-NLS-1$

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -71,6 +71,9 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
   private final static Logger logger =
       Logger.getLogger(LocalAppEngineServerLaunchConfigurationDelegate.class.getName());
 
+  public static final String[] SUPPORTED_LAUNCH_MODES =
+      {ILaunchManager.RUN_MODE, ILaunchManager.DEBUG_MODE};
+
   private static final String DEBUGGER_HOST = "localhost"; //$NON-NLS-1$
 
   private static void validateCloudSdk() throws CoreException  {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
+import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
@@ -25,9 +26,7 @@ import org.eclipse.wst.server.ui.ServerLaunchConfigurationTab;
 
 public class AppEngineTabGroup extends AbstractLaunchConfigurationTabGroup {
 
-  private static final String[] SERVER_TYPE_IDS = new String[]{
-      "com.google.cloud.tools.eclipse.appengine.standard.server"
-  };
+  private static final String[] SERVER_TYPE_IDS = {LocalAppEngineServerDelegate.SERVER_TYPE_ID};
 
   @Override
   public void createTabs(ILaunchConfigurationDialog dialog, String mode) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
@@ -3,6 +3,7 @@ package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
 import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate;
 import com.google.cloud.tools.eclipse.util.AdapterUtil;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
@@ -11,7 +12,6 @@ import java.util.Set;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -29,7 +29,9 @@ import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.eclipse.wst.server.core.ServerCore;
 import org.eclipse.wst.server.core.ServerUtil;
 
-public class LaunchAppEngineStandardHandler extends AbstractHandler implements IHandler {
+public class LaunchAppEngineStandardHandler extends AbstractHandler {
+  @VisibleForTesting
+  boolean mockLaunch = false;
 
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {
@@ -44,7 +46,7 @@ public class LaunchAppEngineStandardHandler extends AbstractHandler implements I
       if (server == null) {
         server = createServer(modules, progress.newChild(3));
       }
-      if (server.getServerState() != IServer.STATE_STARTED
+      if (!mockLaunch && server.getServerState() != IServer.STATE_STARTED
           && server.getServerState() != IServer.STATE_STARTING) {
         server.start(launchMode, progress.newChild(4));
       }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
@@ -1,11 +1,29 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
 import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate;
 import com.google.cloud.tools.eclipse.util.AdapterUtil;
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -14,8 +32,9 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -29,10 +48,8 @@ import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.eclipse.wst.server.core.ServerCore;
 import org.eclipse.wst.server.core.ServerUtil;
 
+/** Find or create a server with the selected projects and launch it. */
 public class LaunchAppEngineStandardHandler extends AbstractHandler {
-  @VisibleForTesting
-  boolean mockLaunch = false;
-
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {
     String launchMode = event.getParameter("launchMode");
@@ -43,20 +60,33 @@ public class LaunchAppEngineStandardHandler extends AbstractHandler {
     SubMonitor progress = SubMonitor.convert(null, 10);
     try {
       IServer server = findExistingServer(modules, progress.newChild(3));
-      if (server == null) {
+      if (server != null && isRunning(server)) {
+        ILaunch launch = server.getLaunch();
+        Preconditions.checkNotNull(launch, "Running server should have a launch");
+        String detail = launchMode.equals(launch.getLaunchMode())
+            ? "Server is already running"
+            : MessageFormat.format("Server is already running in \"{0}\" mode",
+                launch.getLaunchMode());
+        IStatus status = StatusUtil.info(this,
+            MessageFormat.format("\"{0}\" already running", server.getName()));
+        throw new ExecutionException(detail, new CoreException(status));
+      } else if (server == null) {
         server = createServer(modules, progress.newChild(3));
       }
-      if (!mockLaunch && server.getServerState() != IServer.STATE_STARTED
-          && server.getServerState() != IServer.STATE_STARTING) {
-        server.start(launchMode, progress.newChild(4));
-      }
+      launch(server, launchMode, progress.newChild(4));
     } catch (CoreException ex) {
       throw new ExecutionException("Unable to configure server", ex);
     }
     return null;
   }
 
-  private IServer findExistingServer(IModule[] modules, SubMonitor subMonitor) {
+  private boolean isRunning(IServer server) {
+    return server.getServerState() == IServer.STATE_STARTED
+        || server.getServerState() == IServer.STATE_STARTING;
+  }
+
+  @VisibleForTesting
+  protected IServer findExistingServer(IModule[] modules, SubMonitor progress) {
     if (modules.length == 1) {
       IServer defaultServer = ServerCore.getDefaultServer(modules[0]);
       if (defaultServer != null && LocalAppEngineServerDelegate.SERVER_TYPE_ID
@@ -80,14 +110,18 @@ public class LaunchAppEngineStandardHandler extends AbstractHandler {
     return null;
   }
 
-  private IServer createServer(IModule[] modules, IProgressMonitor monitor) throws CoreException {
-    SubMonitor progress = SubMonitor.convert(monitor, 10);
+  private IServer createServer(IModule[] modules, SubMonitor progress) throws CoreException {
     IServerType serverType = ServerCore.findServerType(LocalAppEngineServerDelegate.SERVER_TYPE_ID);
     IServerWorkingCopy serverWorkingCopy =
         serverType.createServer(null, null, progress.newChild(4));
-    // serverWorkingCopy.setAttribute("name", "Generated server instance");
     serverWorkingCopy.modifyModules(modules, null, progress.newChild(4));
     return serverWorkingCopy.save(false, progress.newChild(2));
+  }
+
+  @VisibleForTesting
+  protected void launch(IServer server, String launchMode, SubMonitor progress)
+      throws CoreException {
+    server.start(launchMode, progress);
   }
 
   /** Identify the relevant modules from the execution context. */

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
@@ -80,7 +80,7 @@ public class LaunchAppEngineStandardHandler extends AbstractHandler {
     return null;
   }
 
-  private boolean isRunning(IServer server) {
+  private static boolean isRunning(IServer server) {
     return server.getServerState() == IServer.STATE_STARTED
         || server.getServerState() == IServer.STATE_STARTING;
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchAppEngineStandardHandler.java
@@ -1,0 +1,130 @@
+
+package com.google.cloud.tools.eclipse.appengine.localserver.ui;
+
+import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate;
+import com.google.cloud.tools.eclipse.util.AdapterUtil;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.eclipse.wst.server.core.IServerType;
+import org.eclipse.wst.server.core.IServerWorkingCopy;
+import org.eclipse.wst.server.core.ServerCore;
+import org.eclipse.wst.server.core.ServerUtil;
+
+public class LaunchAppEngineStandardHandler extends AbstractHandler implements IHandler {
+
+  @Override
+  public Object execute(ExecutionEvent event) throws ExecutionException {
+    String launchMode = event.getParameter("launchMode");
+    if (launchMode == null) {
+      launchMode = ILaunchManager.DEBUG_MODE;
+    }
+    IModule[] modules = asModules(event);
+    SubMonitor progress = SubMonitor.convert(null, 10);
+    try {
+      IServer server = findExistingServer(modules, progress.newChild(3));
+      if (server == null) {
+        server = createServer(modules, progress.newChild(3));
+      }
+      if (server.getServerState() != IServer.STATE_STARTED
+          && server.getServerState() != IServer.STATE_STARTING) {
+        server.start(launchMode, progress.newChild(4));
+      }
+    } catch (CoreException ex) {
+      throw new ExecutionException("Unable to configure server", ex);
+    }
+    return null;
+  }
+
+  private IServer findExistingServer(IModule[] modules, SubMonitor subMonitor) {
+    if (modules.length == 1) {
+      IServer defaultServer = ServerCore.getDefaultServer(modules[0]);
+      if (defaultServer != null && LocalAppEngineServerDelegate.SERVER_TYPE_ID
+          .equals(defaultServer.getServerType().getId())) {
+        return defaultServer;
+      }
+    }
+    Set<IModule> myModules = ImmutableSet.copyOf(modules);
+    // Look for servers that contain these modules
+    // Could prioritize servers that have *exactly* these modules,
+    // or that have the smallest overlap
+    for (IServer server : ServerCore.getServers()) {
+      if (!LocalAppEngineServerDelegate.SERVER_TYPE_ID.equals(server.getServerType().getId())) {
+        continue;
+      }
+      Set<IModule> serverModules = ImmutableSet.copyOf(server.getModules());
+      if (Sets.intersection(myModules, serverModules).size() == myModules.size()) {
+        return server;
+      }
+    }
+    return null;
+  }
+
+  private IServer createServer(IModule[] modules, IProgressMonitor monitor) throws CoreException {
+    SubMonitor progress = SubMonitor.convert(monitor, 10);
+    IServerType serverType = ServerCore.findServerType(LocalAppEngineServerDelegate.SERVER_TYPE_ID);
+    IServerWorkingCopy serverWorkingCopy =
+        serverType.createServer(null, null, progress.newChild(4));
+    // serverWorkingCopy.setAttribute("name", "Generated server instance");
+    serverWorkingCopy.modifyModules(modules, null, progress.newChild(4));
+    return serverWorkingCopy.save(false, progress.newChild(2));
+  }
+
+  /** Identify the relevant modules from the execution context. */
+  private static IModule[] asModules(ExecutionEvent event) throws ExecutionException {
+    // First check the current selected objects
+    ISelection selection = HandlerUtil.getCurrentSelection(event);
+    if (selection instanceof IStructuredSelection && !selection.isEmpty()) {
+      Object[] selectedObjects = ((IStructuredSelection) selection).toArray();
+      List<IModule> modules = new ArrayList<>(selectedObjects.length);
+      for (Object object : selectedObjects) {
+        modules.add(asModule(object));
+      }
+      return modules.toArray(new IModule[modules.size()]);
+    }
+    // Check the project of the active editor.
+    IEditorPart editor = HandlerUtil.getActiveEditor(event);
+    if (editor != null && editor.getEditorInput() instanceof IFileEditorInput) {
+      IFileEditorInput input = (IFileEditorInput) editor.getEditorInput();
+      IProject project = input.getFile().getProject();
+      if (project != null) {
+        return new IModule[] {asModule(project)};
+      }
+    }
+    throw new ExecutionException("Cannot determine server execution context");
+  }
+
+  private static IModule asModule(Object object) throws ExecutionException {
+    IModule module = AdapterUtil.adapt(object, IModule.class);
+    if (module != null) {
+      return module;
+    }
+    IProject project = AdapterUtil.adapt(object, IProject.class);
+    if (project != null) {
+      module = ServerUtil.getModule(project);
+      if (module != null) {
+        return module;
+      }
+    }
+    throw new ExecutionException("no module found for " + object);
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchModes.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LaunchModes.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.ui;
+
+import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerLaunchConfigurationDelegate;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.core.commands.IParameterValues;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.ILaunchMode;
+
+/**
+ * A helper class for the Eclipse UI that provides completions for the parameters for
+ * LocalAppEngineServer*-supported launch modes.
+ */
+public class LaunchModes implements IParameterValues {
+  @Override
+  public Map getParameterValues() {
+    ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+    Map<String, String> modes = new HashMap<>();
+    for (String modeId : LocalAppEngineServerLaunchConfigurationDelegate.SUPPORTED_LAUNCH_MODES) {
+      ILaunchMode mode = manager.getLaunchMode(modeId);
+      if (mode != null) {
+        // label is intended to be shown in menus and buttons and often has
+        // embedded '&' for mnemonics, which isn't useful here
+        String label = mode.getLabel();
+        label = label.replace("&", "");
+        modes.put(label, mode.getIdentifier());
+      }
+    }
+    return modes;
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerPortExtension.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/ServerPortExtension.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
 import com.google.cloud.tools.eclipse.appengine.localserver.Messages;
 import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour;
+import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate;
 import com.google.common.annotations.VisibleForTesting;
 import java.beans.PropertyChangeEvent;
 import org.eclipse.jface.fieldassist.ControlDecoration;
@@ -37,9 +38,6 @@ import org.eclipse.wst.server.ui.wizard.ServerCreationWizardPageExtension;
  * An extension that adds a server port field to the WTP server creation wizard page.
  */
 public class ServerPortExtension extends ServerCreationWizardPageExtension {
-
-  private static final String APP_ENGINE_SERVER_TYPE_ID =
-      "com.google.cloud.tools.eclipse.appengine.standard.server"; //$NON-NLS-1$
 
   @VisibleForTesting Label portLabel;
   @VisibleForTesting Text portText;
@@ -73,7 +71,7 @@ public class ServerPortExtension extends ServerCreationWizardPageExtension {
   public void handlePropertyChanged(PropertyChangeEvent event) {
     if (event != null && event.getNewValue() instanceof IServerType) {
       IServerType serverType = (IServerType) event.getNewValue();
-      boolean showPort = APP_ENGINE_SERVER_TYPE_ID.equals(serverType.getId());
+      boolean showPort = LocalAppEngineServerDelegate.SERVER_TYPE_ID.equals(serverType.getId());
       portLabel.setVisible(showPort);
       portText.setVisible(showPort);
       if (showPort) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
@@ -7,9 +7,12 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit;bundle-version="4.12.0"
+Require-Bundle: org.junit;bundle-version="4.12.0",
+ org.eclipse.ui.ide
 Import-Package: com.google.common.base;version="20.0.0",
  javax.servlet,
+ org.eclipse.core.commands,
+ org.eclipse.core.expressions,
  org.eclipse.core.resources,
  org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.core.runtime.jobs,
@@ -19,11 +22,13 @@ Import-Package: com.google.common.base;version="20.0.0",
  org.eclipse.jetty.server;version="9.2.13",
  org.eclipse.jetty.server.handler;version="9.2.13",
  org.eclipse.jetty.util.component;version="9.2.13",
+ org.eclipse.jface.viewers,
  org.eclipse.swt.widgets,
  org.eclipse.wst.common.project.facet.core,
  org.eclipse.wst.common.project.facet.core.internal,
  org.eclipse.wst.common.project.facet.core.util.internal,
  org.mockito;provider=google;version="1.10.19",
+ org.mockito.stubbing;provider=google;version="1.10.19",
  org.osgi.framework;version="1.8.0"
 Export-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.http,

--- a/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.ui.ide
-Import-Package: com.google.common.base;version="20.0.0",
+Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
+ com.google.common.base;version="20.0.0",
  javax.servlet,
  org.eclipse.core.commands,
  org.eclipse.core.expressions,
@@ -27,6 +28,7 @@ Import-Package: com.google.common.base;version="20.0.0",
  org.eclipse.wst.common.project.facet.core,
  org.eclipse.wst.common.project.facet.core.internal,
  org.eclipse.wst.common.project.facet.core.util.internal,
+ org.eclipse.wst.server.core,
  org.mockito;provider=google;version="1.10.19",
  org.mockito.stubbing;provider=google;version="1.10.19",
  org.osgi.framework;version="1.8.0"

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -16,11 +16,18 @@
 
 package com.google.cloud.tools.eclipse.test.util.project;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.common.base.Strings;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -34,12 +41,15 @@ import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.eclipse.wst.common.project.facet.core.internal.FacetedProjectNature;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.ServerUtil;
 import org.junit.rules.ExternalResource;
 
 public final class TestProjectCreator extends ExternalResource {
 
   private IJavaProject javaProject;
   private String containerPath;
+  private String appEngineServiceId;
   private List<IProjectFacetVersion> projectFacetVersions = new ArrayList<>();
 
   public TestProjectCreator withClasspathContainerPath(String containerPath) {
@@ -49,6 +59,11 @@ public final class TestProjectCreator extends ExternalResource {
 
   public TestProjectCreator withFacetVersions(List<IProjectFacetVersion> projectFacetVersions) {
     this.projectFacetVersions.addAll(projectFacetVersions);
+    return this;
+  }
+
+  public TestProjectCreator withAppEngineServiceId(String serviceId) {
+    this.appEngineServiceId = serviceId;
     return this;
   }
 
@@ -76,6 +91,10 @@ public final class TestProjectCreator extends ExternalResource {
     return javaProject.getProject();
   }
 
+  public IModule getModule() {
+    return ServerUtil.getModule(javaProject.getProject());
+  }
+
   private void createJavaProject(String projectName) throws CoreException, JavaModelException {
     IProjectDescription newProjectDescription = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
     newProjectDescription.setNatureIds(new String[]{JavaCore.NATURE_ID, FacetedProjectNature.NATURE_ID});
@@ -86,6 +105,9 @@ public final class TestProjectCreator extends ExternalResource {
 
     addContainerPathToRawClasspath();
     addFacets();
+    if (appEngineServiceId == null) {
+      setAppEngineServiceId(appEngineServiceId);
+    }
   }
 
   private void addContainerPathToRawClasspath() throws JavaModelException {
@@ -106,4 +128,19 @@ public final class TestProjectCreator extends ExternalResource {
       }
     }
   }
+
+  public void setAppEngineServiceId(String serviceId) throws CoreException {
+    IFolder webinf = WebProjectUtil.getWebInfDirectory(getProject());
+    IFile descriptorFile = webinf.getFile("appengine-web.xml");
+    assertTrue(descriptorFile.exists());
+    StringBuilder newAppEngineWebDescriptor = new StringBuilder();
+    newAppEngineWebDescriptor
+        .append("<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n");
+    newAppEngineWebDescriptor.append("<service>").append(serviceId).append("</service>\n");
+    newAppEngineWebDescriptor.append("</appengine-web-app>\n");
+    InputStream contents = new ByteArrayInputStream(
+        newAppEngineWebDescriptor.toString().getBytes(StandardCharsets.UTF_8));
+    descriptorFile.setContents(contents, IFile.FORCE, null);
+  }
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -63,7 +63,7 @@ public final class TestProjectCreator extends ExternalResource {
   }
 
   public TestProjectCreator withAppEngineServiceId(String serviceId) {
-    this.appEngineServiceId = serviceId;
+    appEngineServiceId = serviceId;
     return this;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -105,7 +105,7 @@ public final class TestProjectCreator extends ExternalResource {
 
     addContainerPathToRawClasspath();
     addFacets();
-    if (appEngineServiceId == null) {
+    if (appEngineServiceId != null) {
       setAppEngineServiceId(appEngineServiceId);
     }
   }
@@ -132,7 +132,7 @@ public final class TestProjectCreator extends ExternalResource {
   public void setAppEngineServiceId(String serviceId) throws CoreException {
     IFolder webinf = WebProjectUtil.getWebInfDirectory(getProject());
     IFile descriptorFile = webinf.getFile("appengine-web.xml");
-    assertTrue(descriptorFile.exists());
+    assertTrue("Project should have AppEngine Standard facet", descriptorFile.exists());
     StringBuilder newAppEngineWebDescriptor = new StringBuilder();
     newAppEngineWebDescriptor
         .append("<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n");

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ui/ExecutionEventBuilder.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ui/ExecutionEventBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.test.util.ui;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.expressions.IEvaluationContext;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.ISources;
+
+/**
+ * Mocks up an {@link ExecutionEvent} object for use with Eclipse Commands/Handlers.
+ */
+public class ExecutionEventBuilder {
+
+  private IEvaluationContext context;
+
+  public ExecutionEventBuilder() {
+    context = mock(IEvaluationContext.class);
+  }
+
+  public ExecutionEvent build() {
+    return new ExecutionEvent(null /* command */, Collections.EMPTY_MAP, null /* trigger */,
+        context);
+  }
+
+  public ExecutionEventBuilder withActiveShell(Shell shell) {
+    when(context.getVariable(ISources.ACTIVE_SHELL_NAME)).thenReturn(shell);
+    return this;
+  }
+
+  public ExecutionEventBuilder withCurrentSelection(Object object) {
+    return withCurrentSelection(new StructuredSelection(object));
+  }
+
+  public ExecutionEventBuilder withCurrentSelection(Object... objects) {
+    return withCurrentSelection(new StructuredSelection(objects));
+  }
+
+  public ExecutionEventBuilder withCurrentSelection(IStructuredSelection selection) {
+    when(context.getVariable(ISources.ACTIVE_CURRENT_SELECTION_NAME)).thenReturn(selection);
+    return this;
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ui/ExecutionEventBuilder.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ui/ExecutionEventBuilder.java
@@ -48,10 +48,6 @@ public class ExecutionEventBuilder {
     return this;
   }
 
-  public ExecutionEventBuilder withCurrentSelection(Object object) {
-    return withCurrentSelection(new StructuredSelection(object));
-  }
-
   public ExecutionEventBuilder withCurrentSelection(Object... objects) {
     return withCurrentSelection(new StructuredSelection(objects));
   }

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/status/StatusUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/status/StatusUtil.java
@@ -29,44 +29,44 @@ public class StatusUtil {
 
   private StatusUtil() {}
 
-  public static IStatus error(Class<?> origin, String message) {
-    return error(origin, message, null);
-  }
-
-  public static IStatus error(Class<?> origin, String message, Throwable error) {
-    String bundleOrClassname = null;
-    
-    Bundle bundle = FrameworkUtil.getBundle(origin);
-    if (bundle == null) {
-      bundleOrClassname = origin.getName();
-    } else {
-      bundleOrClassname = bundle.getSymbolicName();
-    }
-    return error(bundleOrClassname, message, error);
-  }
-
   public static IStatus error(Object origin, String message) {
-    if (origin instanceof Class) {
-      return error((Class<?>) origin, message);
-    } else {
-      return error(origin.getClass(), message);
-    }
+    return new Status(IStatus.ERROR, getBundleId(origin), message);
   }
 
   public static IStatus error(Object origin, String message, Throwable error) {
-    if (origin instanceof Class) {
-      return error((Class<?>) origin, message, error);
-    } else {
-      return error(origin.getClass(), message, error);
-    }
+    return new Status(IStatus.ERROR, getBundleId(origin), message, error);
   }
 
-  private static IStatus error(String bundleOrClassname, String message, Throwable error) {
-    if (error == null) {
-      return new Status(IStatus.ERROR, bundleOrClassname, message);
-    } else {
-      return new Status(IStatus.ERROR, bundleOrClassname, message, error);
-    }
+  public static IStatus warn(Object origin, String message) {
+    return new Status(IStatus.WARNING, getBundleId(origin), message);
   }
 
+  public static IStatus warn(Object origin, String message, Throwable error) {
+    return new Status(IStatus.WARNING, getBundleId(origin), message, error);
+  }
+
+  public static IStatus info(Object origin, String message) {
+    return new Status(IStatus.INFO, getBundleId(origin), message);
+  }
+
+  public static IStatus info(Object origin, String message, Throwable error) {
+    return new Status(IStatus.INFO, getBundleId(origin), message, error);
+  }
+
+  private static String getBundleId(Object origin) {
+    Class<?> clazz = null;
+    if (origin == null) {
+      clazz = StatusUtil.class;
+    } else if (origin instanceof Class<?>) {
+      clazz = (Class<?>) origin;
+    } else {
+      clazz = origin.getClass();
+    }
+
+    Bundle bundle = FrameworkUtil.getBundle(clazz);
+    if (bundle == null) {
+      return clazz.getName(); // what else can we do?
+    }
+    return bundle.getSymbolicName();
+  }
 }


### PR DESCRIPTION
  - Creates a new command `com.google.cloud.tools.eclipse.appengine.localserver.launch` that takes a parameter as to whether it should run or debug.  This command can be invoked from the Quick Access.
  - Provides a single handler that supports either the selected projects (e.g., from the _Project Explorer_) or if the project containing the file in the current editor.
  - extracts a few helper methods from elsewhere to aid in testing

Part of #225 