### PR TITLE
Add org.eclipse.equinox.event dep to eliminate test output clutters

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.newproject.maven
 Require-Bundle: org.junit;bundle-version="4.12.0",
+ org.eclipse.equinox.event,
  org.eclipse.equinox.registry,
  org.hamcrest;bundle-version="1.1.0"
 Import-Package: com.google.cloud.tools.eclipse.test.util.ui,


### PR DESCRIPTION
Fixes #1105.

They were from the `.newproject.maven.test` bundle. (I changed the title of #1105.) The `tycho-surefire-plugin` in `pom.xml` of the bundle already defined the product `org.eclipse.platform.ide`, but it didn't help. Adding the `org.eclipse.equinox.event` bundle eliminates the errors.