### PR TITLE
Add Run As/Debug As support

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.properties
@@ -9,3 +9,12 @@ apptoolsRuntimeTypeName=App Engine Standard Runtime
 apptoolsServerTypeName=App Engine Local Server
 apptoolsLaunchTypeName=App Engine Standard
 serverTypeDescription=Local development server for Google App Engine Standard Environment
+
+launch.prefpage.name = Launching
+launch.command.description = Launch on App Engine development server
+launch.command.name = Launch on App Engine
+launch.command.mode.name = Launch mode
+launch.shortcut.description = Launch in the local App Engine development environment
+launch.shortcut.label = App Engine
+launch.shortcut.run.description = Run on the local App Engine development server
+launch.shortcut.debug.description = Debug on the local App Engine development server

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -223,6 +223,37 @@
       </fragment>
    </extension>
    <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.ui.popup.any?after=additions">
+         <command
+               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
+               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/run_exc.png"
+               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/run_exc.png"
+               label="Run in App Engine"
+               mnemonic="R"
+               style="push">
+            <parameter
+                  name="launchMode"
+                  value="run">
+            </parameter>
+         </command>
+         <command
+               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
+               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/debug_exc.png"
+               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/debug_exc.png"
+               label="Debug in App Engine"
+               mnemonic="D"
+               style="push">
+            <parameter
+                  name="launchMode"
+                  value="debug">
+            </parameter>
+         </command>
+      </menuContribution>
+   </extension>
+   <extension
          point="org.eclipse.ui.commands">
       <command
             description="Launch on App Engine development server"
@@ -242,25 +273,22 @@
             class="com.google.cloud.tools.eclipse.appengine.localserver.ui.LaunchAppEngineStandardHandler"
             commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch">
          <enabledWhen>
-            <or>
-               <iterate
-                     ifEmpty="false">
-                  <or>
-                     <adapt
-                           type="org.eclipse.wst.server.core.IModule">
-                     </adapt>
-                     <test
-                           property="org.eclipse.wst.server.ui.isRunnable">
-                     </test>
-                  </or>
-               </iterate>
-               <with
-                     variable="activeEditor">
+           <or>
+           	  <iterate>
+		        <test
+        		    property="org.eclipse.wst.common.project.facet.core.projectFacet"
+            		value="com.google.cloud.tools.eclipse.appengine.facets.standard" />
+              </iterate>
+              <with
+                     variable="activeEditorInput">
                   <adapt
-                        type="org.eclipse.ui.IEditorPart">
+                        type="org.eclipse.core.resources.IFile">
+			        <test
+            			property="org.eclipse.wst.common.project.facet.core.projectFacet"
+            			value="com.google.cloud.tools.eclipse.appengine.facets.standard" />
                   </adapt>
                </with>
-            </or>
+           </or>
          </enabledWhen>
       </handler>
    </extension>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -252,6 +252,34 @@
             </parameter>
          </command>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+         <command
+               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
+               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/run_exc.png"
+               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/run_exc.png"
+               label="Run in App Engine"
+               mnemonic="R"
+               style="push">
+            <parameter
+                  name="launchMode"
+                  value="run">
+            </parameter>
+         </command>
+         <command
+               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
+               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/debug_exc.png"
+               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/debug_exc.png"
+               label="Debug in App Engine"
+               mnemonic="D"
+               style="push">
+            <parameter
+                  name="launchMode"
+                  value="debug">
+            </parameter>
+         </command>
+      </menuContribution>
    </extension>
    <extension
          point="org.eclipse.ui.commands">
@@ -270,7 +298,7 @@
    <extension
          point="org.eclipse.ui.handlers">
       <handler
-            class="com.google.cloud.tools.eclipse.appengine.localserver.ui.LaunchAppEngineStandardHandler"
+            class="com.google.cloud.tools.eclipse.appengine.localserver.launching.LaunchAppEngineStandardHandler"
             commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch">
          <enabledWhen>
            <or>
@@ -291,5 +319,48 @@
            </or>
          </enabledWhen>
       </handler>
+   </extension>
+   <extension
+         point="org.eclipse.debug.ui.launchShortcuts">
+        <shortcut
+            id="com.google.cloud.tools.eclipse.appengine.localserver.launch.appengine.standard"
+            label="App Engine"
+            description="Launch in the local App Engine development environment"
+            path="com.google.cloud.tools.eclipse/appEngineStandard"
+            class="com.google.cloud.tools.eclipse.appengine.localserver.launching.LocalAppEngineStandardLaunchShortcut"
+            icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
+            modes="run,debug">
+         <contextualLaunch>
+            <enablement>
+	           <or>
+    	           <with variable="selection">
+        		   	  <iterate>
+        		   	    <adapt type="org.eclipse.core.resources.IProject">
+		        			<test
+        		    			property="org.eclipse.wst.common.project.facet.core.projectFacet"
+            					value="com.google.cloud.tools.eclipse.appengine.facets.standard" />
+    					</adapt>
+              		  </iterate>
+              		</with>
+              		<with variable="activeEditorInput">
+                  		<adapt type="org.eclipse.core.resources.IFile">
+			        		<test
+            					property="org.eclipse.wst.common.project.facet.core.projectFacet"
+            					value="com.google.cloud.tools.eclipse.appengine.facets.standard" />
+                  		</adapt>
+               		</with>
+           		</or>
+            </enablement>
+         </contextualLaunch>
+         <description
+               description="Run on the local App Engine development server"
+               mode="run" />
+         <description
+               description="Debug on the local App Engine development server"
+               mode="debug" />
+         <configurationType
+               id="com.google.cloud.tools.eclipse.appengine.AppToolsLaunchConfigurationType"/>
+      </shortcut>
+      
    </extension>
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -203,7 +203,7 @@
             category="com.google.cloud.tools.eclipse.preferences.main"
             class="com.google.cloud.tools.eclipse.preferences.areas.AreaBasedPreferencePage"
             id="com.google.cloud.tools.eclipse.preferences.appengine.localserver"
-            name="Launching">
+            name="%launch.prefpage.name">
       </page>
    </extension>
    <extension
@@ -225,12 +225,12 @@
    <extension
          point="org.eclipse.ui.commands">
       <command
-            description="Launch on App Engine development server"
+            description="%launch.command.description"
             id="com.google.cloud.tools.eclipse.appengine.localserver.launch"
-            name="Launch on App Engine">
+            name="%launch.command.name">
          <commandParameter
                id="launchMode"
-               name="Launch mode"
+               name="%launch.command.mode.name"
                optional="true"
                values="com.google.cloud.tools.eclipse.appengine.localserver.ui.LaunchModes">
          </commandParameter>
@@ -265,8 +265,8 @@
          point="org.eclipse.debug.ui.launchShortcuts">
         <shortcut
             id="com.google.cloud.tools.eclipse.appengine.localserver.launch.appengine.standard"
-            label="App Engine"
-            description="Launch in the local App Engine development environment"
+            label="%launch.shortcut.label"
+            description="%launch.shortcut.description"
             path="com.google.cloud.tools.eclipse/appEngineStandard"
             class="com.google.cloud.tools.eclipse.appengine.localserver.launching.LocalAppEngineStandardLaunchShortcut"
             icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
@@ -294,10 +294,10 @@
             </enablement>
          </contextualLaunch>
          <description
-               description="Run on the local App Engine development server"
+               description="%launch.shortcut.run.description"
                mode="run" />
          <description
-               description="Debug on the local App Engine development server"
+               description="%launch.shortcut.debug.description"
                mode="debug" />
          <configurationType
                id="com.google.cloud.tools.eclipse.appengine.AppToolsLaunchConfigurationType"/>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -223,65 +223,6 @@
       </fragment>
    </extension>
    <extension
-         point="org.eclipse.ui.menus">
-      <menuContribution
-            allPopups="false"
-            locationURI="popup:org.eclipse.ui.popup.any?after=additions">
-         <command
-               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
-               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/run_exc.png"
-               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/run_exc.png"
-               label="Run in App Engine"
-               mnemonic="R"
-               style="push">
-            <parameter
-                  name="launchMode"
-                  value="run">
-            </parameter>
-         </command>
-         <command
-               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
-               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/debug_exc.png"
-               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/debug_exc.png"
-               label="Debug in App Engine"
-               mnemonic="D"
-               style="push">
-            <parameter
-                  name="launchMode"
-                  value="debug">
-            </parameter>
-         </command>
-      </menuContribution>
-      <menuContribution
-            allPopups="false"
-            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
-         <command
-               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
-               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/run_exc.png"
-               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/run_exc.png"
-               label="Run in App Engine"
-               mnemonic="R"
-               style="push">
-            <parameter
-                  name="launchMode"
-                  value="run">
-            </parameter>
-         </command>
-         <command
-               commandId="com.google.cloud.tools.eclipse.appengine.localserver.launch"
-               disabledIcon="platform:/plugin/org.eclipse.debug.ui/icons/full/dtool16/debug_exc.png"
-               icon="platform:/plugin/org.eclipse.debug.ui/icons/full/etool16/debug_exc.png"
-               label="Debug in App Engine"
-               mnemonic="D"
-               style="push">
-            <parameter
-                  name="launchMode"
-                  value="debug">
-            </parameter>
-         </command>
-      </menuContribution>
-   </extension>
-   <extension
          point="org.eclipse.ui.commands">
       <command
             description="Launch on App Engine development server"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchAppEngineStandardHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchAppEngineStandardHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.launching;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.wst.server.core.IModule;
+
+/** Find or create a server with the selected projects and launch it. */
+public class LaunchAppEngineStandardHandler extends AbstractHandler {
+  @Override
+  public Object execute(ExecutionEvent event) throws ExecutionException {
+    String launchMode = event.getParameter("launchMode");
+    if (launchMode == null) {
+      launchMode = ILaunchManager.DEBUG_MODE;
+    }
+    LaunchHelper launcher = new LaunchHelper();
+    try {
+      IModule[] modules = asModules(launcher, event);
+      launcher.launch(modules, launchMode);
+    } catch (CoreException ex) {
+      throw new ExecutionException("Unable to configure server", ex);
+    }
+    return null;
+  }
+
+  /** Identify the relevant modules from the execution context. */
+  private static IModule[] asModules(LaunchHelper launcher, ExecutionEvent event)
+      throws ExecutionException {
+    // First check the current selected objects
+    ISelection selection = HandlerUtil.getCurrentSelection(event);
+    if (selection instanceof IStructuredSelection && !selection.isEmpty()) {
+      try {
+        return launcher.asModules(selection);
+      } catch (CoreException e) {
+        // ignore
+      }
+    }
+    // Check the project of the active editor.
+    IEditorPart editor = HandlerUtil.getActiveEditor(event);
+    if (editor != null) {
+      try {
+        return launcher.asModules(editor);
+      } catch (CoreException e) {
+        // ignore
+      }
+    }
+    throw new ExecutionException("Cannot determine server execution context");
+  }
+
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LocalAppEngineStandardLaunchShortcut.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LocalAppEngineStandardLaunchShortcut.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.cloud.tools.eclipse.appengine.localserver.launching;
 
@@ -27,7 +42,7 @@ public class LocalAppEngineStandardLaunchShortcut implements ILaunchShortcut2 {
       IModule[] modules = launcher.asModules(selection);
       launcher.launch(modules, launchMode);
     } catch (CoreException ex) {
-      ErrorDialog.openError(null, "Unable to launch App Engine server", ex.getLocalizedMessage(),
+      ErrorDialog.openError(null, Messages.getString("UnableToLaunch"), ex.getLocalizedMessage(), //$NON-NLS-1$
           ex.getStatus());
     }
   }
@@ -38,33 +53,31 @@ public class LocalAppEngineStandardLaunchShortcut implements ILaunchShortcut2 {
       IModule[] modules = launcher.asModules(editor);
       launcher.launch(modules, launchMode);
     } catch (CoreException ex) {
-      ErrorDialog.openError(null, "Unable to launch App Engine server", ex.getLocalizedMessage(),
+      ErrorDialog.openError(null, Messages.getString("UnableToLaunch"), ex.getLocalizedMessage(), //$NON-NLS-1$
           ex.getStatus());
     }
   }
 
   @Override
   public ILaunchConfiguration[] getLaunchConfigurations(ISelection selection) {
-    IModule[] modules = null;
     try {
-      modules = launcher.asModules(selection);
+      IModule[] modules = launcher.asModules(selection);
+      return getLaunchConfigurations(modules);
     } catch (CoreException ex) {
       // return null as we do not support these types of objects
       return null;
     }
-    return getLaunchConfigurations(modules);
   }
 
   @Override
   public ILaunchConfiguration[] getLaunchConfigurations(IEditorPart editor) {
-    IModule[] modules = null;
     try {
-      modules = launcher.asModules(editor);
+      IModule[] modules = launcher.asModules(editor);
+      return getLaunchConfigurations(modules);
     } catch (CoreException ex) {
       // return null as we do not support this type of project container
       return null;
     }
-    return getLaunchConfigurations(modules);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LocalAppEngineStandardLaunchShortcut.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LocalAppEngineStandardLaunchShortcut.java
@@ -1,0 +1,105 @@
+
+package com.google.cloud.tools.eclipse.appengine.localserver.launching;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.ILaunchShortcut2;
+import org.eclipse.jface.dialogs.ErrorDialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+
+/**
+ * Provides support for run/debug on App Engine. Some of these methods are called frequently, such
+ * as to update tooltips.
+ */
+public class LocalAppEngineStandardLaunchShortcut implements ILaunchShortcut2 {
+
+  private LaunchHelper launcher = new LaunchHelper();
+
+  @Override
+  public void launch(ISelection selection, String launchMode) {
+    try {
+      IModule[] modules = launcher.asModules(selection);
+      launcher.launch(modules, launchMode);
+    } catch (CoreException ex) {
+      ErrorDialog.openError(null, "Unable to launch App Engine server", ex.getLocalizedMessage(),
+          ex.getStatus());
+    }
+  }
+
+  @Override
+  public void launch(IEditorPart editor, String launchMode) {
+    try {
+      IModule[] modules = launcher.asModules(editor);
+      launcher.launch(modules, launchMode);
+    } catch (CoreException ex) {
+      ErrorDialog.openError(null, "Unable to launch App Engine server", ex.getLocalizedMessage(),
+          ex.getStatus());
+    }
+  }
+
+  @Override
+  public ILaunchConfiguration[] getLaunchConfigurations(ISelection selection) {
+    IModule[] modules = null;
+    try {
+      modules = launcher.asModules(selection);
+    } catch (CoreException ex) {
+      // return null as we do not support these types of objects
+      return null;
+    }
+    return getLaunchConfigurations(modules);
+  }
+
+  @Override
+  public ILaunchConfiguration[] getLaunchConfigurations(IEditorPart editor) {
+    IModule[] modules = null;
+    try {
+      modules = launcher.asModules(editor);
+    } catch (CoreException ex) {
+      // return null as we do not support this type of project container
+      return null;
+    }
+    return getLaunchConfigurations(modules);
+  }
+
+  /**
+   * Find any applicable launch configurations.
+   */
+  private ILaunchConfiguration[] getLaunchConfigurations(IModule[] modules) {
+    // First check if there's a server with exactly these modules
+    Collection<IServer> servers = launcher.findExistingServers(modules, /* exact */ true, null);
+    if (servers.isEmpty()) {
+      // otherwise check if there's a server with at least these modules
+      servers = launcher.findExistingServers(modules, /* exact */ false, null);
+    }
+    Collection<ILaunchConfiguration> launchConfigs = new ArrayList<>();
+    for (IServer server : servers) {
+      // Could filter out running servers, but then more servers are created
+      try {
+        ILaunchConfiguration launchConfig = server.getLaunchConfiguration(false, null);
+        if (launchConfig != null) {
+          launchConfigs.add(launchConfig);
+        }
+      } catch (CoreException ex) {
+        /* ignore */
+      }
+    }
+    return launchConfigs.toArray(new ILaunchConfiguration[launchConfigs.size()]);
+  }
+
+  @Override
+  public IResource getLaunchableResource(ISelection selection) {
+    return null;
+  }
+
+  @Override
+  public IResource getLaunchableResource(IEditorPart editor) {
+    return null;
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/Messages.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/Messages.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.launching;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * @author bsd
+ *
+ */
+public class Messages {
+  private static final String BUNDLE_NAME =
+      "com.google.cloud.tools.eclipse.appengine.localserver.launching.messages"; //$NON-NLS-1$
+
+  private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+  private Messages() {}
+
+  public static String getString(String key) {
+    try {
+      return RESOURCE_BUNDLE.getString(key);
+    } catch (MissingResourceException e) {
+      return '!' + key + '!';
+    }
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/messages.properties
@@ -1,0 +1,1 @@
+UnableToLaunch=Unable to launch App Engine server

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -34,13 +34,18 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
@@ -150,6 +155,23 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
 
   private static IStatus newErrorStatus(String message) {
     return new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
+  }
+
+
+  @Override
+  public void setupLaunchConfiguration(ILaunchConfigurationWorkingCopy workingCopy,
+      IProgressMonitor monitor) throws CoreException {
+    super.setupLaunchConfiguration(workingCopy, monitor);
+
+    // it seems surprising that the Server class doesn't already do this
+    Collection<IProject> projects = new ArrayList<>();
+    for (IModule module : getServer().getModules()) {
+      IProject project = module.getProject();
+      if (project != null) {
+        projects.add(project);
+      }
+    }
+    workingCopy.setMappedResources(projects.toArray(new IResource[projects.size()]));
   }
 
   private void checkAndSetPorts() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -106,6 +106,10 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
       String message = "There is no App Engine development server available";
       Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
       throw new CoreException(status);
+    } else if (server.getServerState() != IServer.STATE_STOPPED) {
+      String message = "Server is already in operation";
+      Status status = new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
+      throw new CoreException(status);
     }
     IModule[] modules = server.getModules();
     if (modules == null || modules.length == 0) {


### PR DESCRIPTION
This patch adds support for _Run As_/_Debug As_ launch shortcuts for the local App Engine development server.  Some of the text shown to the UI needs feedback/refinement.

I've backed out the menu contributions to the popup menu (which added a _Debug on App Engine_ options), but kept the launch command/handlers as they will be useful for an GPE-like toolbar drop-down.

Fixes #225

----
_Run As_/_Debug As_ from a selection of projects:
<img width="603" alt="screen shot 2016-12-16 at 3 46 05 pm" src="https://cloud.githubusercontent.com/assets/202851/21277987/c8e962ac-c3a6-11e6-9086-333065e91216.PNG">

Clicking on the _Debug_ toolbar button when selecting a project or on a file in the editor:

<img width="296" alt="screen shot 2016-12-16 at 3 44 49 pm" src="https://cloud.githubusercontent.com/assets/202851/21277941/9bf10e08-c3a6-11e6-8331-5a8bc802617a.PNG">

----

I added a check to our `LocalAppEngineServerLaunchConfigurationDelegate#launch()` to check that the server is in a stopped state to prevent double-launches.  Launching an already-running server results in an error message:
<img width="432" alt="screen shot 2016-12-16 at 3 35 14 pm" src="https://cloud.githubusercontent.com/assets/202851/21277611/4254253e-c3a5-11e6-8a88-aa6b8e780348.PNG">

----

I added some support in `LocalAppEngineServerBehaviour#setupLaunchConfiguration()` to record a the projects corresponding to the server `IModule`s.  This isn't strictly necessary as we implement `ILaunchShortcut2` (see below), but it's probably good form.

----

The launch shortcut implementation reuses existing server definitions where possible, including a server which has other modules (e.g., you select modules A and B and click _Debug As_, then we may choose a server defined with A, B, and C). Reusing existing servers is helpful as:
    1. it's confusing to have multiple servers appear, and will become more so once we support per-server parameters,
    2. It's also helpful as the Run/Debug tooltips show details about the server.
<img width="256" alt="screen shot 2016-12-16 at 3 33 49 pm" src="https://cloud.githubusercontent.com/assets/202851/21277574/10b3d15a-c3a5-11e6-8739-7d9f75aa7c1d.PNG">

----

### Background

I had to peer deeply into the launch code to understand and work around some seemingly pathological behaviour that arises from the odd relationship between WTP's `IServer` and Debug's `ILaunchConfigurations` and `ILaunch`.  `ILaunchConfiguration` normally describes *how* to launch something, and can usually be launched multiple times; each launch results in an `ILaunch` instance.  But each WTP `IServer` instance is tightly associated with a `ILaunchConfiguration` too.  So launching a server's `ILaunchConfiguration` when that server was already started elsewhere results in really strange behaviour as the server's state is changed — and thus starts or stops the previously running server.  Thus the change in `LocalAppEngineServerLaunchConfigurationDelegate#launch()` to ensure the server is not running.

The Debug Launch framework provides two interfaces to implement these _Run As_/_Debug As_ launch shortcuts: `ILaunchShortcut` and `ILaunchShortcut2`.  With plain `ILaunchShortcut`, the framework chooses an existing configuration based on the associated resources (hence the fix to `setupLaunchConfiguration()`), and the `ILaunchShortcut` is only consulted when no matching launch configuration can be found.  `ILaunchShortcut2` provides more control over how an `ILaunchConfiguration` is chosen from existing `ILaunchConfiguration`s.