### PR TITLE
Implement LaunchConfigurationDelegate#getProjectsForProblemSearch()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsGetAllModulesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsGetAllModulesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.localserver.server;
+
+import static org.mockito.Matchers.any;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsArrayContainingInOrder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests of {@link ModuleUtils#getAllModules(org.eclipse.wst.server.core.IServer)}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ModuleUtilsGetAllModulesTest {
+  @Mock
+  IServer server;
+
+  @Mock(name = "module1")
+  private IModule module1;
+  @Mock(name = "module2a")
+  private IModule module2a;
+  @Mock(name = "module2b")
+  private IModule module2b;
+  @Mock(name = "module3")
+  private IModule module3;
+
+
+
+  @Test
+  public void testGetAllModules_single() {
+    Mockito.when(server.getModules()).thenReturn(new IModule[] {module1});
+    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
+        .thenReturn(new IModule[0]);
+
+    IModule[] result = ModuleUtils.getAllModules(server);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(1, result.length);
+    Assert.assertThat(result[0], Matchers.sameInstance(module1));
+  }
+
+  @Test
+  public void testGetAllModules_multi() {
+    Mockito.when(server.getModules()).thenReturn(new IModule[] {module1});
+    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
+        .thenReturn(new IModule[0]);
+
+    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module1}),
+        any(IProgressMonitor.class))).thenReturn(new IModule[] {module2a, module2b});
+
+    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module1, module2b}),
+        any(IProgressMonitor.class))).thenReturn(new IModule[] {module3});
+
+    IModule[] result = ModuleUtils.getAllModules(server);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(4, result.length);
+    Assert.assertThat(result,
+        IsArrayContainingInOrder.arrayContaining(module1, module2a, module2b, module3));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import static org.mockito.Matchers.any;
-
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -26,22 +24,25 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IModule;
-import org.eclipse.wst.server.core.IServer;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.AdditionalMatchers;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ModuleUtilsTest {
 
-  private IModule module = Mockito.mock(IModule.class);
-  private IFile descriptorFile = Mockito.mock(IFile.class);
-  private IFolder webinf = Mockito.mock(IFolder.class);
+  @Mock
+  private IModule module;
+  @Mock
+  private IFile descriptorFile;
+  @Mock
+  private IFolder webinf;
 
   @Before
   public void turnOffLogging() {
@@ -101,43 +102,4 @@ public class ModuleUtilsTest {
     InputStream in = this.getClass().getResourceAsStream(testfile);
     Mockito.when(descriptorFile.getContents()).thenReturn(in);
   }
-
-  @Test
-  public void testGetAllModules_single() {
-    IServer server = Mockito.mock(IServer.class);
-    Mockito.when(server.getModules()).thenReturn(new IModule[] {module});
-    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
-        .thenReturn(new IModule[0]);
-
-    IModule[] result = ModuleUtils.getAllModules(server);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(1, result.length);
-    Assert.assertThat(result[0], Matchers.sameInstance(module));
-  }
-
-  @Test
-  public void testGetAllModules_multi() {
-    IServer server = Mockito.mock(IServer.class);
-    Mockito.when(server.getModules()).thenReturn(new IModule[] {module});
-    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
-        .thenReturn(new IModule[0]);
-
-    IModule module2a = Mockito.mock(IModule.class, "module2a");
-    IModule module2b = Mockito.mock(IModule.class, "module2b");
-    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module}),
-        any(IProgressMonitor.class))).thenReturn(new IModule[] {module2a, module2b});
-
-    IModule module3 = Mockito.mock(IModule.class, "module3");
-    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module, module2b}),
-        any(IProgressMonitor.class))).thenReturn(new IModule[] {module3});
-
-    IModule[] result = ModuleUtils.getAllModules(server);
-    Assert.assertNotNull(result);
-    Assert.assertEquals(4, result.length);
-    Assert.assertThat(result[0], Matchers.sameInstance(module));
-    Assert.assertThat(result[1], Matchers.sameInstance(module2a));
-    Assert.assertThat(result[2], Matchers.sameInstance(module2b));
-    Assert.assertThat(result[3], Matchers.sameInstance(module3));
-  }
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtilsTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
+import static org.mockito.Matchers.any;
+
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -24,11 +26,15 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.AdditionalMatchers;
 import org.mockito.Mockito;
 
 public class ModuleUtilsTest {
@@ -94,6 +100,44 @@ public class ModuleUtilsTest {
   private void mockAppEngineWebXml(String testfile) throws CoreException {
     InputStream in = this.getClass().getResourceAsStream(testfile);
     Mockito.when(descriptorFile.getContents()).thenReturn(in);
+  }
+
+  @Test
+  public void testGetAllModules_single() {
+    IServer server = Mockito.mock(IServer.class);
+    Mockito.when(server.getModules()).thenReturn(new IModule[] {module});
+    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
+        .thenReturn(new IModule[0]);
+
+    IModule[] result = ModuleUtils.getAllModules(server);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(1, result.length);
+    Assert.assertThat(result[0], Matchers.sameInstance(module));
+  }
+
+  @Test
+  public void testGetAllModules_multi() {
+    IServer server = Mockito.mock(IServer.class);
+    Mockito.when(server.getModules()).thenReturn(new IModule[] {module});
+    Mockito.when(server.getChildModules(any(IModule[].class), any(IProgressMonitor.class)))
+        .thenReturn(new IModule[0]);
+
+    IModule module2a = Mockito.mock(IModule.class, "module2a");
+    IModule module2b = Mockito.mock(IModule.class, "module2b");
+    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module}),
+        any(IProgressMonitor.class))).thenReturn(new IModule[] {module2a, module2b});
+
+    IModule module3 = Mockito.mock(IModule.class, "module3");
+    Mockito.when(server.getChildModules(AdditionalMatchers.aryEq(new IModule[] {module, module2b}),
+        any(IProgressMonitor.class))).thenReturn(new IModule[] {module3});
+
+    IModule[] result = ModuleUtils.getAllModules(server);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(4, result.length);
+    Assert.assertThat(result[0], Matchers.sameInstance(module));
+    Assert.assertThat(result[1], Matchers.sameInstance(module2a));
+    Assert.assertThat(result[2], Matchers.sameInstance(module2b));
+    Assert.assertThat(result[3], Matchers.sameInstance(module3));
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -41,11 +41,14 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -451,6 +454,34 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
         server.loadAdapter(LocalAppEngineServerBehaviour.class, null /* monitor */);
 
     return "http://" + server.getHost() + ":" + serverBehaviour.getServerPort(); //$NON-NLS-1$ //$NON-NLS-2$
+  }
+
+  @Override
+  protected IProject[] getBuildOrder(ILaunchConfiguration configuration, String mode)
+      throws CoreException {
+    IProject[] projects = getReferencedProjects(configuration);
+    return computeBuildOrder(projects);
+  }
+
+  @Override
+  protected IProject[] getProjectsForProblemSearch(ILaunchConfiguration configuration, String mode)
+      throws CoreException {
+    IProject[] projects = getReferencedProjects(configuration);
+    return computeReferencedBuildOrder(projects);
+  }
+
+  private static IProject[] getReferencedProjects(ILaunchConfiguration configuration)
+      throws CoreException {
+    IServer thisServer = ServerUtil.getServer(configuration);
+    IModule[] modules = ModuleUtils.getAllModules(thisServer);
+    Set<IProject> projects = new HashSet<>();
+    for (IModule module : modules) {
+      IProject project = module.getProject();
+      if (project != null) {
+        projects.add(project);
+      }
+    }
+    return projects.toArray(new IProject[projects.size()]);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
@@ -20,12 +20,16 @@ import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServer;
 
 /**
  * A set of utility methods for dealing with WTP {@link IModule}s.
@@ -55,5 +59,28 @@ public class ModuleUtils {
     }
     
     return "default";
+  }
+
+  /**
+   * Returns the set of all referenced modules, including child modules. This returns the unique
+   * modules, and doesn't return the module paths.
+   */
+  public static IModule[] getAllModules(IServer server) {
+    Set<IModule> modules = new LinkedHashSet<>();
+    for (IModule module : server.getModules()) {
+      modules.add(module);
+      addChildModules(server, new IModule[] {module}, modules);
+    }
+    return modules.toArray(new IModule[modules.size()]);
+  }
+
+  /** Recursively walk the children from {@code modulePath}. */
+  private static void addChildModules(IServer server, IModule[] modulePath, Set<IModule> modules) {
+    IModule[] newModulePath = Arrays.copyOf(modulePath, modulePath.length + 1);
+    for (IModule child : server.getChildModules(modulePath, null)) {
+      modules.add(child);
+      newModulePath[newModulePath.length - 1] = child;
+      addChildModules(server, newModulePath, modules);
+    }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
@@ -63,7 +63,9 @@ public class ModuleUtils {
 
   /**
    * Returns the set of all referenced modules, including child modules. This returns the unique
-   * modules, and doesn't return the module paths.
+   * modules, and doesn't return the module paths. Required as neither
+   * {@code Server#getAllModules()} nor the module-visiting method {@code #visit()} are exposed on
+   * {@link IServer}, and {@code ServerBehaviourDelegate#getAllModules()} is protected.
    */
   public static IModule[] getAllModules(IServer server) {
     Set<IModule> modules = new LinkedHashSet<>();
@@ -78,9 +80,10 @@ public class ModuleUtils {
   private static void addChildModules(IServer server, IModule[] modulePath, Set<IModule> modules) {
     IModule[] newModulePath = Arrays.copyOf(modulePath, modulePath.length + 1);
     for (IModule child : server.getChildModules(modulePath, null)) {
-      modules.add(child);
-      newModulePath[newModulePath.length - 1] = child;
-      addChildModules(server, newModulePath, modules);
+      if (modules.add(child)) {
+        newModulePath[newModulePath.length - 1] = child;
+        addChildModules(server, newModulePath, modules);
+      }
     }
   }
 }


### PR DESCRIPTION
Platform/Debug uses _LaunchConfigurationDelegate#getProjectsForProblemSearch()_ to return the list of projects to check for build errors.  Our launch configuration is not quite configured as expected by our superclass's implementation in `AbstractJavaLaunchConfigurationDelegate` and so we seemingly have no projects to check.  This fix provides an implementation of _getProjectsForProblemSearch()_ and _getBuildOrder()_ as derived from the server's configured modules.  The implementation requires obtaining the full list of modules used in a server definition (modules can have child modules — seen particularly in maven projects as per #136).

<img width="777" alt="screen shot 2017-02-21 at 9 43 01 pm" src="https://cloud.githubusercontent.com/assets/202851/23195040/c8ae8ac0-f87f-11e6-9669-a48a32563f06.PNG">

Fixes #1423 
