### PR TITLE
another try

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.cloud.tools.eclipse.suite.e45.feature"
       label="Google Cloud Platform for Eclipse 4.5 and later"
-      version="0.1.0.qualifier"
+      version="1.0.0.qualifier"
       provider-name="Google, Inc."
       plugin="com.google.cloud.tools.eclipse.appengine.ui"
       license-feature="com.google.licenses.apache_v2">

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.cloud.tools.eclipse.suite.e45.feature"
       label="Google Cloud Platform for Eclipse 4.5 and later"
-      version="1.0.0"
+      version="1.0.0.qualifier"
       provider-name="Google, Inc."
       plugin="com.google.cloud.tools.eclipse.appengine.ui"
       license-feature="com.google.licenses.apache_v2">

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.cloud.tools.eclipse.suite.e45.feature"
       label="Google Cloud Platform for Eclipse 4.5 and later"
-      version="1.0.0.qualifier"
+      version="1.0.0"
       provider-name="Google, Inc."
       plugin="com.google.cloud.tools.eclipse.appengine.ui"
       license-feature="com.google.licenses.apache_v2">

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
@@ -9,6 +9,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.suite.e45.feature</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
+ 
 </project>

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.suite.e45.feature</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
  
 </project>

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../../</relativePath>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.suite.e45.feature</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>eclipse-feature</packaging>
  
 </project>

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -36,5 +36,5 @@ Please visit the following URL for details:\n\n\
 units.1.licenses.0.location = https://www.apache.org/licenses/LICENSE-2.0
 units.1.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.1.requires.1.name=com.google.cloud.tools.eclipse.suite.e45.feature.feature.group
-units.1.requires.1.range=[1.0.0,1.0.0]
+units.1.requires.1.range=[1.0.0,1.0.1)
 units.1.requires.1.greedy=true

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -36,5 +36,4 @@ Please visit the following URL for details:\n\n\
 units.1.licenses.0.location = https://www.apache.org/licenses/LICENSE-2.0
 units.1.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.1.requires.1.name=com.google.cloud.tools.eclipse.suite.e45.feature.feature.group
-units.1.requires.1.range=[1.0.0,1.0.1)
 units.1.requires.1.greedy=true

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -36,5 +36,5 @@ Please visit the following URL for details:\n\n\
 units.1.licenses.0.location = https://www.apache.org/licenses/LICENSE-2.0
 units.1.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.1.requires.1.name=com.google.cloud.tools.eclipse.suite.e45.feature.feature.group
-units.1.requires.1.range=[0.1.0,1.0.0]
+units.1.requires.1.range=[1.0.0]
 units.1.requires.1.greedy=true

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -36,5 +36,5 @@ Please visit the following URL for details:\n\n\
 units.1.licenses.0.location = https://www.apache.org/licenses/LICENSE-2.0
 units.1.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.1.requires.1.name=com.google.cloud.tools.eclipse.suite.e45.feature.feature.group
-units.1.requires.1.range=[1.0.0]
+units.1.requires.1.range=[1.0.0,1.0.0]
 units.1.requires.1.greedy=true


### PR DESCRIPTION
@briandealwis This PR definitely doesn't work. That is, the compile breaks. The question is why? What else needs to change?

Where is com.google.cloud.tools.eclipse.category defined such, specifically the requirement that it needs 'com.google.cloud.tools.eclipse.suite.e45.feature.feature.group [0.1.0,1.0.0]'

That sounds like a MANIFEST.MF problem, not a pom.xml problem. 

[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: com.google.cloud.tools.eclipse.dist 1.0.0.qualifier
[ERROR]   Missing requirement: com.google.cloud.tools.eclipse.category 1.0.0 requires 'com.google.cloud.tools.eclipse.suite.e45.feature.feature.group [0.1.0,1.0.0]' but it could not be found
[ERROR]   Cannot satisfy dependency: com.google.cloud.tools.eclipse.dist 1.0.0.qualifier depends on: com.google.cloud.tools.eclipse.category [1.0.0]
[ERROR] 
[ERROR] See http://wiki.eclipse.org/Tycho/Dependency_Resolution_Troubleshooting for help.
[ERROR] Cannot resolve dependencies of MavenProject: com.google.cloud.tools.eclipse:google-cloud-plugin-eclipse.repo:0.1.0-SNAPSHOT @ /Users/elharo/google-cloud-eclipse/gcp-repo/pom.xml: See log for details -> [Help 1]
[ERROR] 
