### PR TITLE
Avoid WTP DependencyGraph-related deadlocks

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.eclipse.appengine.facets.ui.AppEngineStandardProje
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
@@ -47,9 +46,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineStandardProjectConvertCommandHandlerTest {
-  private static final Logger logger =
-      Logger.getLogger(AppEngineStandardProjectConvertCommandHandlerTest.class.getName());
-
   @Rule
   public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/AppEngineStandardProjectConvertCommandHandlerTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.eclipse.appengine.facets.ui.AppEngineStandardProje
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -64,7 +63,7 @@ public class AppEngineStandardProjectConvertCommandHandlerTest {
       new AppEngineStandardProjectConvertCommandHandler();
 
   @Before
-  public void setUp() throws CoreException {
+  public void setUp() throws CoreException, OperationCanceledException, InterruptedException {
     facetedProject = ProjectFacetsManager.create(projectCreator.getProject());
 
     // Workaround deadlock bug described in Eclipse bug (https://bugs.eclipse.org/511793).
@@ -72,11 +71,7 @@ public class AppEngineStandardProjectConvertCommandHandlerTest {
     // above (from resource notifications) and from other resource changes from modifying the
     // project facets. So we force the dependency graph to defer updates.
     IDependencyGraph.INSTANCE.preUpdate();
-    try {
-      Job.getJobManager().join(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY, null);
-    } catch (OperationCanceledException | InterruptedException ex) {
-      logger.log(Level.WARNING, "Exception waiting for WTP Graph Update job", ex);
-    }
+    Job.getJobManager().join(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY, null);
   }
 
   @After


### PR DESCRIPTION
A _DependencyGraph_ deadlock reared its head in a build again:

```
"main" [1] TIMED_WAITING on org.eclipse.core.internal.jobs.Semaphore@2f5456c3
|     at java.lang.Object.wait(Native Method)
|     - waiting on org.eclipse.core.internal.jobs.Semaphore@2f5456c3
|     at org.eclipse.core.internal.jobs.Semaphore.acquire(Semaphore.java:39)
|     at org.eclipse.core.internal.jobs.OrderedLock.doAcquire(OrderedLock.java:170)
|     at org.eclipse.core.internal.jobs.OrderedLock.acquire(OrderedLock.java:106)
|     at org.eclipse.core.internal.jobs.OrderedLock.acquire(OrderedLock.java:82)
|     at org.eclipse.wst.common.componentcore.internal.StructureEdit.getComponentModelRoot(StructureEdit.java:467)
|     at org.eclipse.wst.common.componentcore.internal.StructureEdit.getWorkbenchModules(StructureEdit.java:506)
|     at org.eclipse.wst.common.componentcore.internal.StructureEdit.getComponent(StructureEdit.java:949)
|     at org.eclipse.wst.common.componentcore.internal.resources.VirtualComponent.createResource(VirtualComponent.java:124)
|     at org.eclipse.wst.common.componentcore.internal.resources.VirtualComponent.initializeResource(VirtualComponent.java:113)
|     at org.eclipse.wst.common.componentcore.internal.resources.VirtualComponent.<init>(VirtualComponent.java:148)
|     at org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager.createComponent(ComponentImplManager.java:250)
|     - locked org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager@62762026
|     at org.eclipse.wst.common.componentcore.ComponentCore.createComponent(ComponentCore.java:84)
|     at org.eclipse.jst.j2ee.web.project.facet.WebFacetInstallDelegate.setContentPropertyIfNeeded(WebFacetInstallDelegate.java:221)
|     at org.eclipse.jst.j2ee.web.project.facet.WebFacetInstallDelegate.execute(WebFacetInstallDelegate.java:86)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.callDelegate(FacetedProject.java:1477)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.modifyInternal(FacetedProject.java:441)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.mergeChangesInternal(FacetedProject.java:1181)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.access$2(FacetedProject.java:1117)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject$1.run(FacetedProject.java:324)
|     at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2240)
|     at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2267)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.modify(FacetedProject.java:339)
|     at org.eclipse.wst.common.project.facet.core.internal.FacetedProject.installProjectFacet(FacetedProject.java:255)
|     at com.google.cloud.tools.eclipse.appengine.facets.ui.AppEngineStandardProjectConvertCommandHandlerTest.testCheckFacetCompatibility_web3_0FacetIsIncompatible(AppEngineStandardProjectConvertCommandHandlerTest.java:120)
|     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
|     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
|     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
|     at java.lang.reflect.Method.invoke(Method.java:483)
|     at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
|     at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
|     at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
|     at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
|     at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
|     at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
|     at com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog$1.evaluate(ThreadDumpingWatchdog.java:69)
|     at org.junit.rules.RunRules.evaluate(RunRules.java:20)
|     at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
|     at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
|     at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
|     at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
|     at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
|     at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
|     at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
|     at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
|     at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
|     at org.mockito.internal.runners.JUnit45AndHigherRunnerImpl.run(JUnit45AndHigherRunnerImpl.java:37)
|     at org.mockito.runners.MockitoJUnitRunner.run(MockitoJUnitRunner.java:62)
|     at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
|     at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
|     at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
|     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
|     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
|     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
|     at java.lang.reflect.Method.invoke(Method.java:483)
|     at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
|     at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
|     at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
|     at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
|     at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.run(HeadlessTestApplication.java:21)
|     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
|     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
|     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
|     at java.lang.reflect.Method.invoke(Method.java:483)
|     at org.eclipse.equinox.internal.app.EclipseAppContainer.callMethodWithException(EclipseAppContainer.java:587)
|     at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:198)
|     at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
|     at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
|     at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
|     at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
|     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
|     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
|     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
|     at java.lang.reflect.Method.invoke(Method.java:483)
|     at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
|     at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
|     at org.eclipse.equinox.launcher.Main.run(Main.java:1499)
|     at org.eclipse.equinox.launcher.Main.main(Main.java:1472)
| 
| "Worker-2" [66] BLOCKED on org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager@62762026 owned by 'main [id:1]
|     at org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager.createComponent(ComponentImplManager.java)
|     - blocked on org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager@62762026
|     at org.eclipse.wst.common.componentcore.internal.util.ComponentImplManager.createComponent(ComponentImplManager.java:212)
|     at org.eclipse.wst.common.componentcore.ComponentCore.createComponent(ComponentCore.java:64)
|     at org.eclipse.wst.common.componentcore.internal.builder.DependencyGraphImpl$GraphUpdateJob$1.run(DependencyGraphImpl.java:494)
|     at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
|     at org.eclipse.wst.common.componentcore.internal.builder.DependencyGraphImpl$GraphUpdateJob.run(DependencyGraphImpl.java:462)
|     at org.eclipse.core.internal.jobs.Worker.run(Worker.java:56)
| 
```