### PR TITLE
Option to define timeout for SwtBotTreeUtilities.waitUntilTreeContainsText

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -56,6 +56,9 @@ import java.util.concurrent.TimeUnit;
  */
 @RunWith(SWTBotJunit4ClassRunner.class)
 public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
+
+  private static final long TERMINATE_SERVER_TIMEOUT = 10000L;
+
   @Rule
   public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
@@ -124,7 +127,8 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
       }
     }
     assertNotNull(stopServerButton);
-    SwtBotTreeUtilities.waitUntilTreeContainsText(bot, allItems[0], "<terminated>");
+    SwtBotTreeUtilities.waitUntilTreeContainsText(bot, allItems[0], "<terminated>",
+                                                  TERMINATE_SERVER_TIMEOUT);
     assertNoService(new URL("http://localhost:8080/hello"));
     assertTrue("App Engine console should mark as stopped",
         consoleView.getViewReference().getContentDescription().startsWith("<stopped>"));

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -24,6 +24,7 @@ import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.eclipse.swtbot.swt.finder.results.Result;
 import org.eclipse.swtbot.swt.finder.results.VoidResult;
 import org.eclipse.swtbot.swt.finder.results.WidgetResult;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
@@ -340,10 +341,21 @@ public class SwtBotTreeUtilities {
   }
 
   /**
-   * Wait until the tree item contains the given text
+   * Wait until the tree item contains the given text with the
+   * timeout {@link SWTBotPreferences#TIMEOUT}.
    */
   public static void waitUntilTreeContainsText(SWTWorkbenchBot bot, final SWTBotTreeItem treeItem,
       final String text) {
+    waitUntilTreeContainsText(bot, treeItem, text, SWTBotPreferences.TIMEOUT);
+  }
+
+  /**
+   * Wait until the tree item contains the given text with the timeout specified.
+   */
+  public static void waitUntilTreeContainsText(SWTWorkbenchBot bot,
+                                               final SWTBotTreeItem treeItem,
+                                               final String text,
+                                               long timeout) {
     bot.waitUntil(new DefaultCondition() {
       @Override
       public boolean test() throws Exception {
@@ -354,6 +366,6 @@ public class SwtBotTreeUtilities {
       public String getFailureMessage() {
         return "Text never appeared";
       }
-    });
+    }, timeout);
   }
 }


### PR DESCRIPTION
Also: increase timeout to 10s in DebugNativeAppEngineStandardProjectTest.testDebugLaunch when waiting for server termination