### PR TITLE
Explicitly prompt user to save dirty editors before launch

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -47,6 +47,7 @@ import org.eclipse.wst.server.core.IServerType;
 import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.eclipse.wst.server.core.ServerCore;
 import org.eclipse.wst.server.core.ServerUtil;
+import org.eclipse.wst.server.ui.internal.ServerUIPlugin;
 
 /**
  * A helper class for launching modules on a server
@@ -127,9 +128,15 @@ public class LaunchHelper {
     return serverWorkingCopy.save(false, progress.newChild(2));
   }
 
-  @VisibleForTesting
   protected void launch(IServer server, String launchMode, SubMonitor progress)
       throws CoreException {
+    // Explicitly offer to save dirty editors to avoid the puzzling prompt-to-save in
+    // IServer#start() that prompts the user <em>as the server continues to launch</em>.
+    // ServerUIPlugin.saveEditors() respects the "Save editors before starting the server"
+    // preference.
+    if (!ServerUIPlugin.saveEditors()) {
+      return;
+    }
     server.start(launchMode, progress);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -131,7 +131,7 @@ public class LaunchHelper {
   protected void launch(IServer server, String launchMode, SubMonitor progress)
       throws CoreException {
     // Explicitly offer to save dirty editors to avoid the puzzling prompt-to-save in
-    // IServer#start() that prompts the user <em>as the server continues to launch</em>.
+    // IServer#start() that prompts the user *as the server continues to launch*.
     // ServerUIPlugin.saveEditors() respects the "Save editors before starting the server"
     // preference.
     if (!ServerUIPlugin.saveEditors()) {


### PR DESCRIPTION
Explicitly call out to `ServerUIPlugin.saveEditors()` before starting the server with `IServer#start()`. Using `ServerUIPlugin.saveEditors()` respects the user's setting in _Preferences > Server > Launching > Save dirty editors before starting the server_. This is the same approach used by the _Servers_ view. There is one downside: if the user says _No_ to saving dirty editors, then the user will see the same puzzling behaviour as they will be prompted a second time as the server launch continues in the background.  But this same behaviour is seen when using the _Servers_ view.

Fixes #1427 
