### PR TITLE
Wait for Dependency Graph update job

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -31,8 +33,10 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.common.project.facet.core.JavaFacetInstallConfig;
 import org.eclipse.jst.j2ee.project.facet.IJ2EEFacetInstallDataModelProperties;
@@ -41,6 +45,7 @@ import org.eclipse.jst.j2ee.web.project.facet.IWebFacetInstallDataModelPropertie
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetInstallDataModelProvider;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.jst.server.core.FacetUtil;
+import org.eclipse.wst.common.componentcore.internal.builder.DependencyGraphImpl;
 import org.eclipse.wst.common.componentcore.internal.builder.IDependencyGraph;
 import org.eclipse.wst.common.frameworks.datamodel.DataModelFactory;
 import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
@@ -54,6 +59,7 @@ import org.eclipse.wst.server.core.IRuntimeWorkingCopy;
 import org.eclipse.wst.server.core.ServerCore;
 
 public class AppEngineStandardFacet {
+  private static final Logger logger = Logger.getLogger(AppEngineStandardFacet.class.getName());
 
   public static final String ID = "com.google.cloud.tools.eclipse.appengine.facets.standard";
 
@@ -155,8 +161,14 @@ public class AppEngineStandardFacet {
       // project facets. So we force the dependency graph to defer updates.
       try {
         IDependencyGraph.INSTANCE.preUpdate();
+        try {
+          Job.getJobManager().join(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY,
+              subMonitor.newChild(10));
+        } catch (OperationCanceledException | InterruptedException ex) {
+          logger.log(Level.WARNING, "Exception waiting for WTP Graph Update job", ex);
+        }
 
-        facetedProject.modify(facetInstallSet, subMonitor.newChild(100));
+        facetedProject.modify(facetInstallSet, subMonitor.newChild(90));
       } finally {
         IDependencyGraph.INSTANCE.postUpdate();
       }
@@ -183,29 +195,38 @@ public class AppEngineStandardFacet {
       }
     }
 
+    SubMonitor progress = SubMonitor.convert(monitor, 100);
+
     // Workaround deadlock bug described in Eclipse bug (https://bugs.eclipse.org/511793).
     // There are graph update jobs triggered by the completion of the CreateProjectOperation
     // above (from resource notifications) and from other resource changes from modifying the
     // project facets. So we force the dependency graph to defer updates.
     try {
       IDependencyGraph.INSTANCE.preUpdate();
+      try {
+        Job.getJobManager().join(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY,
+            progress.newChild(10));
+      } catch (OperationCanceledException | InterruptedException ex) {
+        logger.log(Level.WARNING, "Exception waiting for WTP Graph Update job", ex);
+      }
 
       org.eclipse.wst.server.core.IRuntime[] appEngineRuntimes = getAppEngineRuntimes();
       if (appEngineRuntimes.length > 0) {
         IRuntime appEngineFacetRuntime = null;
+        progress.setWorkRemaining(appEngineRuntimes.length);
         for (org.eclipse.wst.server.core.IRuntime appEngineRuntime : appEngineRuntimes) {
           appEngineFacetRuntime = FacetUtil.getRuntime(appEngineRuntime);
-          project.addTargetedRuntime(appEngineFacetRuntime, monitor);
+          project.addTargetedRuntime(appEngineFacetRuntime, progress.newChild(1));
         }
         project.setPrimaryRuntime(appEngineFacetRuntime, monitor);
       } else { // Create a new App Engine runtime
-        IRuntime appEngineFacetRuntime = createAppEngineFacetRuntime(monitor);
+        IRuntime appEngineFacetRuntime = createAppEngineFacetRuntime(progress.newChild(10));
         if (appEngineFacetRuntime == null) {
           throw new NullPointerException("Could not locate App Engine facet runtime");
         }
 
-        project.addTargetedRuntime(appEngineFacetRuntime, monitor);
-        project.setPrimaryRuntime(appEngineFacetRuntime, monitor);
+        project.addTargetedRuntime(appEngineFacetRuntime, progress.newChild(10));
+        project.setPrimaryRuntime(appEngineFacetRuntime, progress.newChild(10));
       }
     } finally {
       IDependencyGraph.INSTANCE.postUpdate();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -54,16 +54,17 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
   private void installAppEngineRuntimes(IProject project) throws CoreException {
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
 
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
+    // The first ConvertJob has already been scheduled (which installs JSDT facet), and
+    // this is to suspend the second ConvertJob temporarily.
+    NonSystemJobSuspender.suspendFutureJobs();
+
     // Modifying targeted runtimes while installing/uninstalling facets is not allowed,
     // so schedule a job as a workaround.
     Job installJob = new AppEngineRuntimeInstallJob(facetedProject);
     // Schedule immediately so that it doesn't go into the SLEEPING state. Ensuring the job is
     // active is necessary for unit testing.
     installJob.schedule();
-    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
-    // The first ConvertJob has already been scheduled (which installs JSDT facet), and
-    // this is to suspend the second ConvertJob temporarily.
-    NonSystemJobSuspender.suspendFutureJobs();
   }
 
   private static class AppEngineRuntimeInstallJob extends Job {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -54,11 +54,6 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
   private void installAppEngineRuntimes(IProject project) throws CoreException {
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
 
-    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
-    // The first ConvertJob has already been scheduled (which installs JSDT facet), and
-    // this is to suspend the second ConvertJob temporarily.
-    NonSystemJobSuspender.suspendFutureJobs();
-
     // Modifying targeted runtimes while installing/uninstalling facets is not allowed,
     // so schedule a job as a workaround.
     Job installJob = new AppEngineRuntimeInstallJob(facetedProject);
@@ -107,6 +102,11 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     @Override
     protected IStatus run(IProgressMonitor monitor) {
       try {
+        // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
+        // The first ConvertJob has already been scheduled (which installs JSDT facet), and
+        // this is to suspend the second ConvertJob temporarily.
+        NonSystemJobSuspender.suspendFutureJobs();
+
         // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
         // Wait until the first ConvertJob installs the JSDT facet.
         waitUntilJsdtIsFixedFacet();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -60,6 +60,10 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     // Schedule immediately so that it doesn't go into the SLEEPING state. Ensuring the job is
     // active is necessary for unit testing.
     installJob.schedule();
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
+    // The first ConvertJob has already been scheduled (which installs JSDT facet), and
+    // this is to suspend the second ConvertJob temporarily.
+    NonSystemJobSuspender.suspendFutureJobs();
   }
 
   private static class AppEngineRuntimeInstallJob extends Job {
@@ -102,11 +106,6 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     @Override
     protected IStatus run(IProgressMonitor monitor) {
       try {
-        // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
-        // The first ConvertJob has already been scheduled (which installs JSDT facet), and
-        // this is to suspend the second ConvertJob temporarily.
-        NonSystemJobSuspender.suspendFutureJobs();
-
         // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
         // Wait until the first ConvertJob installs the JSDT facet.
         waitUntilJsdtIsFixedFacet();

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -90,7 +90,7 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
       }
     });
 
-    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
 
     bot.perspectiveById("org.eclipse.debug.ui.DebugPerspective").activate(); // IDebugUIConstants.ID_DEBUG_PERSPECTIVE
     SWTBotView debugView = bot.viewById("org.eclipse.debug.ui.DebugView"); // IDebugUIConstants.ID_DEBUG_VIEW

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -67,7 +67,7 @@ public class SwtBotAppEngineActions {
     // can take a loooong time to resolve jars (e.g. servlet-api.jar) from Maven Central
     int libraryResolutionTimeout = 60000/* ms */;
     SwtBotTimeoutManager.setTimeout(libraryResolutionTimeout);
-    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
     SwtBotTimeoutManager.resetTimeout();
     IProject project = waitUntilProjectExists(bot, getWorkspaceRoot().getProject(projectName));
     SwtBotWorkbenchActions.waitForProjects(bot, project);
@@ -106,7 +106,7 @@ public class SwtBotAppEngineActions {
 
     int mavenCompletionTimeout = 60000/* ms */; // can take a loooong time to fetch archetypes
     SwtBotTimeoutManager.setTimeout(mavenCompletionTimeout);
-    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
     SwtBotTimeoutManager.resetTimeout();
     IProject project = waitUntilProjectExists(bot, getWorkspaceRoot().getProject(artifactId));
     SwtBotWorkbenchActions.waitForProjects(bot, project);

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
@@ -65,7 +65,7 @@ public final class SwtBotProjectActions {
       public void run() {
         bot.activeShell();
         bot.textWithLabel("Name:").setText(className);
-        SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+        SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
       }
     });
   }
@@ -118,7 +118,7 @@ public final class SwtBotProjectActions {
     bot.comboBoxWithLabel("Artifact Id:").setText(artifactId);
     bot.comboBoxWithLabel("Package:").setText(javaPackage);
 
-    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Finish"));
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
     return getWorkspaceRoot().getProject("testartifact");
   }
 
@@ -143,7 +143,7 @@ public final class SwtBotProjectActions {
     // Select the "Delete project contents on disk (cannot be undone)"
     bot.checkBox(0).click();
 
-    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("OK"));
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("OK"));
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
@@ -89,12 +89,7 @@ public final class SwtBotProjectActions {
     bot.button("Next >").click();
 
     // open archetype dialog
-    SwtBotTestingUtilities.performAndWaitForWindowChange(bot, new Runnable() {
-      @Override
-      public void run() {
-        bot.button("Add Archetype...").click();
-      }
-    });
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("Add Archetype..."));
 
     bot.comboBox(0).setText(archetypeGroupId);
     bot.comboBox(1).setText(archetypeArtifactId);
@@ -102,13 +97,8 @@ public final class SwtBotProjectActions {
     bot.comboBox(3).setText(archetypeUrl);
 
     // close archetype dialog
-    SwtBotTestingUtilities.performAndWaitForWindowChange(bot, new Runnable() {
-      @Override
-      public void run() {
-        // After OK, it will take a minute to download
-        bot.button("OK").click();
-      }
-    });
+    // After OK, it will take a minute to download
+    SwtBotTestingUtilities.clickButtonAndWaitForWindowChange(bot, bot.button("OK"));
 
     // move to last wizard
     bot.button("Next >").click();

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
@@ -132,7 +132,7 @@ public class SwtBotTestingUtilities {
   }
 
   /**
-   * Blocks the caller until the given shell is no longer active.
+   * Blocks the caller until the given shell is closed.
    */
   public static void waitUntilShellIsClosed(SWTBot bot, final SWTBotShell shell) {
     bot.waitUntil(new DefaultCondition() {

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
@@ -44,6 +44,16 @@ public class SwtBotTestingUtilities {
     });
   }
 
+  /** Click the button, wait for the window close. */
+  public static void clickButtonAndWaitForWindowClose(SWTBot bot, final SWTBotButton button) {
+    performAndWaitForWindowClose(bot, new Runnable() {
+      @Override
+      public void run() {
+        button.click();
+      }
+    });
+  }
+
   /**
    * Click on all table cells in column {@code col} with the contents {@code value}. Selection
    * should be the last cell clicked upon.
@@ -77,6 +87,16 @@ public class SwtBotTestingUtilities {
   }
 
   /**
+   * Simple wrapper to block for actions that close a window.
+   */
+  public static void performAndWaitForWindowClose(SWTBot bot, Runnable runnable) {
+    SWTBotShell shell = bot.activeShell();
+    runnable.run();
+    waitUntilShellIsClosed(bot, shell);
+  }
+
+
+  /**
    * Injects a key or character via down and up events. Only one of {@code keyCode} or
    * {@code character} must be provided. Use
    * 
@@ -107,6 +127,23 @@ public class SwtBotTestingUtilities {
       @Override
       public boolean test() throws Exception {
         return !shell.isActive();
+      }
+    });
+  }
+
+  /**
+   * Blocks the caller until the given shell is no longer active.
+   */
+  public static void waitUntilShellIsClosed(SWTBot bot, final SWTBotShell shell) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public String getFailureMessage() {
+        return "Shell " + shell.getText() + " did not close"; //$NON-NLS-1$
+      }
+
+      @Override
+      public boolean test() throws Exception {
+        return !shell.isOpen();
       }
     });
   }

--- a/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",
- org.eclipse.ui.ide
+ org.eclipse.ui.ide,
+ org.eclipse.wst.validation
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.common.base;version="[20.0.0,21.0.0)",
  com.google.common.collect;version="[20.0.0,21.0.0)",

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
@@ -89,6 +89,7 @@ public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
 
   @Override
   public void run() {
+    Stopwatch dumpingTime = Stopwatch.createStarted();
     ThreadMXBean bean = ManagementFactory.getThreadMXBean();
     ThreadInfo[] infos = bean.dumpAllThreads(true, true);
     Arrays.sort(infos, new Comparator<ThreadInfo>() {
@@ -102,6 +103,8 @@ public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
     sb.append("\n+-------------------------------------------------------------------------------");
     sb.append("\n| STACK DUMP @ ").append(stopwatch).append(": ").append(description);
     sb.append("\n|");
+    dumpEclipseLocks(sb, "| ");
+
     int uselessThreadsCount = 0;
     for (ThreadInfo tinfo : infos) {
       // Unfortunately ThreadInfo#toString() only dumps up to 8 stackframes, and
@@ -121,7 +124,7 @@ public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
         }
       }
     }
-    dumpEclipseLocks(sb, "| ");
+    sb.append("\n| ELAPSED TIME: ").append(dumpingTime);
     sb.append("\n+-------------------------------------------------------------------------------");
     System.err.println(sb.toString());
   }

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -25,8 +25,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.eclipse.core.resources.IMarker;
@@ -42,10 +45,11 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.wst.common.project.facet.core.util.internal.ZipUtil;
-import org.eclipse.wst.validation.ValidationFramework;
+import org.eclipse.wst.validation.internal.operations.ValidationBuilder;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
@@ -53,6 +57,7 @@ import org.osgi.framework.FrameworkUtil;
  * A set of utility methods for dealing with projects.
  */
 public class ProjectUtils {
+  private static boolean DEBUG = false;
 
   /**
    * Import the Eclipse projects found within the bundle containing {@code clazz} at the
@@ -178,19 +183,43 @@ public class ProjectUtils {
 
   /** Wait for any spawned jobs and builds to complete (e.g., validation jobs). */
   public static void waitForProjects(Runnable delayTactic, IProject... projects) {
+    IJobManager jobManager = Job.getJobManager();
     try {
+      Set<Job> jobs = new LinkedHashSet<>();
+      List<String> allBuildErrors;
       do {
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
-        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
-        // J2EEElementChangedListener.PROJECT_COMPONENT_UPDATE_JOB_FAMILY
-        Job.getJobManager().join("org.eclipse.jst.j2ee.refactor.component", null);
-        // ServerPlugin.SHUTDOWN_JOB_FAMILY
-        Job.getJobManager().join("org.eclipse.wst.server.core.family", null);
-        Job.getJobManager().join("org.eclipse.wst.server.ui.family", null);
-        ValidationFramework.getDefault().join(null);
-
         delayTactic.run();
-      } while (!getAllBuildErrors(projects).isEmpty());
+        for (Job job : jobs) {
+          job.join();
+        }
+        jobs.clear();
+
+        Collections.addAll(jobs, jobManager.find(ResourcesPlugin.FAMILY_MANUAL_BUILD));
+        Collections.addAll(jobs, jobManager.find(ResourcesPlugin.FAMILY_AUTO_BUILD));
+        // J2EEElementChangedListener.PROJECT_COMPONENT_UPDATE_JOB_FAMILY
+        Collections.addAll(jobs, jobManager.find("org.eclipse.jst.j2ee.refactor.component"));
+        // ServerPlugin.SHUTDOWN_JOB_FAMILY
+        Collections.addAll(jobs, jobManager.find("org.eclipse.wst.server.core.family"));
+        Collections.addAll(jobs, jobManager.find("org.eclipse.wst.server.ui.family"));
+        Collections.addAll(jobs, jobManager.find(ValidationBuilder.FAMILY_VALIDATION_JOB));
+        allBuildErrors = getAllBuildErrors(projects);
+        if (DEBUG) {
+          if (!jobs.isEmpty()) {
+            System.err.printf("ProjectUtils#waitForProjects: waiting for %d jobs: %s\n",
+                jobs.size(), jobs);
+          } else if (!allBuildErrors.isEmpty()) {
+            System.err.printf("ProjectUtils#waitForProjects: waiting for %d build errors\n",
+                allBuildErrors.size());
+          } else {
+            Job[] otherJobs = jobManager.find(null);
+            System.err.printf("Ignoring %d unrelated jobs:\n", otherJobs.length);
+            for (Job job : otherJobs) {
+              System.err.printf("  %s: %s\n", job.getClass().getName(), job);
+            }
+            // new ThreadDumpingWatchdog(0, TimeUnit.DAYS).run();
+          }
+        }
+      } while (!(jobs.isEmpty() && allBuildErrors.isEmpty()));
     } catch (CoreException | InterruptedException ex) {
       throw new RuntimeException(ex);
     }

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -211,6 +211,7 @@ public class ProjectUtils {
             System.err.printf("ProjectUtils#waitForProjects: waiting for %d build errors\n",
                 allBuildErrors.size());
           } else {
+            // report any other jobs found in case we're missing something above
             Job[] otherJobs = jobManager.find(null);
             System.err.printf("Ignoring %d unrelated jobs:\n", otherJobs.length);
             for (Job job : otherJobs) {


### PR DESCRIPTION
[Address the finding in #1345](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1345#issuecomment-278784059) that there may be Dependency Graph update jobs already in progress by waiting for any DG update jobs to complete.

Follows on to #1375.

Build failures seen have been related to #1373, and will be addressed by #1376.

Fixes #1345 
Fixes #1314