### PR TITLE
Add safe implementation of SWTBot's resetWorkbench()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
@@ -19,7 +19,9 @@ package com.google.cloud.tools.eclipse.appengine.facets.convert;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
@@ -28,6 +30,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class AppEngineStandardProjectConvertJobTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Rule public final TestProjectCreator projectCreator = new TestProjectCreator();
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
@@ -31,8 +31,7 @@ import org.junit.Test;
 
 public class AppEngineStandardProjectConvertJobTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Rule public final TestProjectCreator projectCreator = new TestProjectCreator();
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.tools.eclipse.appengine.facets.ui.AppEngineStandardProjectConvertCommandHandler.MessageDialogWrapper;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
@@ -39,6 +41,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineStandardProjectConvertCommandHandlerTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Rule public final TestProjectCreator projectCreator = new TestProjectCreator();
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
@@ -42,8 +42,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineStandardProjectConvertCommandHandlerTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Rule public final TestProjectCreator projectCreator = new TestProjectCreator();
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -22,11 +22,13 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
@@ -52,6 +54,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 @SuppressWarnings("restriction") //For ModuleType
 @RunWith(MockitoJUnitRunner.class)
 public class LocalAppEngineServerDelegateTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   private LocalAppEngineServerDelegate delegate = new LocalAppEngineServerDelegate();
   private static final IProjectFacetVersion APPENGINE_STANDARD_FACET_VERSION_1 =

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegateTest.java
@@ -55,8 +55,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class LocalAppEngineServerDelegateTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   private LocalAppEngineServerDelegate delegate = new LocalAppEngineServerDelegate();
   private static final IProjectFacetVersion APPENGINE_STANDARD_FACET_VERSION_1 =

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
@@ -34,7 +34,7 @@ import org.mockito.runners.MockitoJUnitRunner;;
 public class CreateMavenBasedAppEngineStandardProjectTest {
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Mock
   private IProjectConfigurationManager manager;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
@@ -33,8 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;;
 @RunWith(MockitoJUnitRunner.class)
 public class CreateMavenBasedAppEngineStandardProjectTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Mock
   private IProjectConfigurationManager manager;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/CreateMavenBasedAppEngineStandardProjectTest.java
@@ -16,12 +16,15 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -29,6 +32,9 @@ import org.mockito.runners.MockitoJUnitRunner;;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateMavenBasedAppEngineStandardProjectTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
 
   @Mock
   private IProjectConfigurationManager manager;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -56,8 +56,7 @@ public class CreateAppEngineStandardWtpProjectTest {
   private static final String APP_ENGINE_API = "appengine-api";
 
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Mock private IAdaptable adaptable;
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -57,7 +57,7 @@ public class CreateAppEngineStandardWtpProjectTest {
 
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Mock private IAdaptable adaptable;
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineStandardWtpProjectTest.java
@@ -23,9 +23,11 @@ import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -42,6 +44,7 @@ import org.eclipse.wst.common.project.facet.core.runtime.IRuntime;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -51,6 +54,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class CreateAppEngineStandardWtpProjectTest {
 
   private static final String APP_ENGINE_API = "appengine-api";
+
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
 
   @Mock private IAdaptable adaptable;
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -62,13 +62,7 @@ public class BaseProjectTest {
       project = null;
     }
 
-    // Avoid resetWorkbench() due to Eclipse bug 511729 on Oxygen
-    // bot.resetWorkbench();
-    bot.saveAllEditors();
-    bot.closeAllEditors();
-    bot.resetActivePerspective();
-    bot.defaultPerspective().activate();
-    bot.resetActivePerspective();
+    SwtBotWorkbenchActions.resetWorkbench(bot);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
   /**
    * Launch a native application in debug mode and verify that:
    * <ol>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -57,8 +57,8 @@ import java.util.concurrent.TimeUnit;
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+
   /**
    * Launch a native application in debug mode and verify that:
    * <ol>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotTestingUtilities;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotTreeUtilities;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.swt.custom.StyledText;
@@ -37,6 +38,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osgi.service.prefs.Preferences;
@@ -46,6 +48,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Create a native App Engine Standard project, launch in debug mode, verify working, and then
@@ -53,6 +56,9 @@ import java.nio.charset.StandardCharsets;
  */
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
   /**
    * Launch a native application in debug mode and verify that:
    * <ol>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
@@ -34,8 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 public class DeployPropertyPageTest extends BaseProjectTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testPropertyPageTitle_standardProject() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
@@ -21,14 +21,22 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 public class DeployPropertyPageTest extends BaseProjectTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+
   @Test
   public void testPropertyPageTitle_standardProject() throws CoreException {
     String projectName = "foo";

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DeployPropertyPageTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class DeployPropertyPageTest extends BaseProjectTest {
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testPropertyPageTitle_standardProject() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 public class NewMavenBasedAppEngineProjectWizardTest extends BaseProjectTest {
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testHelloWorld() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
@@ -49,8 +49,7 @@ import java.util.concurrent.TimeUnit;
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class NewMavenBasedAppEngineProjectWizardTest extends BaseProjectTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testHelloWorld() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewMavenBasedAppEngineProjectWizardTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 import com.google.cloud.tools.eclipse.util.MavenUtils;
@@ -32,12 +33,14 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test creation of a new project with the "Maven-Based Google App Engine Standard Java Project"
@@ -45,6 +48,9 @@ import java.io.InputStream;
  */
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class NewMavenBasedAppEngineProjectWizardTest extends BaseProjectTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
 
   @Test
   public void testHelloWorld() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
@@ -42,8 +42,7 @@ import java.util.concurrent.TimeUnit;
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class NewNativeAppEngineStandardProjectTest extends BaseProjectTest {
   @Rule
-  public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testWithDefaults() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 
@@ -29,14 +30,20 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Test creation of a new standard App Engine project.
  */
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class NewNativeAppEngineStandardProjectTest extends BaseProjectTest {
+  @Rule
+  public ThreadDumpingWatchdog timer =
+      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
 
   @Test
   public void testWithDefaults() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/NewNativeAppEngineStandardProjectTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 public class NewNativeAppEngineStandardProjectTest extends BaseProjectTest {
   @Rule
   public ThreadDumpingWatchdog timer =
-      new ThreadDumpingWatchdog(getClass().getName(), 2, TimeUnit.MINUTES);
+      new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testWithDefaults() throws Exception {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
@@ -17,7 +17,10 @@
 package com.google.cloud.tools.eclipse.test.util;
 
 import com.google.common.base.Stopwatch;
+import java.lang.Thread.State;
+import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
@@ -35,6 +38,7 @@ import org.junit.runners.model.Statement;
 public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
   private final long period;
   private final TimeUnit unit;
+  private final boolean ignoreUselessThreads = true;
 
   private Description description;
   private Timer timer;
@@ -89,13 +93,164 @@ public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
     sb.append("\n+-------------------------------------------------------------------------------");
     sb.append("\n| STACK DUMP @ ").append(stopwatch).append(": ").append(description);
     sb.append("\n|");
+    int uselessThreadsCount = 0;
     for (ThreadInfo tinfo : infos) {
       // Unfortunately ThreadInfo#toString() only dumps up to 8 stackframes, and
       // this value is not configurable :-(
-      sb.append("\n| ").append(tinfo.toString().replace("\n", "\n|"));
+      if (!isUselessThread(tinfo)) {
+        dumpThreadInfo(sb, "| ", tinfo);
+      } else {
+        uselessThreadsCount++;
+      }
+    }
+    if (uselessThreadsCount > 0) {
+      sb.append("\n| Ignored threads:");
+      for (ThreadInfo tinfo : infos) {
+        if (isUselessThread(tinfo)) {
+          sb.append("\n|   ");
+          dumpThreadHeader(sb, tinfo);
+        }
+      }
     }
     sb.append("\n+-------------------------------------------------------------------------------");
     System.err.println(sb.toString());
+  }
+
+  /**
+   * Identify useless threads, like idle worker pool threads.
+   */
+  private boolean isUselessThread(ThreadInfo tinfo) {
+    String threadName = tinfo.getThreadName();
+    if (tinfo.getThreadState() == State.TIMED_WAITING && tinfo.getLockInfo() != null) {
+      String lockClassName = tinfo.getLockInfo().getClassName();
+      // Eclipse Jobs worker:
+      // "Worker-9" [107] TIMED_WAITING on org.eclipse.core.internal.jobs.WorkerPool@5f4b99c7
+      if (threadName.startsWith("Worker-")
+          && "org.eclipse.core.internal.jobs.WorkerPool".equals(lockClassName)) {
+        return true;
+      }
+      // "Timer-0" [43] TIMED_WAITING on java.util.TaskQueue@6ac9af9e
+      if (threadName.startsWith("Timer-") && "java.util.TaskQueue".equals(lockClassName)) {
+        return true;
+      }
+      // "Active Thread: Equinox Container: 0a1c2f36-c9b6-4aea-8192-af1c5847a0f2" [16] TIMED_WAITING
+      // on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@38a2a717
+      if (threadName.startsWith("Active Thread: Equinox Container: ")
+          && "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject"
+              .equals(lockClassName)) {
+        return true;
+      }
+    }
+    if (tinfo.getThreadState() == State.WAITING && tinfo.getLockInfo() != null) {
+      String lockClassName = tinfo.getLockInfo().getClassName();
+      // "Reference Handler" [2] WAITING on java.lang.ref.Reference$Lock@3a28b268
+      if ("Reference Handler".equals(threadName)
+          && "java.lang.ref.Reference$Lock".equals(lockClassName)) {
+        return true;
+      }
+      // "Finalizer" [3] WAITING on java.lang.ref.ReferenceQueue$Lock@2902d3d5
+      // "EMF Reference Cleaner" [35] WAITING on java.lang.ref.ReferenceQueue$Lock@a0853f9
+      if (("Finalizer".equals(threadName) || "EMF Reference Cleaner".equals(threadName))
+          && "java.lang.ref.ReferenceQueue$Lock".equals(lockClassName)) {
+        return true;
+      }
+      // "Worker-JM" [28] WAITING on java.util.ArrayList@46ce31f9
+      if ("Worker-JM".equals(threadName)
+          && "java.util.ArrayList".equals(lockClassName)) {
+        return true;
+      }
+      // "SCR Component Actor" [27] WAITING on java.util.LinkedList@787d08c3
+      if ("SCR Component Actor".equals(threadName)
+          && "java.util.LinkedList".equals(lockClassName)) {
+        return true;
+      }
+      // "Bundle File Closer" [21] WAITING on org.eclipse.osgi.framework.eventmgr.EventManager$EventThread@76faf029
+      // "Refresh Thread: Equinox Container: 0a1c2f36-c9b6-4aea-8192-af1c5847a0f2" [19] WAITING on
+      // org.eclipse.osgi.framework.eventmgr.EventManager$EventThread@9d34d50
+      // "Start Level: Equinox Container: 0a1c2f36-c9b6-4aea-8192-af1c5847a0f2" [20] WAITING on
+      // org.eclipse.osgi.framework.eventmgr.EventManager$EventThread@3e25e294
+      // "Framework Event Dispatcher:
+      // org.eclipse.osgi.internal.framework.EquinoxEventPublisher@2aa5fe93" [18] WAITING on
+      // org.eclipse.osgi.framework.eventmgr.EventManager$EventThread@19f867b9
+      if (("Bundle File Closer".equals(threadName)
+          || threadName.startsWith("Refresh Thread: Equinox Container: ")
+          || threadName.startsWith("Start Level: Equinox Container: ")
+          || threadName.startsWith(
+              "Framework Event Dispatcher: org.eclipse.osgi.internal.framework.EquinoxEventPublisher"))
+          && "org.eclipse.osgi.framework.eventmgr.EventManager$EventThread".equals(lockClassName)) {
+        return true;
+      }
+    }
+    // "Signal Dispatcher" [4] RUNNABLE
+    // "JDWP Transport Listener: dt_socket" [5] RUNNABLE
+    // "JDWP Event Helper Thread" [6] RUNNABLE
+    // "JDWP Command Reader" [7] RUNNABLE (in native code)
+    if (tinfo.getThreadState() == State.RUNNABLE
+        && (threadName.startsWith("JDWP ") || "Signal Dispatcher".equals(threadName))) {
+      return true;
+    }
+
+    return false;
+  }
+
+  @SuppressWarnings("incomplete-switch")
+  private void dumpThreadInfo(StringBuilder sb, String prefix, ThreadInfo tinfo) {
+    sb.append('\n').append(prefix);
+    dumpThreadHeader(sb, tinfo);
+
+    StackTraceElement[] trace = tinfo.getStackTrace();
+    if (trace.length > 0) {
+      sb.append('\n').append(prefix).append("    at ").append(trace[0]);
+      if (tinfo.getLockInfo() != null) {
+        sb.append('\n').append(prefix).append("    - ");
+        switch (tinfo.getThreadState()) {
+          case BLOCKED:
+            sb.append("blocked on ");
+            break;
+          case TIMED_WAITING:
+          case WAITING:
+            sb.append("waiting on ");
+            break;
+        }
+        sb.append(tinfo.getLockInfo());
+      }
+      MonitorInfo[] lockedMonitors = tinfo.getLockedMonitors();
+      for (int i = 1; i < trace.length; i++) {
+        sb.append("\n").append(prefix).append("    at ").append(trace[i]);
+        for (MonitorInfo minfo : lockedMonitors) {
+          if (minfo.getLockedStackDepth() == i) {
+            sb.append("\n").append(prefix).append("    - locked ").append(minfo);
+          }
+        }
+      }
+    }
+    LockInfo[] lockedSynchronizers = tinfo.getLockedSynchronizers();
+    if (lockedSynchronizers.length > 0) {
+      sb.append("\n").append(prefix).append("    Locked synchronizers:");
+      for (int i = 0; i < lockedSynchronizers.length; i++) {
+        sb.append("\n").append(prefix).append("      ").append(i).append(". ")
+            .append(lockedSynchronizers[i]);
+      }
+    }
+    sb.append("\n").append(prefix);
+  }
+
+  private void dumpThreadHeader(StringBuilder sb, ThreadInfo tinfo) {
+    sb.append('"').append(tinfo.getThreadName()).append("\" [").append(tinfo.getThreadId())
+        .append("] ").append(tinfo.getThreadState());
+    if (tinfo.getLockName() != null) {
+      sb.append(" on ").append(tinfo.getLockName());
+    }
+    if (tinfo.getLockOwnerName() != null) {
+      sb.append(" owned by '").append(tinfo.getLockOwnerName()).append(" [id:")
+          .append(tinfo.getLockOwnerId()).append(']');
+    }
+    if (tinfo.isSuspended()) {
+      sb.append(" (suspended)");
+    }
+    if (tinfo.isInNative()) {
+      sb.append(" (in native code)");
+    }
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.test.util;
+
+import com.google.common.base.Stopwatch;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * 
+ */
+public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
+  private String title;
+  private long period;
+  private TimeUnit unit;
+  private Timer timer;
+  private Stopwatch stopwatch;
+
+  public ThreadDumpingWatchdog(String title, long period, TimeUnit unit) {
+    this.title = title;
+    this.period = period;
+    this.unit = unit;
+  }
+
+  @Override
+  public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        install();
+        try {
+          base.evaluate();
+        } finally {
+          remove();
+        }
+      }
+    };
+  }
+
+  protected void install() {
+    timer = new Timer("Thread Dumping Watchdog");
+    timer.scheduleAtFixedRate(this, unit.toMillis(period), unit.toMillis(period));
+    stopwatch = Stopwatch.createStarted();
+  }
+
+  protected void remove() {
+    timer.cancel();
+  }
+
+  @Override
+  public void run() {
+    Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+    List<Thread> threads = new ArrayList<>(traces.keySet());
+    Collections.sort(threads, new Comparator<Thread>() {
+      @Override
+      public int compare(Thread t1, Thread t2) {
+        return Long.compare(t1.getId(), t2.getId());
+      }
+    });
+    StringBuilder sb = new StringBuilder();
+    sb.append("\n+-------------------------------------------------------------------------------");
+    sb.append("\n| STACK DUMP @ ").append(stopwatch).append(": ").append(title);
+    for (Thread thread : threads) {
+      sb.append("\n|");
+      sb.append("\n| ").append(thread.getId()).append(": ").append(thread).append(' ')
+          .append(thread.getState()).append(thread.isDaemon() ? ", DAEMON" : "");
+      for (StackTraceElement frame : traces.get(thread)) {
+        sb.append("\n|     ").append(frame);
+      }
+    }
+    sb.append("\n+-------------------------------------------------------------------------------");
+    System.err.println(sb.toString());
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
@@ -30,11 +30,11 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 /**
- * 
+ * A JUnit test helper that periodically performs stack dumps for the current threads.
  */
 public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
-  private long period;
-  private TimeUnit unit;
+  private final long period;
+  private final TimeUnit unit;
 
   private Description description;
   private Timer timer;


### PR DESCRIPTION
@chanseokoh noticed a sporadic failure that is due to removing the call to `SWTWorkbenchBot#resetWorkbench()` in #1348, which leaves the `DeployPropertyPageTest` dialog up and interferes with some of the subsequent tests.

```
testHelloWorld(com.google.cloud.tools.eclipse.integration.appengine.NewMavenBasedAppEngineProjectWizardTest)  Time elapsed: 31.072 sec  <<< ERROR!
org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException: Could not find menu bar for shell: Shell with text {Properties for foo}
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:522)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:496)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:484)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntilWidgetAppears(SWTBotFactory.java:466)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.menu(SWTBotFactory.java:216)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.menu(SWTBotFactory.java:204)
	at org.eclipse.swtbot.swt.finder.SWTBotFactory.menu(SWTBotFactory.java:233)
	at com.google.cloud.tools.eclipse.integration.appengine.SwtBotAppEngineActions.createMavenWebAppProject(SwtBotAppEngineActions.java:80)
```