### PR TITLE
Ensure `org.eclipse.rcp` feature is on workbench-related tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
@@ -41,6 +41,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
@@ -41,6 +41,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.newproject.maven
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.equinox.event,
  org.eclipse.equinox.registry,
  org.hamcrest;bundle-version="1.1.0"
 Import-Package: com.google.cloud.tools.eclipse.test.util,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
@@ -38,6 +38,11 @@
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
@@ -47,6 +47,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
                 <id>org.eclipse.m2e.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/pom.xml
@@ -24,6 +24,21 @@
           <product>org.eclipse.platform.ide</product>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
@@ -45,6 +45,11 @@
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/.project
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.google.cloud.tools.eclipse.util.test</name>
+	<name>com.google.cloud.tools.eclipse.sdk.ui.test</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
Ensure that tests requiring the Workbench (_useUIHarness=true_) pull in the `org.eclipse.rcp` feature. 
Fixes #1105 