### PR TITLE
move AppEngineLibraries to model package and rename

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.appengine.libraries;
+package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Filter;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
@@ -34,10 +35,10 @@ import java.util.List;
 import org.junit.Test;
 
 /**
- * Test the App Engine libraries defined in plugin.xml to validate that
+ * Test the libraries defined in plugin.xml to validate that
  * their attributes are correctly set.
  */
-public class AppEngineLibrariesInPluginXmlTest {
+public class CloudLibrariesInPluginXmlTest {
 
   private static final String APP_ENGINE_API_LIBRARY_ID = "appengine-api";
   private static final String CLOUD_ENDPOINTS_LIBRARY_ID = "appengine-endpoints";
@@ -47,13 +48,13 @@ public class AppEngineLibrariesInPluginXmlTest {
 
   @Test
   public void testLibrarySize() {
-    assertThat(AppEngineLibraries.getLibraries("appengine").size(), is(3));
-    assertThat(AppEngineLibraries.getLibraries("servlet").size(), is(2));
+    assertThat(CloudLibraries.getLibraries("appengine").size(), is(3));
+    assertThat(CloudLibraries.getLibraries("servlet").size(), is(2));
   }
 
   @Test
   public void testAppEngineApiLibraryConfig() throws URISyntaxException {
-    Library appEngineLibrary = AppEngineLibraries.getLibrary(APP_ENGINE_API_LIBRARY_ID);
+    Library appEngineLibrary = CloudLibraries.getLibrary(APP_ENGINE_API_LIBRARY_ID);
     assertThat(appEngineLibrary.getContainerPath().toString(),
                is(Library.CONTAINER_PATH_PREFIX + "/" + APP_ENGINE_API_LIBRARY_ID));
     assertThat(appEngineLibrary.getId(), is(APP_ENGINE_API_LIBRARY_ID));
@@ -95,7 +96,7 @@ public class AppEngineLibrariesInPluginXmlTest {
 
   @Test
   public void testEndpointsLibraryConfig() throws URISyntaxException {
-    Library endpointsLibrary = AppEngineLibraries.getLibrary(CLOUD_ENDPOINTS_LIBRARY_ID);
+    Library endpointsLibrary = CloudLibraries.getLibrary(CLOUD_ENDPOINTS_LIBRARY_ID);
     assertThat(endpointsLibrary.getContainerPath().toString(),
                is(Library.CONTAINER_PATH_PREFIX + "/" + CLOUD_ENDPOINTS_LIBRARY_ID));
     assertThat(endpointsLibrary.getId(), is(CLOUD_ENDPOINTS_LIBRARY_ID));
@@ -133,7 +134,7 @@ public class AppEngineLibrariesInPluginXmlTest {
 
   @Test
   public void testObjectifyLibraryConfig() throws URISyntaxException {
-    Library objectifyLibrary = AppEngineLibraries.getLibrary(OBJECTIFY_LIBRARY_ID);
+    Library objectifyLibrary = CloudLibraries.getLibrary(OBJECTIFY_LIBRARY_ID);
     assertThat(objectifyLibrary.getContainerPath().toString(),
                is(Library.CONTAINER_PATH_PREFIX + "/" + OBJECTIFY_LIBRARY_ID));
     assertThat(objectifyLibrary.getId(), is(OBJECTIFY_LIBRARY_ID));
@@ -183,7 +184,7 @@ public class AppEngineLibrariesInPluginXmlTest {
 
   @Test
   public void testServletApiLibraryConfig() throws URISyntaxException {
-    Library servletApiLibrary = AppEngineLibraries.getLibrary(SERVLET_API_LIBRARY_ID);
+    Library servletApiLibrary = CloudLibraries.getLibrary(SERVLET_API_LIBRARY_ID);
     assertThat(servletApiLibrary.getContainerPath().toString(),
                is(Library.CONTAINER_PATH_PREFIX + "/" + SERVLET_API_LIBRARY_ID));
     assertThat(servletApiLibrary.getId(), is(SERVLET_API_LIBRARY_ID));
@@ -217,7 +218,7 @@ public class AppEngineLibrariesInPluginXmlTest {
 
   @Test
   public void testJspApiLibraryConfig() throws URISyntaxException {
-    Library jspApiLibrary = AppEngineLibraries.getLibrary(JSP_API_LIBRARY_ID);
+    Library jspApiLibrary = CloudLibraries.getLibrary(JSP_API_LIBRARY_ID);
     assertThat(jspApiLibrary.getContainerPath().toString(),
                is(Library.CONTAINER_PATH_PREFIX + "/" + JSP_API_LIBRARY_ID));
     assertThat(jspApiLibrary.getId(), is(JSP_API_LIBRARY_ID));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.appengine.libraries;
+package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 
-public class AppEngineLibrariesTest {
+public class CloudLibrariesTest {
   
   @Test
   public void testGetLibraries() {
-    List<Library> libraries = AppEngineLibraries.getLibraries("appengine");
+    List<Library> libraries = CloudLibraries.getLibraries("appengine");
     for (Library library : libraries) {
       Assert.assertFalse(library.getLibraryFiles().isEmpty());
       String tooltip = library.getToolTip();
@@ -39,13 +40,13 @@ public class AppEngineLibrariesTest {
   
   @Test
   public void testGetLibraries_null() {
-    List<Library> libraries = AppEngineLibraries.getLibraries(null);
+    List<Library> libraries = CloudLibraries.getLibraries(null);
     Assert.assertTrue(libraries.isEmpty());
   }
   
   @Test
   public void testGetLibrary() {
-    Library library = AppEngineLibraries.getLibrary("objectify");
+    Library library = CloudLibraries.getLibrary("objectify");
     Assert.assertEquals(library.getGroup(), "appengine");
     Assert.assertEquals(library.getName(), "Objectify");
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.appengine.libraries;
+package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +24,9 @@ import java.util.logging.Logger;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.RegistryFactory;
 
-import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFactory;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFactoryException;
 import com.google.common.collect.ImmutableMap;
 
-public class AppEngineLibraries {
+public class CloudLibraries {
 
   /**
    * Library files for App Engine Standard environment applications; specifically
@@ -43,7 +40,7 @@ public class AppEngineLibraries {
    */
   public static final String SERVLET_GROUP = "servlet";
   
-  private static final Logger logger = Logger.getLogger(AppEngineLibraries.class.getName());
+  private static final Logger logger = Logger.getLogger(CloudLibraries.class.getName());
   private static final ImmutableMap<String, Library> libraries = loadLibraryDefinitions();
   
   // todo consider caching maps of group to libraries

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
@@ -27,9 +27,7 @@ import java.util.logging.Logger;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.InvalidRegistryObjectException;
 
-// todo AppEngineLibraries and LibraryFactory should be in the same package and then this doesn't
-// need to be public
-public class LibraryFactory {
+class LibraryFactory {
 
   private static final Logger logger = Logger.getLogger(LibraryFactory.class.getName());
 
@@ -57,7 +55,7 @@ public class LibraryFactory {
   private static final String ATTRIBUTE_NAME_EXPORT = "export"; //$NON-NLS-1$
   private static final String ATTRIBUTE_NAME_RECOMMENDATION = "recommendation"; //$NON-NLS-1$
 
-  public Library create(IConfigurationElement configurationElement) throws LibraryFactoryException {
+  Library create(IConfigurationElement configurationElement) throws LibraryFactoryException {
     try {
       if (ELEMENT_NAME_LIBRARY.equals(configurationElement.getName())) {
         Library library = new Library(configurationElement.getAttribute(ATTRIBUTE_NAME_ID));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
@@ -16,11 +16,11 @@
 
 package com.google.cloud.tools.eclipse.appengine.libraries.repository;
 
-import com.google.cloud.tools.eclipse.appengine.libraries.AppEngineLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.ILibraryClasspathContainerResolverService;
 import com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainer;
 import com.google.cloud.tools.eclipse.appengine.libraries.Messages;
 import com.google.cloud.tools.eclipse.appengine.libraries.SourceAttacherJob;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Filter;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
@@ -87,7 +87,7 @@ public class LibraryClasspathContainerResolverService
   }
 
   public IClasspathEntry[] resolveLibraryAttachSourcesSync(String libraryId) throws CoreException {
-    Library library = AppEngineLibraries.getLibrary(libraryId);
+    Library library = CloudLibraries.getLibrary(libraryId);
     if (library != null) {
       IClasspathEntry[] resolvedEntries = new IClasspathEntry[library.getLibraryFiles().size()];
       int idx = 0;
@@ -106,7 +106,7 @@ public class LibraryClasspathContainerResolverService
     Preconditions.checkArgument(containerPath.segment(0).equals(Library.CONTAINER_PATH_PREFIX));
     try {
       String libraryId = containerPath.segment(1);
-      Library library = AppEngineLibraries.getLibrary(libraryId);
+      Library library = CloudLibraries.getLibrary(libraryId);
       if (library != null) {
         List<Job> sourceAttacherJobs = new ArrayList<>();
         LibraryClasspathContainer container = resolveLibraryFiles(javaProject, containerPath,
@@ -140,7 +140,7 @@ public class LibraryClasspathContainerResolverService
   private IStatus checkAppEngineStandardJava7(IProgressMonitor monitor) {
     try {
       for (String libraryId : new String[]{ "servlet-api", "jsp-api"}) {
-        Library library = AppEngineLibraries.getLibrary(libraryId);
+        Library library = CloudLibraries.getLibrary(libraryId);
         for (LibraryFile libraryFile : library.getLibraryFiles()) {
           if (monitor.isCanceled()) {
             return Status.CANCEL_STATUS;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineLibrariesSelectorGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineLibrariesSelectorGroup.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.ui;
 
-import com.google.cloud.tools.eclipse.appengine.libraries.AppEngineLibraries;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -57,7 +57,7 @@ public class AppEngineLibrariesSelectorGroup implements ISelectionProvider {
 
   public AppEngineLibrariesSelectorGroup(Composite parentContainer) {
     Collection<Library> availableLibraries =
-        AppEngineLibraries.getLibraries(AppEngineLibraries.APP_ENGINE_GROUP);
+        CloudLibraries.getLibraries(CloudLibraries.APP_ENGINE_GROUP);
     Preconditions.checkNotNull(parentContainer, "parentContainer is null");
     Preconditions.checkNotNull(availableLibraries, "availableLibraries is null");
     


### PR DESCRIPTION
@nbashirbello @akerekes fix #1467 

Soon these classes are going to be used for non-AppEngine libraries such as Cloud SQL. Hence the rename. 