### PR TITLE
Simplify code by removing StandardJobDeployJob builder

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
@@ -125,7 +125,7 @@ public class StandardDeployCommandHandler extends AbstractHandler {
     StandardDeployJobConfig config = getDeployJobConfig(project, credential,
         workDirectory, outputStream, deployConfiguration);
 
-    StandardDeployJob deploy = new StandardDeployJob.Builder().config(config).build();
+    StandardDeployJob deploy = new StandardDeployJob(config);
     messageConsole.setJob(deploy);
     deploy.addJobChangeListener(new JobChangeAdapter() {
 


### PR DESCRIPTION
No one calls `Builder.exporter()`, `Builder.staging()`, and `Builder.deployer()`, and we always use `ExplodedWarPublisher`, `StandardProjectStaging`, and `AppEngineProjectDeployer`. In fact, I think we don't even need the fields for these. Even if we may need to provide alternatives for these in the future, it could be YAGNI.

Let me know what you think.