### PR TITLE
Add support for switching to recommended perspective

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.flex/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.flex/plugin.xml
@@ -35,6 +35,8 @@
             class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.newproject.flex.AppEngineFlexProjectWizard"
             icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
             project="true"
+            finalPerspective="org.eclipse.jst.j2ee.J2EEPerspective"
+            preferredPerspectives="org.eclipse.jst.j2ee.J2EEPerspective,org.eclipse.wst.web.ui.webDevPerspective"
             category="com.google.cloud.tools.eclipse.appengine.wizards">
          <description>%flexWizardDescription</description>
          <selection class="org.eclipse.core.resources.IResource"/>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.2.6",
  org.eclipse.core.jobs,
  org.eclipse.m2e.core;bundle-version="1.6.2",
  org.eclipse.m2e.core.ui;bundle-version="1.6.2",
- org.eclipse.m2e.maven.runtime
+ org.eclipse.m2e.maven.runtime,
+ org.eclipse.equinox.registry
 Bundle-ActivationPolicy: lazy
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.cloud.tools.eclipse.appengine.libraries.model,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/plugin.xml
@@ -8,6 +8,8 @@
             class="com.google.cloud.tools.eclipse.appengine.newproject.maven.MavenArchetypeProjectWizard"
             icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
             project="true"
+            finalPerspective="org.eclipse.jst.j2ee.J2EEPerspective"
+            preferredPerspectives="org.eclipse.jst.j2ee.J2EEPerspective,org.eclipse.wst.web.ui.webDevPerspective"
             category="com.google.cloud.tools.eclipse.appengine.wizards">
          <description>%mavenwizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -3,12 +3,14 @@
 <plugin>
   <extension point="org.eclipse.ui.newWizards">
      <wizard
-            id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard"
-            name="%wizard.name"
-            class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.newproject.standard.AppEngineStandardProjectWizard"
-            icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
-            project="true"
-            category="com.google.cloud.tools.eclipse.appengine.wizards">
+           category="com.google.cloud.tools.eclipse.appengine.wizards"
+           icon="platform:/plugin/com.google.cloud.tools.eclipse.appengine.ui/icons/gae-16x16.png"
+           id="com.google.cloud.tools.eclipse.appengine.newproject.AppEngineStandard"
+           name="%wizard.name"
+           class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.newproject.standard.AppEngineStandardProjectWizard"
+           finalPerspective="org.eclipse.jst.j2ee.J2EEPerspective"
+           preferredPerspectives="org.eclipse.jst.j2ee.J2EEPerspective,org.eclipse.wst.web.ui.webDevPerspective"
+           project="true">
          <description>%wizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GCPKeyword"/>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -47,6 +47,9 @@ public class BaseProjectTest {
     } catch (WidgetNotFoundException ex) {
       // may receive WNFE: "There is no active view"
     }
+
+    // switch to J2EE to avoid new-project switch-perspective prompts
+    bot.perspectiveById("org.eclipse.jst.j2ee.J2EEPerspective").activate();
   }
 
   @After

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/service/ServiceContextFactory.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/service/ServiceContextFactory.java
@@ -1,5 +1,6 @@
 package com.google.cloud.tools.eclipse.util.service;
 
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExecutableExtension;
@@ -12,11 +13,10 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
-import com.google.cloud.tools.eclipse.util.status.StatusUtil;
-
 public class ServiceContextFactory implements IExecutableExtensionFactory, IExecutableExtension {
 
   private Class<?> clazz;
+  private IConfigurationElement configElement;
 
   @Override
   public void setInitializationData(IConfigurationElement config, String propertyName, Object data)
@@ -24,6 +24,7 @@ public class ServiceContextFactory implements IExecutableExtensionFactory, IExec
       if (data == null || !(data instanceof String)) {
         throw new CoreException(StatusUtil.error(getClass(), "Data must be a class name"));
       }
+    configElement = config;
       String className = (String) data;
       String bundleSymbolicName = config.getNamespaceIdentifier();
       Bundle bundle = Platform.getBundle(bundleSymbolicName);
@@ -44,6 +45,12 @@ public class ServiceContextFactory implements IExecutableExtensionFactory, IExec
   public Object create() throws CoreException {
     BundleContext bundleContext = FrameworkUtil.getBundle(clazz).getBundleContext();
     IEclipseContext serviceContext = EclipseContextFactory.getServiceContext(bundleContext);
-    return ContextInjectionFactory.make(clazz, serviceContext);
+    IEclipseContext staticContext = EclipseContextFactory.create();
+    staticContext.set(IConfigurationElement.class, configElement);
+    try {
+      return ContextInjectionFactory.make(clazz, serviceContext, staticContext);
+    } finally {
+      staticContext.dispose();
+    }
   }
 }


### PR DESCRIPTION
Makes the J2EE perspective the recommended perspective (the _final_ perspective) for our New Project wizards, but marks the J2EE and Web perspectives as being acceptable (the _preferred_ perspectives).

No explicit test for this, but I had to change the integration tests to switch to the J2EE perspective as the would-you-like-to-switch-perspective dialog interfered.