### PR TITLE
Fix inconsistent class hierarchy errors within Eclipse

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
                .
 javacSource=1.7
 javacTarget=1.7
+additional.bundles = org.eclipse.jface

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/build.properties
@@ -7,3 +7,4 @@ bin.includes = META-INF/,\
                xslt/
 javacSource=1.7
 javacTarget=1.7               
+additional.bundles = org.eclipse.jface


### PR DESCRIPTION
I'm seeing inconsistent-class-hierarchy errors within Eclipse as the compiler requires some JFace class definitions when processing `XsltQuickFix` and `ValidationTestUtils`.  We can make them available with the `additional.bundles` directive.

<img width="671" alt="screen shot 2017-02-27 at 4 44 55 pm" src="https://cloud.githubusercontent.com/assets/202851/23381346/18920950-fd0c-11e6-9965-2aa5b22d2046.PNG">
