### PR TITLE
Export Maven new project wizard help context file

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/build.properties
@@ -4,7 +4,8 @@ bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                plugin.xml,\
-               lifecycle-mapping-metadata.xml
+               lifecycle-mapping-metadata.xml,\
+               helpContexts.xml
 javacSource=1.7
 javacTarget=1.7               
 additional.bundles = org.eclipse.m2e.maven.runtime,org.eclipse.m2e.archetype.common 


### PR DESCRIPTION
Exports the necessary help context file.

The native wizard had this and was working fine, on the other hand.