### PR TITLE
Add new project wizard extensions

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
@@ -43,6 +43,15 @@
          </exclude>
       </validator>
    </extension>
+   <extension
+         point="org.eclipse.ui.perspectiveExtensions">
+      <perspectiveExtension
+            targetID="*">
+         <newWizardShortcut
+               id="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
+         </newWizardShortcut>
+      </perspectiveExtension>
+   </extension>
    
   <extension
         point="org.eclipse.help.contexts">

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
@@ -45,12 +45,24 @@
    </extension>
    <extension
          point="org.eclipse.ui.perspectiveExtensions">
-      <perspectiveExtension
-            targetID="*">
-         <newWizardShortcut
-               id="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
-         </newWizardShortcut>
-      </perspectiveExtension>
+     <perspectiveExtension
+           targetID="org.eclipse.jdt.ui.JavaPerspective">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
+     <perspectiveExtension
+           targetID="org.eclipse.jst.j2ee.J2EEPerspective">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
+     <perspectiveExtension
+           targetID="org.eclipse.wst.web.ui.webDevPerspective">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
    </extension>
    
   <extension

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -26,7 +26,19 @@
   <extension
         point="org.eclipse.ui.perspectiveExtensions">
      <perspectiveExtension
-           targetID="*">
+           targetID="org.eclipse.jdt.ui.JavaPerspective">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
+     <perspectiveExtension
+           targetID="org.eclipse.jst.j2ee.J2EEPerspective">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
+     <perspectiveExtension
+           targetID="org.eclipse.wst.web.ui.webDevPerspective">
         <newWizardShortcut
               id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard">
         </newWizardShortcut>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -24,12 +24,6 @@
         name="%gcp.category" />
   </extension>
   <extension
-<<<<<<< Updated upstream
-        point="org.eclipse.help.contexts">
-     <contexts
-           file="helpContexts.xml">
-     </contexts>
-=======
         point="org.eclipse.ui.perspectiveExtensions">
      <perspectiveExtension
            targetID="*">
@@ -37,7 +31,12 @@
               id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard">
         </newWizardShortcut>
      </perspectiveExtension>
->>>>>>> Stashed changes
+  </extension>
+  <extension
+        point="org.eclipse.help.contexts">
+     <contexts
+           file="helpContexts.xml">
+     </contexts>
   </extension>
 
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -24,10 +24,20 @@
         name="%gcp.category" />
   </extension>
   <extension
+<<<<<<< Updated upstream
         point="org.eclipse.help.contexts">
      <contexts
            file="helpContexts.xml">
      </contexts>
+=======
+        point="org.eclipse.ui.perspectiveExtensions">
+     <perspectiveExtension
+           targetID="*">
+        <newWizardShortcut
+              id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard">
+        </newWizardShortcut>
+     </perspectiveExtension>
+>>>>>>> Stashed changes
   </extension>
 
 </plugin>


### PR DESCRIPTION
Adds the native and maven projects to the _New_ menu.  Note that, you'll need to reset your perspective to pick up these changes if you're running from an existing workspace/window.

<img width="779" alt="screen shot 2016-12-08 at 4 22 00 pm" src="https://cloud.githubusercontent.com/assets/202851/21028341/a134bd96-bd62-11e6-813a-701ac3fe7546.PNG">
.