### PR TITLE
avoid build problems in eclipse

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.logback/src/README.txt
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/src/README.txt
@@ -1,0 +1,3 @@
+Hack to avoid occasional build errors in Eclipse since this bundle
+doesn't contain any Java code but still needs a src folder which git
+won't track when empty.

--- a/plugins/com.google.cloud.tools.eclipse.test.logback/src/README.txt
+++ b/plugins/com.google.cloud.tools.eclipse.test.logback/src/README.txt
@@ -1,3 +1,0 @@
-Hack to avoid occasional build errors in Eclipse since this bundle
-doesn't contain any Java code but still needs a src folder which git
-won't track when empty.


### PR DESCRIPTION
@briandealwis Hack to avoid occasional build errors in Eclipse since welcome doesn't contain any Java code. 

Description	Resource	Path	Location	Type
Project 'com.google.cloud.tools.eclipse.welcome' is missing required source folder: 'src'	com.google.cloud.tools.eclipse.welcome		Build path	Build Path Problem
