### PR TITLE
Add context help to new Maven project wizard

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
@@ -11,6 +11,17 @@
   <artifactId>com.google.cloud.tools.eclipse.appengine.newproject.maven.test</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <useUIHarness>true</useUIHarness>
+          <product>org.eclipse.platform.ide</product>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>
-
-

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/ContextXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/ContextXmlTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.newproject.maven;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public class ContextXmlTest {
+
+  @Test
+  public void testWellFormed() throws ParserConfigurationException, IOException, SAXException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+
+    try (InputStream contentXml = new FileInputStream(
+        "../com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml")) {
+      Document document = builder.parse(contentXml);
+      assertEquals(2, document.getElementsByTagName("context").getLength());
+    }
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
@@ -7,7 +7,7 @@
 
 &lt;b&gt;Artifact ID:&lt;/b&gt; The Maven Artifact ID. Should be an alphanumeric name separated by dashes.
  
-&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add some libraries on the App Engine standard environment to your build path.</description>
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add useful libraries for the App Engine standard environment for your project build path.</description>
   </context>
   <context id="ArchetypeSelectionContext" title="Select Maven Archetype">
      <description>Choose one of the Maven archetypes pre-configured for the App Engine standard environment.</description>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<contexts>
+  <context id="NewMavenProjectContext" title="Create Maven-based App Engine Standard Project">
+     <description>Create a new Maven-based Eclipse project that can be deployed to the App Engine standard environment.
+
+&lt;b&gt;Group ID:&lt;/b&gt; The Maven Group ID. Should be an alphanumeric path separated by periods.
+
+&lt;b&gt;Artifact ID:&lt;/b&gt; The Maven Artifact ID. Should be an alphanumeric name separated by dashes.
+ 
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add some libraries on the App Engine standard environment to your build path.</description>
+  </context>
+  <context id="ArchetypeSelectionContext" title="Select Maven Archetype">
+     <description>Choose one of the Maven archetypes pre-configured for the App Engine standard environment.</description>
+  </context>
+</contexts>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/helpContexts.xml
@@ -7,7 +7,7 @@
 
 &lt;b&gt;Artifact ID:&lt;/b&gt; The Maven Artifact ID. Should be an alphanumeric name separated by dashes.
  
-&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add useful libraries for the App Engine standard environment for your project build path.</description>
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Adds useful libraries for the App Engine standard environment for your project build path.</description>
   </context>
   <context id="ArchetypeSelectionContext" title="Select Maven Archetype">
      <description>Choose one of the Maven archetypes pre-configured for the App Engine standard environment.</description>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
@@ -44,4 +44,11 @@
       </validator>
    </extension>
    
+  <extension
+        point="org.eclipse.help.contexts">
+     <contexts
+           file="helpContexts.xml">
+     </contexts>
+  </extension>
+
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardArchetypeWizardPage.java
@@ -18,7 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.common.annotations.VisibleForTesting;
-
+import java.util.Arrays;
+import java.util.Collections;
 import org.apache.maven.archetype.catalog.Archetype;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.layout.GridDataFactory;
@@ -30,15 +31,13 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.List;
-
-import java.util.Arrays;
-import java.util.Collections;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * UI to select an archetype in creating a new Maven-based App Engine Standard Java project.
  */
 public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
-  
+
   @VisibleForTesting
   static final java.util.List<ArchetypeTuple> PRESET_ARCHETYPES =
       Collections.unmodifiableList(Arrays.asList(
@@ -67,6 +66,9 @@ public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
   public void createControl(Composite parent) {
     Composite container = new Composite(parent, SWT.NONE);
     GridLayoutFactory.swtDefaults().numColumns(2).applyTo(container);
+
+    PlatformUI.getWorkbench().getHelpSystem().setHelp(container,
+        "com.google.cloud.tools.eclipse.appengine.newproject.maven.ArchetypeSelectionContext"); //$NON-NLS-1$
 
     // List of (selectable) archetypes on the left
     archetypeList = new List(container, SWT.SINGLE | SWT.BORDER);
@@ -109,7 +111,7 @@ public class MavenAppEngineStandardArchetypeWizardPage extends WizardPage {
     Archetype archetype;
     String displayName;
     String description;
-    
+
     ArchetypeTuple(String groupId, String artifactId, String displayName, String description) {
       archetype = new Archetype();
       archetype.setGroupId(groupId);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -56,6 +56,7 @@ import org.eclipse.swt.widgets.DirectoryDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * UI to collect all information necessary to create a new Maven-based App Engine Standard Java
@@ -110,6 +111,9 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
     Composite container = new Composite(parent, SWT.NONE);
     GridLayoutFactory.swtDefaults().numColumns(2).applyTo(container);
     setControl(container);
+
+    PlatformUI.getWorkbench().getHelpSystem().setHelp(container,
+        "com.google.cloud.tools.eclipse.appengine.newproject.maven.NewMavenProjectContext"); //$NON-NLS-1$
 
     createLocationArea(container);
     createMavenCoordinatesArea(container);
@@ -304,11 +308,11 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
       } catch (FileAlreadyExistsException ex) {
           String message = MessageFormat.format(Messages.getString("FILE_LOCATION"), location); //$NON-NLS-1$
           page.setMessage(message, ERROR);
-          return false;  
+          return false;
       } catch (IOException ex) {
         String message = MessageFormat.format(Messages.getString("INVALID_PATH"), location); //$NON-NLS-1$
         page.setMessage(message, ERROR);
-        return false;  
+        return false;
       }
     }
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
@@ -72,5 +72,3 @@
     </plugins>
   </build>
 </project>
-
-

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/StandardProjectWizardTest.java
@@ -38,7 +38,7 @@ public class StandardProjectWizardTest {
   public void testTitleSet() {
     Assert.assertEquals("New App Engine Standard Project", wizard.getWindowTitle());
   }
-  
+
   @Test
   public void testAddPages() {
     wizard.addPages();
@@ -46,5 +46,5 @@ public class StandardProjectWizardTest {
     Assert.assertEquals(1, wizard.getPageCount());
     Assert.assertNotNull(wizard.getPage("basicNewProjectPage"));
   }
-  
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
@@ -5,6 +5,6 @@
 
 &lt;b&gt;Project name:&lt;/b&gt; An Eclipse project name.
 
-&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add useful libraries for the App Engine standard environment for your project build path.</description>
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Adds useful libraries for the App Engine standard environment for your project build path.</description>
   </context>
 </contexts>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <contexts>
   <context id="NewProjectContext" title="Create App Engine Standard Project">
-     <description>Create a new Eclipse project that can be deployed to the App Engine Standard environment.
+     <description>Create a new Eclipse project that can be deployed to the App Engine standard environment.
 
 &lt;b&gt;Project name:&lt;/b&gt; An Eclipse project name.
 
-&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add some libraries on the App Engine Standard environment to your build path.</description>
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add some libraries on the App Engine standard environment to your build path.</description>
   </context>
 </contexts>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/helpContexts.xml
@@ -5,6 +5,6 @@
 
 &lt;b&gt;Project name:&lt;/b&gt; An Eclipse project name.
 
-&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add some libraries on the App Engine standard environment to your build path.</description>
+&lt;b&gt;Libraries to add to build path:&lt;/b&gt; Add useful libraries for the App Engine standard environment for your project build path.</description>
   </context>
 </contexts>


### PR DESCRIPTION
Part of #696. I think we will want to commit the framework first with minimally acceptable help texts and iterator over them later.

![maven-based app engine standard project _013](https://cloud.githubusercontent.com/assets/10523105/21020886/4bd23608-bd44-11e6-99d0-4f25533c183e.png)

![maven-based app engine standard project _014](https://cloud.githubusercontent.com/assets/10523105/21020889/4ef24d1e-bd44-11e6-80a4-d1d3406d1663.png)

Notes:
- `tycho-surefile-plugin` allows getting a Workbench in tests.
- Lower-case "standard env" in normal text body as in https://cloud.google.com/appengine/docs/about-the-standard-environment