### PR TITLE
Add watchdog timer to LibraryClasspathContainerInitializerTest

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -27,9 +27,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.persistence.LibraryClasspathContainerSerializer;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -64,9 +66,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class LibraryClasspathContainerInitializerTest {
 
-/**
-   * 
-   */
   private static final String NON_EXISTENT_FILE = "/non/existent/file";
   private static final String TEST_CONTAINER_PATH = "test.appengine.libraries";
   private static final String TEST_LIBRARY_ID = "libraryId";
@@ -74,6 +73,9 @@ public class LibraryClasspathContainerInitializerTest {
 
   @Mock private ILibraryClasspathContainerResolverService resolverService;
   @Mock private LibraryClasspathContainerSerializer serializer;
+
+  @Rule
+  public ThreadDumpingWatchdog watchdog = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Rule
   public TestProjectCreator testProject = new TestProjectCreator().withClasspathContainerPath(TEST_LIBRARY_PATH);


### PR DESCRIPTION
Noticed a test hang in LibraryClasspathContainerInitializerTest.

```
Running com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainerInitializerTest
!SESSION 2017-02-27 21:41:58.224 -----------------------------------------------
eclipse.buildId=unknown
java.version=1.8.0_31
java.vendor=Oracle Corporation
BootLoader constants: OS=linux, ARCH=x86_64, WS=gtk, NL=en_US
Framework arguments:  -application org.eclipse.tycho.surefire.osgibooter.headlesstest -testproperties /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/target/surefire.properties
Command-line arguments:  -debug -consolelog -data /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/target/work/data -application org.eclipse.tycho.surefire.osgibooter.headlesstest -testproperties /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/target/surefire.properties
!ENTRY org.eclipse.wst.common.project.facet.core 4 0 2017-02-27 21:42:20.159
!MESSAGE Project facet jst.ejb has not been defined. It is used in plugin org.eclipse.jst.j2ee.
[ERROR] Timeout 600 s exceeded. Process was killed.
```