### PR TITLE
Add tooltips to deploy dialog

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -270,7 +270,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private void createCredentialSection(IGoogleLoginService loginService) {
     Composite accountComposite = new Composite(this, SWT.NONE);
 
-    Label accountLabel = new Label(accountComposite, SWT.LEFT);
+    Label accountLabel = new Label(accountComposite, SWT.LEAD);
     accountLabel.setText(Messages.getString("deploy.preferences.dialog.label.selectAccount"));
     accountLabel.setToolTipText(Messages.getString("tooltip.account"));
 
@@ -284,13 +284,13 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private void createProjectIdSection() {
     Composite projectIdComposite = new Composite(this, SWT.NONE);
 
-    projectIdLabel = new Label(projectIdComposite, SWT.LEFT);
+    projectIdLabel = new Label(projectIdComposite, SWT.LEAD);
     projectIdLabel.setText(Messages.getString("project.id"));
     projectIdLabel.setToolTipText(Messages.getString("tooltip.project.id"));
     GridData layoutData = GridDataFactory.swtDefaults().create();
     projectIdLabel.setLayoutData(layoutData);
 
-    projectId = new Text(projectIdComposite, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
+    projectId = new Text(projectIdComposite, SWT.LEAD | SWT.SINGLE | SWT.BORDER);
     projectId.setToolTipText(Messages.getString("tooltip.project.id"));
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(projectIdComposite);
   }
@@ -355,7 +355,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     overrideDefaultBucketButton.setLayoutData(layoutData);
     overrideDefaultBucketButton.setToolTipText(Messages.getString("tooltip.staging.bucket"));
 
-    bucket = new Text(bucketComposite, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
+    bucket = new Text(bucketComposite, SWT.LEAD | SWT.SINGLE | SWT.BORDER);
     bucket.setToolTipText(Messages.getString("tooltip.staging.bucket"));
 
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(bucketComposite);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -226,7 +226,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     ISWTObservableValue bucketField = WidgetProperties.text(SWT.Modify).observe(bucket);
     ISWTObservableValue bucketFieldEnablement = WidgetProperties.enabled().observe(bucket);
 
-    // use an intermediary value to control the enabled state of the label and the field 
+    // use an intermediary value to control the enabled state of the label and the field
     // based on the override checkbox's state
     WritableValue enablement = new WritableValue();
     context.bindValue(overrideButton, enablement);
@@ -270,12 +270,14 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
   private void createCredentialSection(IGoogleLoginService loginService) {
     Composite accountComposite = new Composite(this, SWT.NONE);
 
-    new Label(accountComposite, SWT.LEFT).setText(
-        Messages.getString("deploy.preferences.dialog.label.selectAccount"));
+    Label accountLabel = new Label(accountComposite, SWT.LEFT);
+    accountLabel.setText(Messages.getString("deploy.preferences.dialog.label.selectAccount"));
+    accountLabel.setToolTipText(Messages.getString("tooltip.account"));
 
     // If we don't require values, then don't auto-select accounts
     accountSelector = new AccountSelector(accountComposite, loginService,
         Messages.getString("deploy.preferences.dialog.accountSelector.login"), requireValues);
+    accountSelector.setToolTipText(Messages.getString("tooltip.account"));
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(accountComposite);
   }
 
@@ -284,10 +286,12 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
 
     projectIdLabel = new Label(projectIdComposite, SWT.LEFT);
     projectIdLabel.setText(Messages.getString("project.id"));
+    projectIdLabel.setToolTipText(Messages.getString("tooltip.project.id"));
     GridData layoutData = GridDataFactory.swtDefaults().create();
     projectIdLabel.setLayoutData(layoutData);
-    
+
     projectId = new Text(projectIdComposite, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
+    projectId.setToolTipText(Messages.getString("tooltip.project.id"));
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(projectIdComposite);
   }
 
@@ -296,10 +300,12 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
 
     overrideDefaultVersionButton = new Button(versionComposite, SWT.CHECK);
     overrideDefaultVersionButton.setText(Messages.getString("use.custom.versioning"));
+    overrideDefaultVersionButton.setToolTipText(Messages.getString("tooltip.version"));
     GridData layoutData = GridDataFactory.swtDefaults().create();
     overrideDefaultVersionButton.setLayoutData(layoutData);
 
     version = new Text(versionComposite, SWT.LEAD | SWT.SINGLE | SWT.BORDER);
+    version.setToolTipText(Messages.getString("tooltip.version"));
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(versionComposite);
   }
 
@@ -307,11 +313,13 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     Composite promoteComposite = new Composite(this, SWT.NONE);
     autoPromoteButton = new Button(promoteComposite, SWT.CHECK);
     autoPromoteButton.setText(Messages.getString("auto.promote"));
-    String manualPromoteMessage = Messages.getString("deploy.manual.link", APPENGINE_VERSIONS_URL);
+    String manualPromoteMessage = Messages.getString(
+        "tooltip.manual.promote.link", APPENGINE_VERSIONS_URL);
     autoPromoteButton.setToolTipText(manualPromoteMessage);
 
     stopPreviousVersionButton = new Button(promoteComposite, SWT.CHECK);
     stopPreviousVersionButton.setText(Messages.getString("stop.previous.version"));
+    stopPreviousVersionButton.setToolTipText(Messages.getString("tooltip.stop.previous.version"));
 
     GridLayoutFactory.fillDefaults().generateLayout(promoteComposite);
   }
@@ -345,8 +353,10 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     overrideDefaultBucketButton.setText(Messages.getString("use.custom.bucket"));
     GridData layoutData = GridDataFactory.swtDefaults().create();
     overrideDefaultBucketButton.setLayoutData(layoutData);
+    overrideDefaultBucketButton.setToolTipText(Messages.getString("tooltip.staging.bucket"));
 
     bucket = new Text(bucketComposite, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
+    bucket.setToolTipText(Messages.getString("tooltip.staging.bucket"));
 
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(bucketComposite);
     return bucketComposite;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -29,15 +29,15 @@ appengine.java.component.missing=Could not deploy project because the App Engine
  at the command line and try again.
 cloudsdk.not.configured.detail=Could not deploy project because the Cloud SDK was not found.\
  Check Preferences > Google Cloud Tools > SDK location and try again.
-tooltip.account=Google Account used to deploy the app to the Google Cloud Platform project.
-tooltip.project.id=The Google Cloud Platform project where the app will be deployed to.
+tooltip.account=Google Account used to deploy the app to the Google Cloud Platform.
+tooltip.project.id=The Google Cloud Platform project where the app will be deployed.
 tooltip.version=The version of the app that will be created or replaced by this\
  deployment. If you do not specify a version, one will be generated for you.
 tooltip.manual.promote.link=To manually promote a version use the Google Cloud Console: {0}
 tooltip.stop.previous.version=If checked, stops the previously running version when deploying a new\
  version that receives all traffic.
-tooltip.staging.bucket=The Google Cloud Storage bucket used to stage files associated with the\
- deployment. If not specified, the application's default code bucket is used.
+tooltip.staging.bucket=The Google Cloud Storage bucket used to stage files for the deployment.\
+ If not specified, the application's default code bucket is used.
 
 # Flex deploy settings
 browse.button=Browse

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -5,7 +5,6 @@ google.preferences=Google Cloud Platform-related settings
 auto.promote=Promote the deployed version to receive all traffic
 deploy=Deploy
 deploy.login.dialog.message=Browser opened to authorize deployment.
-deploy.manual.link=To manually promote a version use the Google Cloud Console: {0}
 deploy.preferences.dialog.title=Deploy to App Engine Standard
 deploy.preferences.dialog.title.withProject=Deployment Parameters for "{0}"
 deploy.preferences.dialog.label.selectAccount=Account:
@@ -30,6 +29,15 @@ appengine.java.component.missing=Could not deploy project because the App Engine
  at the command line and try again.
 cloudsdk.not.configured.detail=Could not deploy project because the Cloud SDK was not found.\
  Check Preferences > Google Cloud Tools > SDK location and try again.
+tooltip.account=Google Account used to deploy the app to the Google Cloud Platform project.
+tooltip.project.id=The Google Cloud Platform project where the app will be deployed to.
+tooltip.version=The version of the app that will be created or replaced by this\
+ deployment. If you do not specify a version, one will be generated for you.
+tooltip.manual.promote.link=To manually promote a version use the Google Cloud Console: {0}
+tooltip.stop.previous.version=If checked, stops the previously running version when deploying a new\
+ version that receives all traffic.
+tooltip.staging.bucket=The Google Cloud Storage bucket used to stage files associated with the\
+ deployment. If not specified, the application's default code bucket is used.
 
 # Flex deploy settings
 browse.button=Browse

--- a/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.login/src/com/google/cloud/tools/eclipse/appengine/login/ui/AccountSelector.java
@@ -188,4 +188,9 @@ public class AccountSelector extends Composite {
       selectAccount(account.getEmail());
     }
   }
+
+  @Override
+  public void setToolTipText(String string) {
+    combo.setToolTipText(string);
+  }
 }


### PR DESCRIPTION
Fixes #1124.

Most of the tooltip text are taken from `gcloud app deploy --help`. I verified that every tooltip is working.