### PR TITLE
Feature advice must include p2.inf

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/build.properties
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/build.properties
@@ -13,4 +13,5 @@
 #  limitations under the License.
 ############################################################################
 bin.includes = feature.xml,\
-               feature.properties
+               feature.properties,\
+               p2.inf


### PR DESCRIPTION
Fixes #1246 by including the `.suite` feature's `p2.inf` once again.