### PR TITLE
don't fail test due to timeout in tearDown when deleting project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/AbstractProjectTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/AbstractProjectTests.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.eclipse.swtbot.SwtBotWorkbenchActions;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.widgets.TimeoutException;
 import org.junit.After;
 import org.junit.BeforeClass;
 
@@ -48,7 +49,11 @@ public class AbstractProjectTests {
     if (project != null) {
       // ensure there are no jobs
       SwtBotWorkbenchActions.waitForIdle(bot);
-      SwtBotProjectActions.deleteProject(bot, project.getName());
+      try {
+        SwtBotProjectActions.deleteProject(bot, project.getName());
+      } catch (TimeoutException ex) {
+        // If this fails it shouldn't fail the test, which has already run
+      }
       project = null;
     }
     bot.resetWorkbench();

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProject.java
@@ -74,8 +74,8 @@ public class DebugNativeAppEngineStandardProject extends AbstractProjectTests {
         "app.engine.test");
     assertTrue(project.exists());
 
-    SWTBotTreeItem project = SwtBotProjectActions.selectProject(bot, "testapp");
-    assertNotNull(project);
+    SWTBotTreeItem testappProject = SwtBotProjectActions.selectProject(bot, "testapp");
+    assertNotNull(testappProject);
     SwtBotTestingUtilities.performAndWaitForWindowChange(bot, new Runnable() {
       @Override
       public void run() {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
@@ -28,7 +28,6 @@ import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.junit.Test;
 
 public class DeployPropertyPageTest extends AbstractProjectTests {
-  // TODO: add tests for flex project when Create New Flex project wizard is available
   @Test
   public void testPropertyPageTitle_standardProject() throws CoreException {
     String projectName = "foo";

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkOutOfDateException;
 import com.google.cloud.tools.eclipse.preferences.areas.PreferenceArea;
 import com.google.cloud.tools.eclipse.sdk.internal.PreferenceConstants;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.Dialog;


### PR DESCRIPTION
@nbashirbello @briandealwis Noticed in the log from https://api.travis-ci.org/jobs/182184944/log.txt?deansi=true that this is a flaky failure mode that doesn't have to cause the test to fail. If we timeout deleting the project in tearDown, the test itself can still have passed. 