### PR TITLE
Get tests working on Windows 10

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -178,7 +178,7 @@ public class LibraryClasspathContainerInitializerTest {
     testProject.getJavaProject().getRawClasspath();
     IClasspathEntry[] resolvedClasspath = testProject.getJavaProject().getResolvedClasspath(false);
     assertThat(resolvedClasspath.length, is(2));
-    assertThat(resolvedClasspath[1].getPath().toString(), is(artifactFile.getAbsolutePath()));
+    assertThat(resolvedClasspath[1].getPath().toOSString(), is(artifactFile.getAbsolutePath()));
     verifyContainerWasNotResolvedFromScratch();
   }
 
@@ -201,8 +201,8 @@ public class LibraryClasspathContainerInitializerTest {
     testProject.getJavaProject().getRawClasspath();
     IClasspathEntry[] resolvedClasspath = testProject.getJavaProject().getResolvedClasspath(false);
     assertThat(resolvedClasspath.length, is(2));
-    assertThat(resolvedClasspath[1].getPath().toString(), is(artifactFile.getAbsolutePath()));
-    assertThat(resolvedClasspath[1].getSourceAttachmentPath().toString(),
+    assertThat(resolvedClasspath[1].getPath().toOSString(), is(artifactFile.getAbsolutePath()));
+    assertThat(resolvedClasspath[1].getSourceAttachmentPath().toOSString(),
                is(sourceArtifactFile.getAbsolutePath()));
     verifyContainerWasNotResolvedFromScratch();
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryTest.java
@@ -50,7 +50,7 @@ public class LibraryTest {
   @Test
   public void testGetContainerPath() {
     Library library = new Library("a");
-    assertThat(library.getContainerPath().toOSString(),
+    assertThat(library.getContainerPath().toString(),
                is("com.google.cloud.tools.eclipse.appengine.libraries" + "/" + "a"));
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableClasspathEntry.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableClasspathEntry.java
@@ -92,7 +92,7 @@ public class SerializableClasspathEntry {
     if (sourceAttachmentPath == null) {
       this.sourceAttachmentPath = "";
     } else {
-      this.sourceAttachmentPath = sourceAttachmentPath.toOSString();
+      this.sourceAttachmentPath = sourceAttachmentPath.toString();
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
@@ -32,7 +32,7 @@ public class SerializableLibraryClasspathContainer {
 
   public SerializableLibraryClasspathContainer(LibraryClasspathContainer container, IPath baseDirectory, IPath sourceBaseDirectory) {
     description = container.getDescription();
-    path = container.getPath().toOSString();
+    path = container.getPath().toString();
     IClasspathEntry[] classpathEntries = container.getClasspathEntries();
     entries = new SerializableClasspathEntry[classpathEntries.length];
     for (int i = 0; i < classpathEntries.length; i++) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProviderTest.java
@@ -58,8 +58,8 @@ public class ServletClasspathProviderTest {
   @Test
   public void testResolveClasspathContainer() {
     IClasspathEntry[] result = provider.resolveClasspathContainer(null, null);
-    Assert.assertTrue(result[0].getPath().toString().endsWith("servlet-api.jar"));
-    Assert.assertTrue(result[1].getPath().toString().endsWith("jsp-api.jar"));
+    Assert.assertTrue(result[0].getPath().lastSegment().equals("servlet-api.jar"));
+    Assert.assertTrue(result[1].getPath().lastSegment().equals("jsp-api.jar"));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPageTest.java
@@ -54,7 +54,7 @@ public class MavenAppEngineStandardWizardPageTest {
     assertTrue(page.useDefaults());
     assertTrue(page.useDefaults.getSelection());
     assertFalse(page.locationField.getEnabled());
-    assertEquals("/default/workspace/location", page.locationField.getText());
+    assertEquals(new Path("/default/workspace/location").toOSString(), page.locationField.getText());
     assertEquals("", page.locationField.getData());
 
     assertEquals("/default/workspace/location", page.getLocationPath().toString());
@@ -82,7 +82,7 @@ public class MavenAppEngineStandardWizardPageTest {
     assertTrue(page.useDefaults());
     assertTrue(page.useDefaults.getSelection());
     assertFalse(page.locationField.getEnabled());
-    assertEquals("/default/workspace/location", page.locationField.getText());
+    assertEquals(new Path("/default/workspace/location").toOSString(), page.locationField.getText());
     assertEquals("", page.locationField.getData());
 
     assertEquals("/default/workspace/location", page.getLocationPath().toString());
@@ -95,7 +95,7 @@ public class MavenAppEngineStandardWizardPageTest {
     page.locationField.setText("/manually/entered/path");
     checkBox.click();
 
-    assertEquals("/default/workspace/location", page.locationField.getText());
+    assertEquals(new Path("/default/workspace/location").toOSString(), page.locationField.getText());
     assertEquals("/manually/entered/path", page.locationField.getData());
 
     assertEquals("/default/workspace/location", page.getLocationPath().toString());
@@ -112,6 +112,6 @@ public class MavenAppEngineStandardWizardPageTest {
     assertEquals("/manually/entered/path", page.locationField.getText());
     assertEquals("/manually/entered/path", page.locationField.getData());
 
-    assertEquals("/manually/entered/path", page.getLocationPath().toOSString());
+    assertEquals("/manually/entered/path", page.getLocationPath().toString());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkPreferenceAreaTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkPreferenceAreaTest.java
@@ -71,16 +71,22 @@ public class CloudSdkPreferenceAreaTest {
   public void testInvalidPath() {
     when(preferences.getString(anyString())).thenReturn(null);
 
-    File[] roots = File.listRoots();
-    assertTrue("No root directory!?", roots.length > 0);
+    File root = null;
+    for(File r : File.listRoots()) {
+      if(r.exists()) {
+        // must check as roots includes A: on Windows for the floppy
+        root = r;
+      }
+    }
+    assertTrue("No root directory!?", root.exists());
     // root should exist but not contain a valid Cloud SDK
 
     show();
-    area.setStringValue(roots[0].getAbsolutePath());
+    area.setStringValue(root.getAbsolutePath());
     assertEquals(IStatus.WARNING, area.getStatus().getSeverity());
     
     area.setStringValue("");
-    assertEquals(IStatus.OK, area.getStatus().getSeverity());    
+    assertEquals(IStatus.OK, area.getStatus().getSeverity());
   }
 
   private void show() {

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/META-INF/MANIFEST.MF
@@ -17,4 +17,5 @@ Export-Package: com.google.cloud.tools.eclipse.swtbot;
    org.eclipse.swtbot.eclipse.finder,
    org.eclipse.swtbot.eclipse.finder.widgets,
    org.eclipse.swtbot.swt.finder"
-Import-Package: com.google.common.base;version="[20.0.0,21.0.0)"
+Import-Package: com.google.common.base;version="[20.0.0,21.0.0)",
+ org.eclipse.wst.validation

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotWorkbenchActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotWorkbenchActions.java
@@ -29,6 +29,7 @@ import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.waits.ICondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
+import org.eclipse.wst.validation.ValidationFramework;
 import org.hamcrest.Matcher;
 
 /**
@@ -70,6 +71,12 @@ public final class SwtBotWorkbenchActions {
       try {
         Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
         Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+        // J2EEElementChangedListener.PROJECT_COMPONENT_UPDATE_JOB_FAMILY
+        Job.getJobManager().join("org.eclipse.jst.j2ee.refactor.component", null);
+        // ServerPlugin.SHUTDOWN_JOB_FAMILY
+        Job.getJobManager().join("org.eclipse.wst.server.core.family", null);
+        Job.getJobManager().join("org.eclipse.wst.server.ui.family", null);
+        ValidationFramework.getDefault().join(null);
       } catch (InterruptedException ex) {
         // interruption likely happened for a reason
         return;

--- a/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
@@ -31,6 +31,7 @@ Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  org.eclipse.wst.common.project.facet.core.internal,
  org.eclipse.wst.common.project.facet.core.util.internal,
  org.eclipse.wst.server.core,
+ org.eclipse.wst.validation,
  org.mockito;provider=google;version="1.10.19",
  org.mockito.stubbing;provider=google;version="1.10.19",
  org.osgi.framework;version="1.8.0"

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.eclipse.test.util.project;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.base.Joiner;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -29,6 +28,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -45,8 +45,11 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.wst.common.project.facet.core.util.internal.ZipUtil;
+import org.eclipse.wst.validation.ValidationFramework;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
+
+import com.google.common.base.Joiner;
 
 /**
  * A set of utility methods for dealing with projects.
@@ -165,6 +168,12 @@ public class ProjectUtils {
       do {
         Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
         Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+        // J2EEElementChangedListener.PROJECT_COMPONENT_UPDATE_JOB_FAMILY
+        Job.getJobManager().join("org.eclipse.jst.j2ee.refactor.component", null);
+        // ServerPlugin.SHUTDOWN_JOB_FAMILY
+        Job.getJobManager().join("org.eclipse.wst.server.core.family", null);
+        Job.getJobManager().join("org.eclipse.wst.server.ui.family", null);
+        ValidationFramework.getDefault().join(null);
 
         Display display = Display.getCurrent();
         if (display != null) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import com.google.common.base.Joiner;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -48,8 +49,6 @@ import org.eclipse.wst.common.project.facet.core.util.internal.ZipUtil;
 import org.eclipse.wst.validation.ValidationFramework;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-
-import com.google.common.base.Joiner;
 
 /**
  * A set of utility methods for dealing with projects.


### PR DESCRIPTION
Assorted fixes to enable tests to pass on Windows 10:
  - a few path comparisons were being done with `IPath.toOSString()` and so messing up `\` with `/`
  - Cloud SDK tests used `Files.listRoots()[0]` to obtain a root directory, which is `A:` on Windows, the floppy drive
  - Integration tests failing due to files still being written to after deletion.  Enhance test utility classes `SwtBotWorkbenchActions#waitForIdle()` and `ProjectUtils#waitForIdle()` to join to as many WTP job families as I could find.  It's possible the `ValidationFramework` jobs are the only ones we really need to wait for, but the rest cannot hurt.

Fixes #841 