### PR TITLE
Reduce synchronization region in NonSystemJobSuspender

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/NonSystemJobSuspender.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/NonSystemJobSuspender.java
@@ -83,10 +83,13 @@ class NonSystemJobSuspender {
   }
 
   static void suspendJob(Job job, long scheduleDelay) {
-    if (!suspended.get() || job.isSystem()) {
+    if (job.isSystem()) {
       return;
     }
     synchronized (suspendedJobs) {
+      if (!suspended.get()) {
+        return;
+      }
       suspendedJobs.add(new SuspendedJob(job, scheduleDelay));
     }
     job.cancel(); // This will always succeed since the job is not running yet.


### PR DESCRIPTION
Ensure that Job changes are not done when object monitors are held.

Fixes #1373 