### PR TITLE
Set application name for login API

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.login/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.login/META-INF/MANIFEST.MF
@@ -31,6 +31,7 @@ Export-Package: com.google.api.client.auth.oauth2;x-friends:="com.google.cloud.t
  com.google.cloud.tools.login;version="0.1.1"
 Import-Package: com.google.cloud.tools.eclipse.ui.util,
  com.google.cloud.tools.eclipse.usagetracker,
+ com.google.cloud.tools.eclipse.util,
  javax.servlet.http;version="3.1.0",
  org.eclipse.core.databinding.observable,
  org.eclipse.core.databinding.observable.value,

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/GoogleLoginService.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/GoogleLoginService.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.login;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
 import com.google.cloud.tools.eclipse.login.ui.LoginServiceUi;
+import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.cloud.tools.login.Account;
 import com.google.cloud.tools.login.GoogleLoginState;
 import com.google.cloud.tools.login.JavaPreferenceOAuthDataStore;
@@ -86,6 +87,7 @@ public class GoogleLoginService implements IGoogleLoginService {
         Constants.getOAuthClientId(), Constants.getOAuthClientSecret(), OAUTH_SCOPES,
         new JavaPreferenceOAuthDataStore(PREFERENCE_PATH_OAUTH_DATA_STORE, logger),
         loginServiceUi, logger);
+    loginState.setApplicationName(CloudToolsInfo.USER_AGENT);
     accounts = loginState.listAccounts();
   }
 
@@ -107,6 +109,7 @@ public class GoogleLoginService implements IGoogleLoginService {
       OAuthDataStore dataStore, LoginServiceUi uiFacade, LoggerFacade loggerFacade) {
     loginServiceUi = uiFacade;
     this.loginState = loginState;
+    loginState.setApplicationName(CloudToolsInfo.USER_AGENT);
     accounts = loginState.listAccounts();
   }
 


### PR DESCRIPTION
#1381

Setting it for the test constructor isn't really necessary, but to be consistent.