### PR TITLE
Fix input field length in native wizard

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineStandardWizardPage.java
@@ -80,7 +80,8 @@ public class AppEngineStandardWizardPage extends WizardNewProjectCreationPage {
 
   private void createCustomFields(Composite container, ModifyListener pageValidator) {
     Composite composite = new Composite(container, SWT.NONE);
-    
+    GridDataFactory.fillDefaults().applyTo(composite);
+
     GridLayout layout = new GridLayout();
     layout.numColumns = 2;
     composite.setLayout(layout);


### PR DESCRIPTION
The problem started with #1240, when the line was removed (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/1240#discussion_r96426626). I believe the removed line was setting `GridData` and not `GridLayout`, so it is necessary.