### PR TITLE
add client libraries group

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPageTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.libraries.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ApiClientLibrariesPageTest {
+
+  private ApiClientLibrariesPage page = new ApiClientLibrariesPage();
+
+  @Test
+  public void testConstructor() {
+    Assert.assertEquals("Google Client APIs for Java", page.getTitle());
+    Assert.assertNull(page.getMessage());
+    Assert.assertNull(page.getErrorMessage());
+    Assert.assertEquals(
+        "Additional jars used by Google Client APIs for Java",
+        page.getDescription());
+    Assert.assertNotNull(page.getImage());
+  }
+  
+  @Test
+  public void testFinish() {
+    Assert.assertTrue(page.finish());
+  }
+  
+  @Test
+  public void testGetSelection() {
+    Assert.assertNull(page.getSelection());
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPageTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 
 public class ApiClientLibrariesPageTest {
 
-  private ApiClientLibrariesPage page = new ApiClientLibrariesPage();
+  private final ApiClientLibrariesPage page = new ApiClientLibrariesPage();
 
   @Test
   public void testConstructor() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/MessagesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/MessagesTest.java
@@ -22,15 +22,26 @@ import org.junit.Test;
 public class MessagesTest {
 
   @Test
-  public void testTitle() {
-    Assert.assertEquals("App Engine Standard Environment Libraries",  Messages.getString("title"));
+  public void testAppEngineTitle() {
+    Assert.assertEquals("App Engine Standard Environment Libraries",  Messages.getString("appengine-title"));
+  }
+  
+  @Test
+  public void testClientApisTitle() {
+    Assert.assertEquals("Google Client APIs for Java",  Messages.getString("clientapis-title"));
+  }
+  
+  @Test
+  public void testClientApisDescription() {
+    Assert.assertEquals("Additional jars used by Google Client APIs for Java", 
+        Messages.getString("clientapis-description"));
   }
   
   @Test
   public void testDescription() {
     Assert.assertEquals(
         "Additional jars commonly used in App Engine Standard Environment applications", 
-        Messages.getString("description"));
+        Messages.getString("appengine-description"));
   }
   
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/plugin.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+
    <extension point="org.eclipse.jdt.ui.classpathContainerPage">
      <classpathContainerPage
        id="com.google.cloud.tools.eclipse.appengine.libraries.ui"
        name="App Engine Libraries"
        class="com.google.cloud.tools.eclipse.appengine.libraries.ui.AppEngineLibrariesPage">
     </classpathContainerPage>
+    <classpathContainerPage
+       id="com.google.cloud.tools.eclipse.appengine.libraries.ui"
+       name="Google API Libraries"
+       class="com.google.cloud.tools.eclipse.appengine.libraries.ui.ApiClientLibrariesPage">
+    </classpathContainerPage>
+    
  </extension>
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/plugin.xml
@@ -4,12 +4,12 @@
 
    <extension point="org.eclipse.jdt.ui.classpathContainerPage">
      <classpathContainerPage
-       id="com.google.cloud.tools.eclipse.appengine.libraries.ui"
+       id="com.google.cloud.tools.eclipse.appengine.libraries"
        name="App Engine Libraries"
        class="com.google.cloud.tools.eclipse.appengine.libraries.ui.AppEngineLibrariesPage">
     </classpathContainerPage>
     <classpathContainerPage
-       id="com.google.cloud.tools.eclipse.appengine.libraries.ui"
+       id="com.google.cloud.tools.eclipse.appengine.libraries"
        name="Google API Libraries"
        class="com.google.cloud.tools.eclipse.appengine.libraries.ui.ApiClientLibrariesPage">
     </classpathContainerPage>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ApiClientLibrariesPage.java
@@ -18,14 +18,10 @@ package com.google.cloud.tools.eclipse.appengine.libraries.ui;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 
-/**
- * UI for adding App Engine libraries to an existing project.
- */
-public class AppEngineLibrariesPage extends CloudLibrariesPage {
+public class ApiClientLibrariesPage extends CloudLibrariesPage {
 
-  public AppEngineLibrariesPage() {
-    super(CloudLibraries.APP_ENGINE_GROUP);
+  public ApiClientLibrariesPage() {
+    super(CloudLibraries.CLIENT_APIS_GROUP);
   }
-
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
@@ -42,7 +42,7 @@ import com.google.cloud.tools.eclipse.util.MavenUtils;
 public abstract class CloudLibrariesPage extends WizardPage implements IClasspathContainerPage,
     IClasspathContainerPageExtension, IClasspathContainerPageExtension2 {
 
-  private static final Logger logger = Logger.getLogger(AppEngineLibrariesPage.class.getName());
+  private static final Logger logger = Logger.getLogger(CloudLibrariesPage.class.getName());
   private LibrarySelectorGroup librariesSelector;
   private IJavaProject project;
   private final String group;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.libraries.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.ui.wizards.IClasspathContainerPage;
+import org.eclipse.jdt.ui.wizards.IClasspathContainerPageExtension;
+import org.eclipse.jdt.ui.wizards.IClasspathContainerPageExtension2;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+import com.google.cloud.tools.eclipse.appengine.libraries.BuildPath;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
+import com.google.cloud.tools.eclipse.appengine.ui.LibrarySelectorGroup;
+import com.google.cloud.tools.eclipse.util.MavenUtils;
+
+public abstract class CloudLibrariesPage extends WizardPage implements IClasspathContainerPage,
+    IClasspathContainerPageExtension, IClasspathContainerPageExtension2 {
+
+  private static final Logger logger = Logger.getLogger(AppEngineLibrariesPage.class.getName());
+  private LibrarySelectorGroup librariesSelector;
+  private IJavaProject project;
+  private final String group;
+
+  protected CloudLibrariesPage(String group) {
+    super(group + "-page"); //$NON-NLS-1$
+    setTitle(Messages.getString(group + "-title"));  //$NON-NLS-1$
+    setDescription(Messages.getString(group + "-description"));  //$NON-NLS-1$
+    setImageDescriptor(AppEngineImages.appEngine(64));
+    this.group = group;
+  }
+
+  @Override
+  public void createControl(Composite parent) {
+    Composite composite = new Composite(parent, SWT.BORDER);
+    composite.setLayout(new GridLayout(2, true));
+    
+    librariesSelector = new LibrarySelectorGroup(composite, group);
+    
+    setControl(composite);
+  }
+
+  @Override
+  public boolean finish() {
+    return true;
+  }
+
+  @Override
+  public IClasspathEntry getSelection() {
+    // Since this class implements IClasspathContainerPageExtension2,
+    // Eclipse calls getNewContainers instead.
+    logger.log(Level.WARNING, "Unexpected call to getSelection()");
+    return null;
+  }
+
+  @Override
+  public void setSelection(IClasspathEntry containerEntry) {
+  }
+
+  @Override
+  public void initialize(IJavaProject project, IClasspathEntry[] currentEntries) {
+    this.project = project;
+  }
+
+  @Override
+  public IClasspathEntry[] getNewContainers() {
+    List<Library> libraries = new ArrayList<>(librariesSelector.getSelectedLibraries());
+    if (libraries == null || libraries.isEmpty()) {
+      return null;
+    }
+  
+    try {
+      if (MavenUtils.hasMavenNature(project.getProject())) {
+        BuildPath.addMavenLibraries(project.getProject(), libraries, new NullProgressMonitor());
+        return new IClasspathEntry[0];
+      } else {
+        IClasspathEntry[] added =
+            BuildPath.addLibraries(project, libraries, new NullProgressMonitor());
+        return added;
+      }
+    } catch (CoreException ex) {
+      logger.log(Level.WARNING, "Error adding libraries to project", ex);
+      return new IClasspathEntry[0];
+    }
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
@@ -100,7 +100,7 @@ public abstract class CloudLibrariesPage extends WizardPage implements IClasspat
         return new IClasspathEntry[0];
       } else {
         IClasspathEntry[] added =
-            BuildPath.addLibraries(project, libraries, new NullProgressMonitor());
+            BuildPath.listAdditionalLibraries(project, libraries, new NullProgressMonitor());
         return added;
       }
     } catch (CoreException ex) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/messages.properties
@@ -1,2 +1,5 @@
-title=App Engine Standard Environment Libraries
-description=Additional jars commonly used in App Engine Standard Environment applications
+appengine-title=App Engine Standard Environment Libraries
+appengine-description=Additional jars commonly used in App Engine Standard Environment applications
+clientapis-title=Google Client APIs for Java
+clientapis-description=Additional jars used by Google Client APIs for Java
+

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.properties
@@ -2,4 +2,6 @@ pluginName=Cloud Tools For Eclipse App Engine Libraries Management
 providerName=Google Inc.
 objectify.tooltip=com.googlecode.objectify, a Java data access API designed for Google Cloud Datastore	
 appengine.api.tooltip=The com.google.appengine.api, com.google.apphosting, and javax.mail libraries
+googleapiclient.tooltip=Functionality common to Google client APIs, including HTTP transport, \
+ error handling, authentication, JSON and protobuf parsing, media download/upload, and batching. 
 endpoints.tooltip=Google Cloud Endpoints v1 (com.google.api.server.spi)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -117,8 +117,8 @@
               groupId="com.google.http-client"
               version="1.22.0" />
       </libraryFile>
-      <libraryFile
-            javadocUri="https://google.github.io/google-oauth-client/releases/1.21.0/javadoc/index.html">
+      <libraryFile javadocUri=
+          "https://developers.google.com/api-client-library/java/google-oauth-java-client/reference/1.20.0/">
         <mavenCoordinates
               artifactId="google-oauth-client"
               groupId="com.google.oauth-client"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -96,11 +96,40 @@
         <mavenCoordinates artifactId="jstl" groupId="javax.servlet" version="1.2" />
       </libraryFile>
     </library>
+    
+    <library
+          id="googleapiclient"
+          group="clientapis"
+          name="Google API Client Library for Java"
+          tooltip="%googleapiclient.tooltip"
+          siteUri="https://developers.google.com/api-client-library/java/" >
+      <libraryFile
+            javadocUri="https://google.github.io/google-api-java-client/releases/1.21.0/javadoc/index.html">
+        <mavenCoordinates
+              artifactId="google-api-client"
+              groupId="com.google.api-client"
+              version="1.22.0" />
+      </libraryFile>
+      <libraryFile
+            javadocUri="https://google.github.io/google-http-java-client/releases/1.21.0/javadoc/index.html">
+        <mavenCoordinates
+              artifactId="google-http-client"
+              groupId="com.google.http-client"
+              version="1.22.0" />
+      </libraryFile>
+      <libraryFile
+            javadocUri="https://google.github.io/google-oauth-client/releases/1.21.0/javadoc/index.html">
+        <mavenCoordinates
+              artifactId="google-oauth-client"
+              groupId="com.google.oauth-client"
+              version="1.22.0" />
+      </libraryFile>
+    </library>
   </extension>
 
   <extension point="org.eclipse.jdt.core.classpathContainerInitializer">
-     <classpathContainerInitializer
-           class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainerInitializer"
-           id="com.google.cloud.tools.eclipse.appengine.libraries" />
+    <classpathContainerInitializer
+        class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainerInitializer"
+        id="com.google.cloud.tools.eclipse.appengine.libraries" />
   </extension>
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
@@ -32,7 +32,13 @@ public class CloudLibraries {
    * Library files for App Engine Standard environment applications; specifically
    * Objectify, App Engine API, and Google Cloud Endpoints.
    */
-  public static final String APP_ENGINE_GROUP = "appengine";
+  public static final String APP_ENGINE_GROUP = "appengine";   //$NON-NLS-1$
+  
+  /**
+   * Library files for Google Client APIs for Java; specifically
+   * google-api-client, oAuth, and google-http-client.
+   */
+  public static final String CLIENT_APIS_GROUP = "clientapis"; //$NON-NLS-1$
   
   /**
    * Library files for all Java servlet applications; specifically

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -16,10 +16,11 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.newproject.JavaPackageValidator;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineLibrariesSelectorGroup;
+import com.google.cloud.tools.eclipse.appengine.ui.LibrarySelectorGroup;
 import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
 import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import com.google.cloud.tools.io.FilePermissions;
@@ -69,7 +70,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
   private Text artifactIdField;
   private Text versionField;
   @VisibleForTesting Text javaPackageField;
-  private AppEngineLibrariesSelectorGroup appEngineLibrariesSelectorGroup;
+  private LibrarySelectorGroup appEngineLibrariesSelectorGroup;
 
   private boolean canFlipPage;
 
@@ -115,7 +116,8 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
     createLocationArea(container, pageValidator);
     createMavenCoordinatesArea(container, pageValidator);
     createAppEngineProjectDetailsArea(container, pageValidator);
-    appEngineLibrariesSelectorGroup = new AppEngineLibrariesSelectorGroup(container);
+    appEngineLibrariesSelectorGroup =
+        new LibrarySelectorGroup(container, CloudLibraries.APP_ENGINE_GROUP);
     appEngineLibrariesSelectorGroup.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override
       public void selectionChanged(SelectionChangedEvent event) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineLibrariesSelectorGroup;
+import com.google.cloud.tools.eclipse.appengine.ui.LibrarySelectorGroup;
 import java.io.File;
 import java.util.Collection;
 import org.eclipse.core.runtime.IStatus;
@@ -40,7 +41,7 @@ import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
 public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
 
   private Text javaPackageField;
-  private AppEngineLibrariesSelectorGroup appEngineLibrariesSelectorGroup;
+  private LibrarySelectorGroup appEngineLibrariesSelectorGroup;
   private Text serviceNameField;
 
   public AppEngineWizardPage() {
@@ -64,7 +65,8 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
     createCustomFields(container, pageValidator);
 
     // Manage APIs
-    appEngineLibrariesSelectorGroup = new AppEngineLibrariesSelectorGroup(container);
+    appEngineLibrariesSelectorGroup =
+        new LibrarySelectorGroup(container, CloudLibraries.APP_ENGINE_GROUP);
 
     setPageComplete(validatePage());
     // Show enter project name on opening

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineLibrariesSelectorGroupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui.test/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineLibrariesSelectorGroupTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class AppEngineLibrariesSelectorGroupTest {
   @Rule public ShellTestResource shellTestResource = new ShellTestResource();
 
   private Shell shell;
-  private AppEngineLibrariesSelectorGroup librariesSelector;
+  private LibrarySelectorGroup librariesSelector;
   private SWTBotCheckBox appengineButton;
   private SWTBotCheckBox endpointsButton;
   private SWTBotCheckBox objectifyButton;
@@ -54,7 +55,8 @@ public class AppEngineLibrariesSelectorGroupTest {
   public void setUp() throws Exception {
         shell = shellTestResource.getShell();
         shell.setLayout(new FillLayout());
-        librariesSelector = new AppEngineLibrariesSelectorGroup(shell);
+        librariesSelector = new LibrarySelectorGroup(
+            shell, CloudLibraries.APP_ENGINE_GROUP);
         shell.open();
         appengineButton = getButton("appengine-api");
         endpointsButton = getButton("appengine-endpoints");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/LibrarySelectorGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/LibrarySelectorGroup.java
@@ -44,7 +44,10 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 
-public class AppEngineLibrariesSelectorGroup implements ISelectionProvider {
+/**
+ * A radio button group to choose libraries defined in plugin.xml.
+ */
+public class LibrarySelectorGroup implements ISelectionProvider {
 
   /** The libraries that can be selected. */
   private final Map<String, Library> availableLibraries;
@@ -55,9 +58,8 @@ public class AppEngineLibrariesSelectorGroup implements ISelectionProvider {
   private final Map<Library, Button> libraryButtons = new LinkedHashMap<>();
   private final ListenerList/* <ISelectedChangeListener> */ listeners = new ListenerList/* <> */();
 
-  public AppEngineLibrariesSelectorGroup(Composite parentContainer) {
-    Collection<Library> availableLibraries =
-        CloudLibraries.getLibraries(CloudLibraries.APP_ENGINE_GROUP);
+  public LibrarySelectorGroup(Composite parentContainer, String groupName) {
+    Collection<Library> availableLibraries = CloudLibraries.getLibraries(groupName);
     Preconditions.checkNotNull(parentContainer, "parentContainer is null");
     Preconditions.checkNotNull(availableLibraries, "availableLibraries is null");
     

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/LibrarySelectorGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/LibrarySelectorGroup.java
@@ -45,7 +45,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 
 /**
- * A radio button group to choose libraries defined in plugin.xml.
+ * A checkbox group to choose libraries defined in plugin.xml.
  */
 public class LibrarySelectorGroup implements ISelectionProvider {
 


### PR DESCRIPTION
@briandealwis @akerekes 

This PR refactors the library page so that we can add multiple library groups with different jars.

As an example, this PR defines a new API Client library in an API group that adds the google-api-client, google-oauth-client and google-http-client jars. 