### PR TITLE
Elimiate "Event Admin service" test output clutters

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.ui
 Require-Bundle: org.junit,
+ org.eclipse.equinox.event,
  org.eclipse.equinox.registry
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.ui,


### PR DESCRIPTION
Fixes #1105. Now it's not happening.