### PR TITLE
Order our New menu to distinguish App Engine Standard from Flexible

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.flex/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.flex/plugin.xml
@@ -77,7 +77,7 @@
         point="org.eclipse.ui.menus">
      <menuContribution
            allPopups="false"
-           locationURI="menu:com.google.cloud.tools.eclipse.appengine.actions.new">
+           locationURI="menu:com.google.cloud.tools.eclipse.appengine.actions.new?after=com.google.cloud.tools.eclipse.appengine.flexible">
         <command
               commandId="org.eclipse.ui.newWizard"
               style="push">

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
@@ -41,6 +41,10 @@
         <menu
               id="com.google.cloud.tools.eclipse.appengine.actions.new"
               label="%createNewProject">
+           <separator
+                 name="com.google.cloud.tools.eclipse.appengine.standard"
+                 visible="true">
+           </separator>
            <command
                  commandId="org.eclipse.ui.newWizard"
                  style="push">
@@ -57,6 +61,10 @@
                     value="com.google.cloud.tools.eclipse.appengine.newproject.MavenAppEngineStandard">
               </parameter>
            </command>
+           <separator
+                 name="com.google.cloud.tools.eclipse.appengine.flexible"
+                 visible="true">
+           </separator>
         </menu>
         <separator
               name="launch"


### PR DESCRIPTION
Adds placeholders to our GCP Toolbar's _New_ menu to separate _Standard_ options from _Flexible_.

<img width="689" alt="screen shot 2017-03-07 at 1 37 35 pm" src="https://cloud.githubusercontent.com/assets/202851/23672331/532e2e46-033c-11e7-816b-debb1f8f7b2d.PNG">

Fixes #1536