### PR TITLE
Add CT4E Release Note link to What's New Welcome page

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
+++ b/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
@@ -22,6 +22,17 @@
     </group>
   </extensionContent>
 
+  <extensionContent path="whatsnew/@" style="css/intro.css">
+    <group style-id="content-group">
+      <link id="cloud-tools-for-eclipse-whatsnew-link"
+            label="Google Cloud Tools for Eclipse Release Notes"
+            style-id="content-link"
+            url="https://cloud.google.com/eclipse/docs/release-notes">
+        <text>Announcements about new or updated features, bug fixes, known issues, and deprecated functionality.</text>
+      </link>
+    </group>
+  </extensionContent>
+
   <extensionContent path="migrate/@" style="css/intro.css">
     <group style-id="content-group">
       <link id="cloud-tools-for-eclipse-migration-link"

--- a/plugins/com.google.cloud.tools.eclipse.welcome/intro/css/intro.css
+++ b/plugins/com.google.cloud.tools.eclipse.welcome/intro/css/intro.css
@@ -1,5 +1,6 @@
 a#cloud-tools-for-eclipse-link img,
 a#cloud-tools-for-eclipse-tutorial-link img,
+a#cloud-tools-for-eclipse-whatsnew-link img,
 a#cloud-tools-for-eclipse-migration-link img {
   background-image : url(../icons/gcp-32x32.png);
 }


### PR DESCRIPTION
Closes #1009. Clicking on the link opens https://cloud.google.com/eclipse/docs/release-notes.

![java ee - eclipse platform _016](https://cloud.githubusercontent.com/assets/10523105/21152197/57c08562-c133-11e6-8530-87bed72841c2.png)