### PR TITLE
Verify if jars are all signed

### DIFF
--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -53,7 +53,8 @@ echo "#"
 
 echo -n "Enter GCS bucket URL taken from the Kokoro page: "
 read GCS_URL
-GCS_BUCKET_URL=$( echo $GCS_URL | sed -e 's,.*\(signedjars/staging/prod/google-cloud-eclipse/ubuntu/release/[0-9]\+/[0-9-]\+\),\1,' )
+GCS_BUCKET_URL=$( echo $GCS_URL | \
+    sed -e 's,.*\(signedjars/staging/prod/google-cloud-eclipse/ubuntu/release/[0-9]\+/[0-9-]\+\),\1,' )
 echo "GCS URL extracted: $GCS_BUCKET_URL"
 echo -n "Check if the URL is correct. "
 ask_proceed
@@ -73,12 +74,12 @@ echo "#"
 echo "# Now verifying whether jars are all signed."
 echo "#"
 for jar in $SIGNED_DIR/plugins/com.google.cloud.tools.eclipse.*.jar \
-		$SIGNED_DIR/features/com.google.cloud.tools.eclipse.*.jar; do
+        $SIGNED_DIR/features/com.google.cloud.tools.eclipse.*.jar; do
     echo -n "$( basename $jar ): "
-	if ! jarsigner -strict -verify $jar; then
+    if ! jarsigner -strict -verify $jar; then
         echo "unsigned artifact. Halting."
         exit 1
-	fi
+    fi
 done
 
 ###############################################################################
@@ -90,18 +91,18 @@ ask_proceed
 
 LOGIN_CONSTANTS=$( javap -private -classpath \
     $SIGNED_DIR/plugins/com.google.cloud.tools.eclipse.appengine.login_*.jar \
-    -constants com.google.cloud.tools.eclipse.appengine.login.Constants \
-    | grep OAUTH_CLIENT_ )
+    -constants com.google.cloud.tools.eclipse.appengine.login.Constants | \
+    grep OAUTH_CLIENT_ )
 ANALYTICS_CONSTANT=$( javap -classpath \
     $SIGNED_DIR/plugins/com.google.cloud.tools.eclipse.usagetracker_*.jar \
-    -constants com.google.cloud.tools.eclipse.usagetracker.Constants \
-    | grep ANALYTICS_TRACKING_ID )
+    -constants com.google.cloud.tools.eclipse.usagetracker.Constants | \
+    grep ANALYTICS_TRACKING_ID )
 echo -e "$LOGIN_CONSTANTS\n$ANALYTICS_CONSTANT"
 
 if echo -e "$LOGIN_CONSTANTS\n$ANALYTICS_CONSTANT" | \
         grep -q '@oauth.client\|@ga.tracking.id@'; then
-	echo "Some constant(s) have not been injected. Halting."
-	exit 1
+    echo "Some constant(s) have not been injected. Halting."
+    exit 1
 fi
 
 echo

--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -99,9 +99,28 @@ ANALYTICS_CONSTANT=$( javap -classpath \
     grep ANALYTICS_TRACKING_ID )
 echo -e "$LOGIN_CONSTANTS\n$ANALYTICS_CONSTANT"
 
+# Verify if the constants have been injected.
 if echo -e "$LOGIN_CONSTANTS\n$ANALYTICS_CONSTANT" | \
         grep -q '@oauth.client\|@ga.tracking.id@'; then
     echo "Some constant(s) have not been injected. Halting."
+    exit 1
+fi
+
+# Verify if the injected constants have the right lengths.
+OAUTH_CLIENT_ID=$( echo "$LOGIN_CONSTANTS" | grep "OAUTH_CLIENT_ID" | \
+    sed -e 's/.* = "\(.*\)"; */\1/' )
+OAUTH_CLIENT_SECRET=$( echo "$LOGIN_CONSTANTS" | grep "OAUTH_CLIENT_SECRET" | \
+    sed -e 's/.* = "\(.*\)"; */\1/' )
+ANALYTICS_TRACKING_ID=$( echo "$ANALYTICS_CONSTANT" | \
+    sed -e 's/.* = "\(.*\)"; */\1/' )
+if [ ${#OAUTH_CLIENT_ID} -ne 72 ]; then
+    echo "The length of injected OAUTH_CLIENT_ID is not 72. Halting."
+    exit 1
+elif [ ${#OAUTH_CLIENT_SECRET} -ne 24 ]; then
+    echo "The length of injected OAUTH_CLIENT_SECRET is not 24. Halting."
+    exit 1
+elif [ ${#ANALYTICS_TRACKING_ID} -ne 13 ]; then
+    echo "The length of injected ANALYTICS_TRACKING_ID is not 13. Halting."
     exit 1
 fi
 

--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -114,11 +114,11 @@ OAUTH_CLIENT_SECRET=$( echo "$LOGIN_CONSTANTS" | grep "OAUTH_CLIENT_SECRET" | \
 ANALYTICS_TRACKING_ID=$( echo "$ANALYTICS_CONSTANT" | \
     sed -e 's/.* = "\(.*\)"; */\1/' )
 [ ${#OAUTH_CLIENT_ID} -ne 72 ] && \
-    die "OAUTH_CLIENT_ID is not 72. Halting."
+    die "OAUTH_CLIENT_ID is not of length 72. Halting."
 [ ${#OAUTH_CLIENT_SECRET} -ne 24 ] && \
-    die "The length of injected OAUTH_CLIENT_SECRET is not 24. Halting."
+    die "OAUTH_CLIENT_SECRET is not of length 24. Halting."
 [ ${#ANALYTICS_TRACKING_ID} -ne 13 ] && \
-    die "The length of injected ANALYTICS_TRACKING_ID is not 13. Halting."
+    die "ANALYTICS_TRACKING_ID is not of length 13. Halting."
 
 echo
 echo -n "Looks good, but check the output above once more. "

--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -80,7 +80,7 @@ for jar in $SIGNED_DIR/plugins/com.google.cloud.tools.eclipse.*.jar \
         $SIGNED_DIR/features/com.google.cloud.tools.eclipse.*.jar; do
     echo -n "$( basename $jar ): "
     if ! jarsigner -strict -verify $jar; then
-        die "unsigned artifact. Halting."
+        die "Unsigned artifact found. Halting."
     fi
 done
 

--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -102,7 +102,7 @@ ANALYTICS_CONSTANT=$( javap -classpath \
 echo -e "$LOGIN_CONSTANTS\n$ANALYTICS_CONSTANT"
 
 # Verify if the constants have been injected.
-if [[ "${LOGIN_CONSTANTS}${ANALYTICS_CONSTANT}" =~ "@" ]]; then
+if echo "${LOGIN_CONSTANTS}${ANALYTICS_CONSTANT}" | grep -q @; then
     die "Some constant(s) have not been injected. Halting."
 fi
 


### PR DESCRIPTION
Part of #1253. I noticed verifying jars takes quite some time, so I decided to let `jarsigner` print verification results.

I also automated verification of constant injection.
 
Output looks like below:

```
Operation completed over 29 objects/6.4 MiB.
+ set +x
#
# Now verifying whether jars are all signed.
#
com.google.cloud.tools.eclipse.appengine.deploy_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.deploy.ui_0.1.0.201701161800.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.facets_0.1.0.201701112147.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.libraries_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.localserver_0.1.0.201701112147.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.login_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.newproject_0.1.0.201701081354.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.newproject.maven_0.1.0.201701081354.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.ui_0.1.0.201701160540.jar: jar verified.
com.google.cloud.tools.eclipse.appengine.whitelist_0.1.0.201610241636.jar: jar verified.
com.google.cloud.tools.eclipse.jdt.launching_0.1.0.201610262044.jar: jar verified.
com.google.cloud.tools.eclipse.jst.server.core_0.1.0.201611181529.jar: jar verified.
com.google.cloud.tools.eclipse.preferences_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.sdk_0.1.0.201701112147.jar: jar verified.
com.google.cloud.tools.eclipse.sdk.ui_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.ui.util_0.1.0.201701111857.jar: jar verified.
com.google.cloud.tools.eclipse.usagetracker_0.1.0.201701132149.jar: jar verified.
com.google.cloud.tools.eclipse.util_0.1.0.201701122020.jar: jar verified.
com.google.cloud.tools.eclipse.welcome_0.1.0.201701171430.jar: jar verified.
com.google.cloud.tools.eclipse.3rdparty.feature_0.1.0.201612060008.jar: jar verified.
com.google.cloud.tools.eclipse.suite.e45.feature_0.1.0.201701171430.jar: jar verified.

#
# Verify if constants have been injected...
#
Proceed ([Y]/n)? 
  private static final java.lang.String OAUTH_CLIENT_ID = "... redacted ....";
  private static final java.lang.String OAUTH_CLIENT_SECRET = "... redacted ...";
  public static final java.lang.String ANALYTICS_TRACKING_ID = "... redacted ...;

Looks good, but check the output above once more. Proceed ([Y]/n)? 
```