### PR TITLE
Forgotten file on #1145

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -59,7 +59,7 @@ public class LaunchHelper {
       for (IServer existing : servers) {
         if (isRunning(existing)) {
           ILaunch launch = existing.getLaunch();
-          Preconditions.checkNotNull(launch, Messages.getString("RUNNING_SERVER_SHOULD_HAVE_A_LAUNCH")); //$NON-NLS-1$
+          Preconditions.checkNotNull(launch, "A running server should have a launch"); //$NON-NLS-1$
           String detail = launchMode.equals(launch.getLaunchMode()) ? Messages.getString("SERVER_ALREADY_RUNNING") //$NON-NLS-1$
               : MessageFormat.format(Messages.getString("SERVER_ALREADY_RUNNING_IN_MODE"), //$NON-NLS-1$
                   launch.getLaunchMode());


### PR DESCRIPTION
My last commit on #1145 (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/1145/commits/f306514d58a85c07c7b423390bf75912f3669b77) backed out an externalized string used in a `Preconditions` call, but neglected to commit the change to the actual `Preconditions` call.