### PR TITLE
Avoid running tests with SDK features

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
@@ -36,22 +36,22 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.web_sdk.feature</id>
+                <id>org.eclipse.jst.web_ui.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.common.fproj.enablement.jdt.sdk</id>
+                <id>org.eclipse.jst.common.fproj.enablement.jdt</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.common.fproj.sdk</id>
+                <id>org.eclipse.wst.common.fproj</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.server_adapters.sdk.feature</id>
+                <id>org.eclipse.wst.server_adapters.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
@@ -36,22 +36,22 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.web_sdk.feature</id>
+                <id>org.eclipse.jst.web_ui.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.common.fproj.enablement.jdt.sdk</id>
+                <id>org.eclipse.jst.common.fproj.enablement.jdt</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.common.fproj.sdk</id>
+                <id>org.eclipse.wst.common.fproj</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.server_adapters.sdk.feature</id>
+                <id>org.eclipse.wst.server_adapters.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
@@ -42,22 +42,22 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.web_sdk.feature</id>
+                <id>org.eclipse.jst.web_ui.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.jst.common.fproj.enablement.jdt.sdk</id>
+                <id>org.eclipse.jst.common.fproj.enablement.jdt</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.common.fproj.sdk</id>
+                <id>org.eclipse.wst.common.fproj</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.wst.server_adapters.sdk.feature</id>
+                <id>org.eclipse.wst.server_adapters.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>


### PR DESCRIPTION
Avoid spurious messages in our tests like the following by replacing SDK features with runtime features:
```
!ENTRY org.eclipse.equinox.registry 2 0 2016-12-09 11:37:52.205
!MESSAGE The extensions and extension-points from the bundle "org.eclipse.wst.common.infopop.source" are ignored. The bundle is not marked as singleton.

!ENTRY org.eclipse.equinox.registry 2 0 2016-12-09 11:37:52.205
!MESSAGE The extensions and extension-points from the bundle "org.eclipse.wst.validation.infopop.source" are ignored. The bundle is not marked as singleton.

!ENTRY org.eclipse.equinox.registry 2 0 2016-12-09 11:37:52.345
!MESSAGE The extensions and extension-points from the bundle "org.eclipse.wst.command.env.infopop.source" are ignored. The bundle is not marked as singleton.
```