### PR TITLE
Fix project name for plugins/com.google.cloud.tools.eclipse.sdk.ui.test

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/.project
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.google.cloud.tools.eclipse.util.test</name>
+	<name>com.google.cloud.tools.eclipse.sdk.ui.test</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
Current shows `com.google.cloud.tools.eclipse.util.test`.