### PR TITLE
Fix build hang on .validation.test

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
@@ -17,5 +17,8 @@ Import-Package: com.google.cloud.tools.eclipse.appengine.compat,
  org.eclipse.core.resources,
  org.eclipse.jface.text,
  org.eclipse.jface.text.contentassist,
+ org.eclipse.jst.common.project.facet.core,
+ org.eclipse.jst.j2ee.web.project.facet,
  org.eclipse.ui,
+ org.eclipse.wst.common.project.facet.core,
  org.mockito;provider=google

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
@@ -7,18 +7,12 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.validation.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.validation
-Require-Bundle: org.junit,
- org.eclipse.equinox.registry,
- com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.appengine.compat,
- com.google.cloud.tools.eclipse.test.util,
+Require-Bundle: org.junit;bundle-version="4.12.0"
+Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.ui.util,
- org.eclipse.core.resources,
- org.eclipse.jface.text,
- org.eclipse.jface.text.contentassist,
  org.eclipse.jst.common.project.facet.core,
  org.eclipse.jst.j2ee.web.project.facet,
- org.eclipse.ui,
  org.eclipse.wst.common.project.facet.core,
- org.mockito;provider=google
+ org.mockito;provider=google;version="1.10.19",
+ org.mockito.stubbing;provider=google;version="1.10.19"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
@@ -39,6 +39,11 @@
                 <id>org.eclipse.wst.xml.ui</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.jst.web_ui.feature</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
@@ -31,7 +31,7 @@
             <extraRequirements>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.rcp</id>
+                <id>org.eclipse.platform</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/pom.xml
@@ -31,7 +31,7 @@
             <extraRequirements>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.platform</id>
+                <id>org.eclipse.rcp</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
@@ -19,51 +19,55 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
-
 public class XsltSourceQuickFixTest {
-  
+
   private static final String APPLICATION_XML =
       "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>"
       + "<application>"
       + "</application>"
       + "</appengine-web-app>";
-  
+
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
-  
+
   @Test
   public void testApply() throws CoreException {
-    
+
     IProject project = projectCreator.getProject();
     IFile file = project.getFile("testdata.xml");
     file.create(ValidationTestUtils.stringToInputStream(
       APPLICATION_XML), IFile.FORCE, null);
-    
+
     IWorkbench workbench = PlatformUI.getWorkbench();
-    WorkbenchUtil.openInEditor(workbench, file);
+    IEditorPart editorPart = WorkbenchUtil.openInEditor(workbench, file);
     ITextViewer viewer = ValidationTestUtils.getViewer(file);
     String preContents = viewer.getDocument().get();
-    
+
     assertTrue(preContents.contains("application"));
-    
+
     XsltSourceQuickFix quickFix = new XsltSourceQuickFix("/xslt/application.xsl",
         Messages.getString("remove.application.element"));
     quickFix.apply(viewer, 'a', 0, 0);
-    
+
     IDocument document = viewer.getDocument();
     String contents = document.get();
     assertFalse(contents.contains("application"));
+
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1527
+    editorPart.doSave(new NullProgressMonitor());
   }
-  
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
@@ -24,7 +24,6 @@ import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
 import java.util.Arrays;
-import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -37,7 +36,6 @@ import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -52,11 +50,8 @@ public class XsltSourceQuickFixTest {
       + "</application>"
       + "</appengine-web-app>";
 
-  private static final List<IProjectFacetVersion> facetsToInstall = Arrays.asList(
-      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25);
-
-  @Rule public TestProjectCreator projectCreator = new TestProjectCreator()
-      .withFacetVersions(facetsToInstall);
+  @Rule public TestProjectCreator projectCreator = new TestProjectCreator().withFacetVersions(
+      Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25));
 
   @Test
   public void testApply() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltSourceQuickFixTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
@@ -39,7 +38,6 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
-import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,11 +52,8 @@ public class XsltSourceQuickFixTest {
       + "</application>"
       + "</appengine-web-app>";
 
-  private static final IProjectFacetVersion APPENGINE_STANDARD_FACET_VERSION_1 =
-      ProjectFacetsManager.getProjectFacet(AppEngineStandardFacet.ID).getVersion("1");
-
   private static final List<IProjectFacetVersion> facetsToInstall = Arrays.asList(
-      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, APPENGINE_STANDARD_FACET_VERSION_1);
+      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25);
 
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator()
       .withFacetVersions(facetsToInstall);

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/WorkbenchUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/WorkbenchUtil.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.program.Program;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -41,22 +42,23 @@ public class WorkbenchUtil {
 
   /**
    * Open the specified file in the editor.
-   * 
+   *
    * @param workbench the active workbench
    * @param file the file to open
    */
-  public static void openInEditor(IWorkbench workbench, IFile file) {
+  public static IEditorPart openInEditor(IWorkbench workbench, IFile file) {
     IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
     if (window != null && file != null) {
       IWorkbenchPage page = window.getActivePage();
       try {
-        IDE.openEditor(page, file, true);
+        return IDE.openEditor(page, file, true);
       } catch (PartInitException ex) {
         // ignore; we don't have to open the file
       }
     }
+    return null;
   }
-  
+
   /**
    * Opens the specified url in a Web browser instance in a UI thread.
    *


### PR DESCRIPTION
Fixes #1527.

About `org.eclispe.platform`: I had originally thought using `org.eclipse.platform` instead of `org.eclipse.rcp` somehow eliminated the build hang (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/1484#issuecomment-282609491), but it wasn't the case, so I am reverting that.