### PR TITLE
Fix compilation errors in .appengine.compat and .test.util

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigratorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigratorTest.java
@@ -41,7 +41,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
-import org.eclipse.wst.common.project.facet.core.internal.FacetedProject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,7 +99,7 @@ public class GpeMigratorTest {
   @Test
   public void testRemoveGpeRuntimeAndFacets_doNotLogIfMetadataFileDoesNotExist()
       throws CoreException {
-    IFile metadataFile = gpeProject.getFile(FacetedProject.METADATA_FILE);
+    IFile metadataFile = gpeProject.getFile(GpeMigrator.FACETS_METADATA_FILE);
     metadataFile.delete(true, null);
     assertFalse(metadataFile.exists());
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigrator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigrator.java
@@ -47,7 +47,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
-import org.eclipse.wst.common.project.facet.core.internal.FacetedProject;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -64,6 +63,10 @@ public class GpeMigrator {
   private static final String GPE_GAE_NATURE_ID = "com.google.appengine.eclipse.core.gaeNature";
 
   private static final String WTP_METADATA_XSLT = "/xslt/wtpMetadata.xsl";
+
+  // FacetedProject.METADATA_FILE = ".settings/" + FacetCorePlugin.PLUGIN_ID + ".xml";
+  @VisibleForTesting
+  static final String FACETS_METADATA_FILE = ".settings/org.eclipse.wst.common.component.xml";
 
   /**
    * Removes various GPE-related remnants: classpath entries, nature, runtime, and facets. Any
@@ -118,7 +121,7 @@ public class GpeMigrator {
   static void removeGpeRuntimeAndFacets(IFacetedProject facetedProject, Logger logger) {
     // To remove the facets, we will directly modify the WTP facet metadata file (using XSLT):
     // .settings/org.eclipse.wst.common.project.facet.core.xml
-    IFile metadataFile = facetedProject.getProject().getFile(FacetedProject.METADATA_FILE);
+    IFile metadataFile = facetedProject.getProject().getFile(FACETS_METADATA_FILE);
     if (!metadataFile.exists()) {
       return;
     }

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/NatureUtilsTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/NatureUtilsTest.java
@@ -22,23 +22,25 @@ import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.wst.common.project.facet.core.internal.FacetedProjectNature;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class NatureUtilsTest {
 
+  // FacetedProjectNature.NATURE_ID = FacetCorePlugin.PLUGIN_ID + ".nature"
+  private static final String FACETED_NATURE_ID =
+      "org.eclipse.wst.common.project.facet.core.nature";
   @Rule public final TestProjectCreator projectCreator = new TestProjectCreator();
 
   @Test
   public void testRemoveNature() throws CoreException {
     IProject project = projectCreator.getProject();
     // By default, project has Java nature and faceted project nature.
-    assertArrayEquals(new String[]{JavaCore.NATURE_ID, FacetedProjectNature.NATURE_ID},
+    assertArrayEquals(new String[] {JavaCore.NATURE_ID, FACETED_NATURE_ID},
         project.getDescription().getNatureIds());
 
     NatureUtils.removeNature(project, JavaCore.NATURE_ID);
-    assertArrayEquals(new String[]{FacetedProjectNature.NATURE_ID},
+    assertArrayEquals(new String[] {FACETED_NATURE_ID},
         project.getDescription().getNatureIds());
   }
 
@@ -48,7 +50,7 @@ public class NatureUtilsTest {
     NatureUtils.removeNature(project, JavaCore.NATURE_ID);
 
     NatureUtils.removeNature(project, JavaCore.NATURE_ID);
-    assertArrayEquals(new String[]{FacetedProjectNature.NATURE_ID},
+    assertArrayEquals(new String[] {FACETED_NATURE_ID},
         project.getDescription().getNatureIds());
   }
 }


### PR DESCRIPTION
I'm seeing reference errors in my Eclipse as `GpeMigrator` and `NatureUtils` are referencing `FacetedProject.METADATA_FILE` and
`FacetedProjectNature.NATURE_ID` but are not importing
`org.eclipse.wst.common.project.facet.core.internal`.

Not sure why this isn't causing errors in the Travis build.  I do see testing errors in my local build, though it didn't fail the compilation process.