### PR TITLE
Log more info for setPrimaryRuntime CoreException

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Fragment-Host: com.google.cloud.tools.eclipse.appengine.newproject
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.equinox.registry,
  org.hamcrest;bundle-version="1.1.0"
-Import-Package: org.eclipse.core.resources,
+Import-Package: com.google.common.io;version="20.0.0",
+ org.eclipse.core.resources,
  org.mockito;provider=google;version="1.10.19",
  org.mockito.runners;provider=google;version="1.10.19",
  org.mockito.stubbing;provider=google;version="1.10.19",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -78,7 +77,8 @@ public class CreateAppEngineStandardWtpProjectTest {
   // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1086
   // (Don't forget to remove Guava from MANIFEST.MF.)
   private void logForSetPrimaryRuntimeError() {
-    assertSame(project, config.getProject());
+    System.out.println("project: " + project.getName());
+    System.out.println("config.getProject(): " + config.getProject());
 
     // Log targeted runtimes that have been added to the project.
     try {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -21,10 +21,15 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
-
+import java.util.Set;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -34,6 +39,9 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.eclipse.wst.common.project.facet.core.runtime.IRuntime;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,41 +60,77 @@ public class CreateAppEngineStandardWtpProjectTest {
   private NullProgressMonitor monitor = new NullProgressMonitor();
   private AppEngineStandardProjectConfig config = new AppEngineStandardProjectConfig();
   private IProject project;
-  
+
   @Before
   public void setUp() {
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     project = workspace.getRoot().getProject("testproject" + Math.random());
     config.setProject(project);
   }
-  
+
   @After
   public void cleanUp() throws CoreException {
     project.delete(true, monitor);
   }
-  
+
+  // TODO(chanseok): Debugging code. Remove after the issue is resolved:
+  // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1086
+  // (Don't forget to remove Guava from MANIFEST.MF.)
+  private void logForSetPrimaryRuntimeError() {
+    assertTrue(project == config.getProject());
+
+    // Log targeted runtimes that have been added to the project.
+    try {
+      IFacetedProject facetedProject = ProjectFacetsManager.create(project);
+      Set<IRuntime> targetedRuntimes = facetedProject.getTargetedRuntimes();
+      System.out.println("No. targeted runtimes: " + targetedRuntimes.size());
+      for (IRuntime targetedRuntime : targetedRuntimes) {
+        System.out.println("  Runtime: " + targetedRuntime.toString());
+      }
+      System.out.println("Primary runtime: " + facetedProject.getPrimaryRuntime().toString());
+    } catch (CoreException ex) {
+      ex.printStackTrace(System.out);
+    }
+
+    // Log contents of the facet settings file.
+    IFile settingsFile = project.getFile(".settings/org.eclipse.wst.common.project.facet.core.xml");
+    System.out.println("File in sync? " + settingsFile.isSynchronized(IResource.DEPTH_INFINITE));
+    try {
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      ByteStreams.copy(settingsFile.getContents(), outputStream);
+      System.out.println(outputStream.toString());
+    } catch (CoreException | IOException ex) {
+      ex.printStackTrace(System.out);
+    }
+  }
+
   @Test
   public void testConstructor() {
     new CreateAppEngineStandardWtpProject(config, adaptable);
   }
-  
+
   @Test
   public void testUnitTestCreated() throws InvocationTargetException, CoreException {
-    CreateAppEngineStandardWtpProject creator = new CreateAppEngineStandardWtpProject(config, adaptable);
-    creator.execute(new NullProgressMonitor());
-    
-    assertJunitAndHamcrestAreOnClasspath();
+    try {
+      CreateAppEngineStandardWtpProject creator = new CreateAppEngineStandardWtpProject(config, adaptable);
+      creator.execute(new NullProgressMonitor());
+
+      assertJunitAndHamcrestAreOnClasspath();
+    } catch (CoreException ex) {
+      logForSetPrimaryRuntimeError();
+      throw ex;
+    }
   }
 
   private void assertJunitAndHamcrestAreOnClasspath() throws CoreException {
     assertTrue(project.hasNature(JavaCore.NATURE_ID));
     IJavaProject javaProject = JavaCore.create(project);
     IType junit = javaProject.findType("org.junit.Assert");
-    
+
     // Is findType doing what we think it's doing?
     // Locally where it passes it finds JUnit in
     // class Assert [in Assert.class [in org.junit [in /Users/elharo/workspace/.metadata/.plugins/org.eclipse.pde.core/.bundle_pool/plugins/org.junit_4.12.0.v201504281640/junit.jar]]]
-    
+
     assertNotNull("Did not find junit", junit);
     assertTrue(junit.exists());
     IType hamcrest = javaProject.findType("org.hamcrest.CoreMatchers");
@@ -96,11 +140,16 @@ public class CreateAppEngineStandardWtpProjectTest {
 
   @Test
   public void testAppEngineLibrariesAdded() throws InvocationTargetException, CoreException {
-    Library library = new Library(APP_ENGINE_API);
-    config.setAppEngineLibraries(Collections.singletonList(library));
-    CreateAppEngineStandardWtpProject creator = new CreateAppEngineStandardWtpProject(config, adaptable);
-    creator.execute(new NullProgressMonitor());
-    assertAppEngineContainerOnClasspath(library);
+    try {
+      Library library = new Library(APP_ENGINE_API);
+      config.setAppEngineLibraries(Collections.singletonList(library));
+      CreateAppEngineStandardWtpProject creator = new CreateAppEngineStandardWtpProject(config, adaptable);
+      creator.execute(new NullProgressMonitor());
+      assertAppEngineContainerOnClasspath(library);
+    } catch (CoreException ex) {
+      logForSetPrimaryRuntimeError();
+      throw ex;
+    }
   }
 
   private void assertAppEngineContainerOnClasspath(Library library) throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -77,7 +78,7 @@ public class CreateAppEngineStandardWtpProjectTest {
   // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1086
   // (Don't forget to remove Guava from MANIFEST.MF.)
   private void logForSetPrimaryRuntimeError() {
-    assertTrue(project == config.getProject());
+    assertSame(project, config.getProject());
 
     // Log targeted runtimes that have been added to the project.
     try {


### PR DESCRIPTION
I have been investigating #1086 since yesterday afternoon. I looked into the `FacetedProject` code, but I can't get how this error can ever happen. It doesn't make sense. I guess this will be very tricky to find a cause. This PR will log information like this:

```
No. targeted runtimes: 1
  Runtime: App Engine Standard Runtime
Primary runtime: App Engine Standard Runtime
File in sync? true
<?xml version="1.0" encoding="UTF-8"?>
<faceted-project>
  <runtime name="App Engine Standard Runtime"/>
  <fixed facet="wst.jsdt.web"/>
  <installed facet="java" version="1.7"/>
  <installed facet="jst.web" version="2.5"/>
  <installed facet="com.google.cloud.tools.eclipse.appengine.facets.standard" version="1"/>
  <installed facet="wst.jsdt.web" version="1.0"/>
</faceted-project>
```