### PR TITLE
Set up AERI bundles for exception reporting

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -17,6 +17,8 @@
    <feature id="org.eclipse.wst.common.fproj.sdk" version="0.0.0"/>
    <feature id="org.eclipse.wst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.wst.server_adapters.sdk.feature" version="0.0.0"/>
+   <feature id="org.eclipse.epp.logging.aeri.feature" version="0.0.0"/>
+   <feature id="org.eclipse.epp.logging.aeri.feature.source" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.http" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.servlet" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.server" version="0.0.0"/>

--- a/eclipse/mars/gcp-eclipse-mars.target
+++ b/eclipse/mars/gcp-eclipse-mars.target
@@ -25,6 +25,11 @@
       <repository location="http://download.eclipse.org/releases/mars/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.3.v20160923-1310"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.3.v20160923-1310"/>
+      <repository location="http://download.eclipse.org/technology/epp/logging/stable/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.7.1.v201512021921"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.200.v201512031711"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.6.3.v201501141810"/>

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -36,6 +36,11 @@ location "http://download.eclipse.org/releases/mars/" {
 	org.eclipse.jetty.util
 }
 
+location "http://download.eclipse.org/technology/epp/logging/stable/" {
+	org.eclipse.epp.logging.aeri.feature.feature.group
+	org.eclipse.epp.logging.aeri.feature.source.feature.group
+}
+
 location "http://download.eclipse.org/webtools/repository/mars/" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -18,6 +18,8 @@
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.13.0.201603142002"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.3.v20161205-0933"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.3.v20161205-0933"/>
       <unit id="org.eclipse.jetty.http" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.servlet" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.server" version="9.3.9.v20160517"/>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -1,9 +1,9 @@
-/* 
- * Target Platform Definition created using Mikael Barbero's TPD editor 
+/*
+ * Target Platform Definition created using Mikael Barbero's TPD editor
  * <https://github.com/mbarbero/fr.obeo.releng.targetplatform/>
- * 
+ *
  * If you make changes to this file, either:
- * 
+ *
  *    * Right-click in the editor and choose 'Create Target Definition File'
  *      to update the corresponding .target file.
  *    * Right-lick in the editor and choose 'Set as Target Platform'
@@ -12,7 +12,7 @@
 target "GCP for Eclipse Neon" with source requirements
 
 location "http://download.eclipse.org/cbi/updates/license" {
-    org.eclipse.license.feature.group    
+    org.eclipse.license.feature.group
 }
 
 location "http://download.eclipse.org/releases/neon" {
@@ -26,6 +26,9 @@ location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.jpt.jpa.feature.feature.group
 	org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
+	
+	org.eclipse.epp.logging.aeri.feature.feature.group
+	org.eclipse.epp.logging.aeri.feature.source.feature.group
 	
 	org.eclipse.jetty.http
 	org.eclipse.jetty.servlet

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -18,10 +18,13 @@
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201610131832"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.14.0.201701131441"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.3.v20161205-0933"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.3.v20161205-0933"/>
       <unit id="org.eclipse.jetty.http" version="9.4.0.v20161208"/>
       <unit id="org.eclipse.jetty.servlet" version="9.4.0.v20161208"/>
       <unit id="org.eclipse.jetty.server" version="9.4.0.v20161208"/>
       <unit id="org.eclipse.jetty.util" version="9.4.0.v20161208"/>
+      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
       <repository location="http://download.eclipse.org/releases/oxygen/201702031000/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -27,6 +27,9 @@ location "http://download.eclipse.org/releases/oxygen/201702031000/" {
 	org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
+	org.eclipse.epp.logging.aeri.feature.feature.group
+	org.eclipse.epp.logging.aeri.feature.source.feature.group
+	
 	org.eclipse.jetty.http
 	org.eclipse.jetty.servlet
 	org.eclipse.jetty.server

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/feature.xml
@@ -171,6 +171,13 @@
          unpack="false"/>
 
    <plugin
+         id="com.google.cloud.tools.eclipse.aeri"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="com.google.cloud.tools.eclipse.jdt.launching"
          download-size="0"
          install-size="0"

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/.project
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.google.cloud.tools.eclipse.aeri.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests for Cloud Tools for Eclipse Error Reporting
+Bundle-SymbolicName: com.google.cloud.tools.eclipse.aeri.test
+Bundle-Version: 0.1.0.qualifier
+Bundle-Vendor: Google Inc.
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Fragment-Host: com.google.cloud.tools.eclipse.aeri
+Require-Bundle: org.junit;bundle-version="4.12.0"
+Import-Package: org.mockito;provider=google;version="1.10.19"

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .
+javacSource=1.7
+javacTarget=1.7

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>com.google.cloud.tools.eclipse.aeri.test</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+</project>

--- a/plugins/com.google.cloud.tools.eclipse.aeri.test/src/com/google/cloud/tools/eclipse/aeri/DummyTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.aeri.test/src/com/google/cloud/tools/eclipse/aeri/DummyTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.aeri;
+
+import org.junit.Test;
+
+public class DummyTest {
+
+  @Test
+  public void test() {}
+}

--- a/plugins/com.google.cloud.tools.eclipse.aeri/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/com.google.cloud.tools.eclipse.aeri/.project
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.google.cloud.tools.eclipse.util</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.google.cloud.tools.eclipse.aeri/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-ManifestVersion: 2
+Bundle-Name: Cloud Tools for Eclipse Error Reporting
+Bundle-SymbolicName: com.google.cloud.tools.eclipse.aeri;singleton:=true
+Bundle-Version: 0.1.0.qualifier
+Bundle-Vendor: Google Inc.
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ActivationPolicy: lazy

--- a/plugins/com.google.cloud.tools.eclipse.aeri/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .
+javacSource=1.7
+javacTarget=1.7               

--- a/plugins/com.google.cloud.tools.eclipse.aeri/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.aeri/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <artifactId>com.google.cloud.tools.eclipse.aeri</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,8 @@
     <module>plugins/com.google.cloud.tools.eclipse.swtbot</module>
     <module>plugins/com.google.cloud.tools.eclipse.welcome</module>
     <module>plugins/com.google.cloud.tools.eclipse.welcome.test</module>
+    <module>plugins/com.google.cloud.tools.eclipse.aeri</module>
+    <module>plugins/com.google.cloud.tools.eclipse.aeri.test</module>
 
     <module>third_party/com.google.cloud.tools.eclipse.jdt.launching</module>
     <module>third_party/com.google.cloud.tools.eclipse.jst.server.core</module>


### PR DESCRIPTION
#517

- Setting up skeleton bundles.
- Pulling AERI in the target platform. (This doesn't change `sequenceNumber`, and I wonder if it's OK?)

```xml
<target name="GCP for Eclipse Mars" sequenceNumber="1485456851">
```

@briandealwis FYI, I fixed miscellaneous things in the skeletons, including
- various things regarding Java 8 --> Java 7
- `Google, Inc.` --> `Google Inc.`
- `bin/` --> `target/classes/`
- typos in a bundle name
- etc