### PR TITLE
Update gcp-repo's index.html to point to cloud.google.com

### DIFF
--- a/gcp-repo/src/main/resources/index.html
+++ b/gcp-repo/src/main/resources/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
 <title>Cloud Tools for Eclipse p2 repository</title>
-<meta http-equiv="Refresh" content="0; url=https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">
+<meta http-equiv="Refresh" content="0; url=https://cloud.google.com/eclipse/docs/">
 </head>
 
 <body>
 <p>This is a p2 repository for the Google Cloud Tools for Eclipse.
 Please see the <a
-href="https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Installation-and-setup">instructions</a>
+href="https://cloud.google.com/eclipse/docs/">instructions</a>
 for configuring your Eclipse.</p>
 </body>
 </html>


### PR DESCRIPTION
Change our `index.html` from pointing at our GitHub wiki to _cloud.google.com/eclipse/docs_