### PR TITLE
Pull in the lof4j -> slf4j facade for tests

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -30,4 +30,5 @@
    <bundle id="com.google.cloud.tools.appengine" version="0.0.0"/>
    <bundle id="jackson-core-asl" version="1.9.13"/>
    <bundle id="ch.qos.logback.slf4j" version="0.0.0"/>
+   <bundle id="org.slf4j.log4j" version="0.0.0"/>
 </site>

--- a/eclipse/mars/gcp-eclipse-mars.target
+++ b/eclipse/mars/gcp-eclipse-mars.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Mars" sequenceNumber="1481947585">
+<target name="GCP for Eclipse Mars" sequenceNumber="1485456851">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
@@ -22,7 +22,6 @@
       <unit id="org.eclipse.jetty.servlet" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.server" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.util" version="9.2.13.v20150730"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
       <repository location="http://download.eclipse.org/releases/mars/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -36,6 +35,8 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
     </location>
   </locations>

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -34,8 +34,6 @@ location "http://download.eclipse.org/releases/mars/" {
 	org.eclipse.jetty.servlet
 	org.eclipse.jetty.server
 	org.eclipse.jetty.util
-	
-	ch.qos.logback.slf4j
 }
 
 location "http://download.eclipse.org/webtools/repository/mars/" {
@@ -49,4 +47,6 @@ location "http://download.eclipse.org/webtools/repository/mars/" {
 
 location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/" {
 	org.hamcrest
+	ch.qos.logback.slf4j
+	org.slf4j.log4j
 }

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1481947578">
+<target name="GCP for Eclipse Neon" sequenceNumber="1485456840">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.6.1.v20160907-1200"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.12.1.v20160907-1200"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.6.2.v20161124-1529"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.12.2.v20161124-1400"/>
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160603-1933"/>
       <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.7.0.20160603-1933"/>
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.1.20160831-1005"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.1.20160831-1005"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.20.0.v20160421-1819"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.21.0.v20160707-1856"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.13.0.201603142002"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
@@ -22,7 +22,6 @@
       <unit id="org.eclipse.jetty.servlet" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.server" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.util" version="9.3.9.v20160517"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
       <repository location="http://download.eclipse.org/releases/neon"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -36,6 +35,8 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
     </location>
   </locations>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -31,8 +31,6 @@ location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.jetty.servlet
 	org.eclipse.jetty.server
 	org.eclipse.jetty.util
-	
-	ch.qos.logback.slf4j
 }
 
 // /webtools/repository/neon currently has some issues
@@ -48,4 +46,6 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.8.0/R-3.8.0-20
 
 location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/" {
     org.hamcrest
+	ch.qos.logback.slf4j
+	org.slf4j.log4j
 }

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1481947569">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1485456836">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
@@ -22,7 +22,6 @@
       <unit id="org.eclipse.jetty.servlet" version="9.3.14.v20161028"/>
       <unit id="org.eclipse.jetty.server" version="9.3.14.v20161028"/>
       <unit id="org.eclipse.jetty.util" version="9.3.14.v20161028"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
       <repository location="http://download.eclipse.org/releases/oxygen"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -36,6 +35,8 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
     </location>
   </locations>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -31,8 +31,6 @@ location "http://download.eclipse.org/releases/oxygen" {
 	org.eclipse.jetty.servlet
 	org.eclipse.jetty.server
 	org.eclipse.jetty.util
-	
-	ch.qos.logback.slf4j
 }
 
 // /webtools/repository/oxygen currently has some issues
@@ -48,4 +46,6 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M2-
 
 location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/" {
     org.hamcrest
+	ch.qos.logback.slf4j
+	org.slf4j.log4j
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/pom.xml
@@ -36,6 +36,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
@@ -32,6 +32,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/pom.xml
@@ -36,6 +36,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/pom.xml
@@ -35,6 +35,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/pom.xml
@@ -42,6 +42,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
@@ -42,6 +42,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>

--- a/plugins/com.google.cloud.tools.eclipse.util.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/pom.xml
@@ -32,6 +32,11 @@
               </requirement>
               <requirement>
                 <type>eclipse-plugin</type>
+                <id>org.slf4j.log4j</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
                 <id>com.google.cloud.tools.eclipse.test.logback</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>


### PR DESCRIPTION
Pull in the log4j facade for slf4j, confusingly named `org.slf4j.log4j` in Eclipse Orbit.  We need the version from Orbit as m2e pulls in the SLF4j bundle from Orbit.  `org.slf4j.log4j` is only used in tests.

Fixes #1290