### PR TITLE
Add "Accounts" section to the GCP toolbar

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
@@ -92,6 +92,10 @@
               name="additions"
               visible="true">
         </separator>
+        <separator
+              name="accounts"
+              visible="true">
+        </separator>
      </menuContribution>       
   </extension>
 

--- a/plugins/com.google.cloud.tools.eclipse.login/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.login/plugin.xml
@@ -46,6 +46,16 @@
             </command>
          </toolbar>
       </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="menu:com.google.cloud.tools.eclipse.appengine.actions?after=accounts">
+         <command
+               commandId="com.google.cloud.tools.eclipse.login.commands.loginCommand"
+               icon="icons/googleFavicon.png"
+               tooltip="%loginIconTooltip"
+               id="com.google.cloud.tools.eclipse.login.toolbars.loginCommand">
+         </command>
+      </menuContribution>
    </extension>
 
 </plugin>


### PR DESCRIPTION
- `.appengine.ui`: adds an `account` placeholder in the GCP toolbar at the end
- `.login`: adds a login contribution to the account placeholder

We should move the GCP toolbar to a more central location than `.appengine.ui`.

<img width="281" alt="screen shot 2017-02-01 at 10 20 00 am" src="https://cloud.githubusercontent.com/assets/202851/22512760/007563fc-e868-11e6-944f-8548eafb8461.PNG">
