### PR TITLE
Move UI classes to .ui package

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.login/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.login/plugin.xml
@@ -2,7 +2,7 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension point="org.eclipse.ui.startup">
-     <startup class="com.google.cloud.tools.eclipse.login.MenuContributionInitializer"/>
+     <startup class="com.google.cloud.tools.eclipse.login.ui.MenuContributionInitializer"/>
    </extension>
 
    <extension
@@ -20,7 +20,7 @@
    <extension
          point="org.eclipse.ui.handlers">
       <handler
-            class="com.google.cloud.tools.eclipse.login.GoogleLoginCommandHandler"
+            class="com.google.cloud.tools.eclipse.login.ui.GoogleLoginCommandHandler"
             commandId="com.google.cloud.tools.eclipse.login.commands.loginCommand">
       </handler>
    </extension>

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/CredentialHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/CredentialHelper.java
@@ -16,11 +16,10 @@
 
 package com.google.cloud.tools.eclipse.login;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Helper class to work with {@link Credential} objects

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/GoogleLoginCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/GoogleLoginCommandHandler.java
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.login;
+package com.google.cloud.tools.eclipse.login.ui;
 
-import com.google.cloud.tools.eclipse.login.ui.AccountsPanel;
+import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
+import com.google.cloud.tools.eclipse.login.Messages;
 import com.google.cloud.tools.eclipse.ui.util.ServiceUtils;
-
+import java.util.Map;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.menus.UIElement;
-
-import java.util.Map;
 
 public class GoogleLoginCommandHandler extends AbstractHandler implements IElementUpdater {
 

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/MenuContributionInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/MenuContributionInitializer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.login;
+package com.google.cloud.tools.eclipse.login.ui;
 
 import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;


### PR DESCRIPTION
Moving `MenuContributionInitializer` and `GoogleLoginCommandHandler` to the `.ui` package.