### PR TITLE
Quieten Maven builds by specifying a logback configuration for tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
@@ -35,6 +35,11 @@
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
                 <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
@@ -31,6 +31,11 @@
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
                 <type>eclipse-feature</type>
                 <id>org.eclipse.jdt</id>
                 <versionRange>0.0.0</versionRange>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
@@ -35,6 +35,11 @@
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
                 <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
@@ -33,6 +33,11 @@
                 <id>ch.qos.logback.slf4j</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
@@ -41,6 +41,11 @@
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
                 <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
@@ -40,6 +40,11 @@
                 <id>ch.qos.logback.slf4j</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/.project
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.google.cloud.tools.eclipse.test.logback</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.logback
+Bundle-Version: 0.1.0.qualifier
+Fragment-Host: ch.qos.logback.classic
+Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ActivationPolicy: lazy
+Import-Package: org.slf4j.impl
+Eclipse-ExtensibleAPI: true
+Eclipse-BundleShape: dir

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
@@ -9,5 +9,4 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: org.slf4j.impl
-Eclipse-ExtensibleAPI: true
 Eclipse-BundleShape: dir

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.logback
+Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.logback;singleton:=true
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: ch.qos.logback.classic
 Bundle-Vendor: %providerName

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/build.properties
@@ -1,0 +1,8 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               logback.xml,\
+               plugin.properties
+javacSource=1.7
+javacTarget=1.7

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/logback.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/logback.xml
@@ -1,0 +1,12 @@
+<configuration scan="true"> 
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"> 
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.google.cloud.tools" level="debug"/>
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/plugin.properties
@@ -1,0 +1,2 @@
+pluginName=Cloud Tools for Eclipse Logback logging for tests
+providerName=Google Inc.

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>com.google.cloud.tools.eclipse.test.logback</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/plugins/com.google.cloud.tools.eclipse.util.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/pom.xml
@@ -30,6 +30,11 @@
                 <id>ch.qos.logback.slf4j</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>com.google.cloud.tools.eclipse.test.logback</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>plugins/com.google.cloud.tools.eclipse.sdk.ui.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.test.dependencies</module>
     <module>plugins/com.google.cloud.tools.eclipse.test.util</module>
+    <module>plugins/com.google.cloud.tools.eclipse.test.logback</module>
     <module>plugins/com.google.cloud.tools.eclipse.usagetracker</module>
     <module>plugins/com.google.cloud.tools.eclipse.usagetracker.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.ui.util</module>


### PR DESCRIPTION
Although bringing in Logback for the tests (#1143) did rid us of the SLF4j errors (#263), the cure was worse than the disease as Logback's [default configuration logs at the `DEBUG` level](http://logback.qos.ch/manual/configuration.html#automaticConf), and our logs are now clogged with m2e-related `DEBUG`-level detail.  This patch creates a new fragment, `com.google.cloud.tools.eclipse.test.logback`, hosted against `ch.qos.logback.classic`, that provides a `logback.xml` configuration file that sets the default logging level to `INFO`.

Logback can be configured either by setting system property to point to a `logback.xml`, or by finding the file on its classpath.  Maven doesn't provide a way to easily reference a file (requires using the _assembly_ plugin or something).  We could configure .travis.yml to reference a file, but we'd need to specify it when building locally too.

We could simplify the setup slightly by having a feature that pulls in `ch.qos.logback.slf4j` (the SLF4j binding configuration), `ch.qos.logback.classic`, and this new `com.google.cloud.tools.eclipse.test.logback` bundle, so that the test `pom.xml`s specify the feature rather than 2 plugins.  As this is a build-time testing issue, it doesn't seem much of a win.

### Asides ###

We must use SLF4j from Orbit as M2Eclipse explicitly pulls in Orbit's SLF4j by a `Require-Bundle: org.sfl4j.api`; SLF4j has since added OSGi metadata but unfortunately chose to name its bundle `slf4j.api`.  Orbit only provides SLF4j logging bindings for Logback and _log4j 1.2_; the `org.slf4j.jul`, `org.slf4j.jcl`, and `org.slf4j.log4j` bundles are logging facades.

Using _log4j 1.2_ without a configuration it produces similar output to #263, and so would also require a configuration fragment.
```
log4j:WARN No appenders could be found for logger (org.eclipse.m2e.core.internal.project.registry.ProjectRegistryRefreshJob).
log4j:WARN Please initialize the log4j system properly.
```
Since this is a build-time test-only issue anyways, and since log4j 1.2 is ancient, we'll just stay with Logback. 