### PR TITLE
Add "About" feature branding information

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/build.properties
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/build.properties
@@ -13,5 +13,4 @@
 #  limitations under the License.
 ############################################################################
 bin.includes = feature.xml,\
-               feature.properties,\
-               p2.inf
+               feature.properties

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -4,6 +4,7 @@
       label="Google Cloud Platform for Eclipse 4.5 and later"
       version="0.1.0.qualifier"
       provider-name="Google, Inc."
+      plugin="com.google.cloud.tools.eclipse.appengine.ui"
       license-feature="com.google.licenses.apache_v2">
 
    <description>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.ini
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.ini
@@ -1,5 +1,2 @@
 featureImage=icons/gcp-32x32.png
-aboutText=Google Cloud Tools for Eclipse\n\
-\n\
-Cloud Tools for Eclipse is a Google-sponsored plugin that adds \
-support for the App Engine standard environment to the Eclipse IDE.
+aboutText=%blurb

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.ini
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.ini
@@ -1,0 +1,5 @@
+featureImage=icons/gcp-32x32.png
+aboutText=Google Cloud Tools for Eclipse\n\
+\n\
+Cloud Tools for Eclipse is a Google-sponsored plugin that adds \
+support for the App Engine standard environment to the Eclipse IDE.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/about.properties
@@ -1,0 +1,8 @@
+blurb=Google Cloud Tools for Eclipse\n\
+Version: {featureVersion}\n\
+\n\
+Copyright 2016-2017 Google Inc.\n\
+\n\
+Cloud Tools for Eclipse is a Google-sponsored plugin that adds \
+support for the App Engine standard environment to the Eclipse IDE.\n\
+Visit: https://cloud.google.com/eclipse

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/build.properties
@@ -4,6 +4,7 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties,\
-               icons/
+               icons/,\
+               about.ini
 javacSource=1.7
 javacTarget=1.7               

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/build.properties
@@ -5,6 +5,7 @@ bin.includes = META-INF/,\
                plugin.xml,\
                plugin.properties,\
                icons/,\
-               about.ini
+               about.ini,\
+               about.properties
 javacSource=1.7
 javacTarget=1.7               


### PR DESCRIPTION
Cause `com.google.cloud.tools.eclipse.appengine.ui` to be a _branding plugin_ for CTE, to contribute to the _About_ dialog.  Although this doesn't seem the best bundle to use, I used it as it's the bundle that's hosting our images.

The use of an `about.properties` is required for the `{featureVersion}` substitution to be performed.

<img width="931" alt="screen shot 2017-01-13 at 11 40 14 pm" src="https://cloud.githubusercontent.com/assets/202851/21952415/c0b26512-d9e9-11e6-8f5e-d8ba08b9f8ec.PNG">
