### PR TITLE
Simplify library code

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
@@ -16,9 +16,9 @@
 
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -27,8 +27,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 
 public class BuildPathTest {
 
@@ -44,7 +42,7 @@ public class BuildPathTest {
     IJavaProject project = Mockito.mock(IJavaProject.class);
     IClasspathEntry[] rawClasspath = new IClasspathEntry[0];
     Mockito.when(project.getRawClasspath()).thenReturn(rawClasspath);
-    
+
     List<Library> libraries = new ArrayList<>();
     Library library = new Library("libraryId");
     libraries.add(library);
@@ -52,33 +50,33 @@ public class BuildPathTest {
         BuildPath.addLibraries(project, libraries, new NullProgressMonitor());
     Assert.assertEquals(1, result.length);
   }
-  
+
   @Test
   public void testAddLibraries_noDuplicates() throws CoreException {
     Library library = new Library("libraryId");
     IClasspathEntry entry = BuildPath.makeClasspathEntry(library);
-    
+
     IJavaProject project = Mockito.mock(IJavaProject.class);
     IClasspathEntry[] rawClasspath = {entry};
     Mockito.when(project.getRawClasspath()).thenReturn(rawClasspath);
-    
+
     List<Library> libraries = new ArrayList<>();
     libraries.add(library);
     IClasspathEntry[] result =
         BuildPath.addLibraries(project, libraries, new NullProgressMonitor());
     Assert.assertEquals(0, result.length);
   }
-  
+
   @Test
   public void testAddLibraries_withDuplicates() throws CoreException {
     Library library1 = new Library("library1");
     Library library2 = new Library("library2");
     IClasspathEntry entry = BuildPath.makeClasspathEntry(library1);
-    
+
     IJavaProject project = Mockito.mock(IJavaProject.class);
     IClasspathEntry[] rawClasspath = {entry};
     Mockito.when(project.getRawClasspath()).thenReturn(rawClasspath);
-    
+
     List<Library> libraries = new ArrayList<>();
     libraries.add(library1);
     libraries.add(library2);
@@ -88,5 +86,5 @@ public class BuildPathTest {
     Assert.assertTrue(result[0].getPath().toString()
         .endsWith("com.google.cloud.tools.eclipse.appengine.libraries/library2"));
   }
-  
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -128,18 +128,18 @@ public class LibraryClasspathContainerInitializerTest {
   public void testInitialize_ifArtifactJarPathIsInvalidContainerResolvedFromScratch() throws CoreException,
                                                                                              IOException {
     assertFalse(new File(NON_EXISTENT_FILE).exists());
-    
+
     IClasspathEntry entry = mock(IClasspathEntry.class);
     when(entry.getPath()).thenReturn(new Path(NON_EXISTENT_FILE));
     IClasspathEntry[] entries = new IClasspathEntry[]{ entry };
     LibraryClasspathContainer container = mock(LibraryClasspathContainer.class);
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
-    
+
     LibraryClasspathContainerInitializer containerInitializer =
         new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
-    
+
     verifyContainerResolvedFromScratch();
   }
 
@@ -148,7 +148,7 @@ public class LibraryClasspathContainerInitializerTest {
                                                                                                  IOException {
     File artifactFile = temporaryFolder.newFile();
     assertFalse(new File(NON_EXISTENT_FILE).exists());
-    
+
     IClasspathEntry entry = mock(IClasspathEntry.class);
     when(entry.getPath()).thenReturn(new Path(artifactFile.getAbsolutePath()));
     when(entry.getSourceAttachmentPath()).thenReturn(new Path(NON_EXISTENT_FILE));
@@ -156,24 +156,24 @@ public class LibraryClasspathContainerInitializerTest {
     LibraryClasspathContainer container = mock(LibraryClasspathContainer.class);
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
-    
+
     LibraryClasspathContainerInitializer containerInitializer =
         new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
-    
+
     verifyContainerResolvedFromScratch();
   }
 
   @Test
   public void testInitialize_ifSourcePathIsNullContainerIsNotResolvedAgain() throws CoreException, IOException {
     File artifactFile = temporaryFolder.newFile();
-    
+
     IClasspathEntry entry = JavaCore.newLibraryEntry(new Path(artifactFile.getAbsolutePath()), null, null);
     IClasspathEntry[] entries = new IClasspathEntry[]{ entry };
     LibraryClasspathContainer container = mock(LibraryClasspathContainer.class);
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
-    
+
     LibraryClasspathContainerInitializer containerInitializer =
         new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
@@ -188,7 +188,7 @@ public class LibraryClasspathContainerInitializerTest {
   public void testInitialize_ifSourcePathIsValidContainerIsNotResolvedAgain() throws CoreException, IOException {
     File artifactFile = temporaryFolder.newFile();
     File sourceArtifactFile = temporaryFolder.newFile();
-    
+
     IClasspathEntry entry = JavaCore.newLibraryEntry(new Path(artifactFile.getAbsolutePath()),
                                                      new Path(sourceArtifactFile.getAbsolutePath()),
                                                      null);
@@ -196,7 +196,7 @@ public class LibraryClasspathContainerInitializerTest {
     LibraryClasspathContainer container = mock(LibraryClasspathContainer.class);
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
-    
+
     LibraryClasspathContainerInitializer containerInitializer =
         new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerTest.java
@@ -22,20 +22,18 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.Arrays;
+import java.util.List;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public class LibraryClasspathContainerTest {
 
-  @Mock private IClasspathEntry mockClasspathEntry = mock(IClasspathEntry.class);
+  private List<IClasspathEntry> mockClasspathEntry = Arrays.asList(mock(IClasspathEntry.class));
 
   private LibraryClasspathContainer classpathContainer;
 
@@ -43,35 +41,27 @@ public class LibraryClasspathContainerTest {
   public void setUp() {
     classpathContainer = new LibraryClasspathContainer(new Path("container/path"),
                                                        "description",
-                                                       new IClasspathEntry[]{ mockClasspathEntry });
+                                                       mockClasspathEntry);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructor_nullPath() {
-    new LibraryClasspathContainer(null,
-                                  "description",
-                                  new IClasspathEntry[]{ mockClasspathEntry });
+    new LibraryClasspathContainer(null, "description", mockClasspathEntry);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructor_nullDescription() {
-    new LibraryClasspathContainer(new Path("container/path"),
-                                  null,
-                                  new IClasspathEntry[]{ mockClasspathEntry });
+    new LibraryClasspathContainer(new Path("container/path"), null, mockClasspathEntry);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testConstructor_emptyDescription() {
-    new LibraryClasspathContainer(new Path("container/path"),
-                                  "",
-                                  new IClasspathEntry[]{ mockClasspathEntry });
+    new LibraryClasspathContainer(new Path("container/path"), "", mockClasspathEntry);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructor_nullClasspathEntries() {
-    new LibraryClasspathContainer(new Path("container/path"),
-                                  "description",
-                                  null);
+    new LibraryClasspathContainer(new Path("container/path"), "description", null);
   }
 
   @Test
@@ -94,6 +84,6 @@ public class LibraryClasspathContainerTest {
     IClasspathEntry[] classpathEntries = classpathContainer.getClasspathEntries();
     assertNotNull(classpathEntries);
     assertThat(classpathEntries.length, is(1));
-    assertSame(mockClasspathEntry, classpathEntries[0]);
+    assertSame(mockClasspathEntry.get(0), classpathEntries[0]);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/SourceAttacherJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/SourceAttacherJobTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.libraries;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathContainer;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SourceAttacherJobTest {
+
+  private SourceAttacherJob attacherJob;
+
+  @Before
+  public void setUp() {
+    IPath path = mock(IPath.class);
+    IJavaProject javaProject = mock(IJavaProject.class);
+    when(javaProject.getProject()).thenReturn(mock(IProject.class));
+    attacherJob = new SourceAttacherJob(javaProject, path, path, mock(Callable.class));
+  }
+
+  @Test
+  public void testAttachSource_normalExecutionOnLibraryClasspathContainer() throws Exception {
+    LibraryClasspathContainer validContainer = mock(LibraryClasspathContainer.class);
+    when(validContainer.getClasspathEntries()).thenReturn(new IClasspathEntry[0]);
+    when(validContainer.copyWithNewEntries(any(List.class))).thenReturn(validContainer);
+
+    LibraryClasspathContainer newContainer = attacherJob.attachSource(validContainer);
+    assertNotNull(newContainer);
+  }
+
+  @Test
+  public void testAttachSource_shortCircuitOnGenericClasspathContainer() throws Exception {
+    IClasspathContainer invalidContainer = mock(IClasspathContainer.class);
+
+    LibraryClasspathContainer newContainer = attacherJob.attachSource(invalidContainer);
+    assertNull(newContainer);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/LibraryClasspathContainerSerializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/LibraryClasspathContainerSerializerTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -89,12 +91,12 @@ public class LibraryClasspathContainerSerializerTest {
 
   @Before
   public void setUp() throws Exception {
-    IClasspathEntry[] classpathEntries =
-        new IClasspathEntry[] {getClasspathEntry(IClasspathEntry.CPE_LIBRARY, "/test/path/to/jar",
-            "/test/path/to/src", new IClasspathAttribute[] {getAttribute("attrName", "attrValue")},
-            new IAccessRule[] {getAccessRule("/com/example/accessible", true /* accessible */),
-                getAccessRule("/com/example/nonaccessible", false /* accessible */)},
-            true)};
+    List<IClasspathEntry> classpathEntries = Arrays.asList(
+        newClasspathEntry(IClasspathEntry.CPE_LIBRARY, "/test/path/to/jar",
+            "/test/path/to/src", new IClasspathAttribute[] {newAttribute("attrName", "attrValue")},
+            new IAccessRule[] {newAccessRule("/com/example/accessible", true /* accessible */),
+                newAccessRule("/com/example/nonaccessible", false /* accessible */)},
+            true));
     when(binaryBaseLocationProvider.getBaseLocation()).thenReturn(new Path("/test"));
     when(sourceBaseLocationProvider.getBaseLocation()).thenReturn(new Path("/test"));
     container = new LibraryClasspathContainer(new Path(CONTAINER_PATH), CONTAINER_DESCRIPTION,
@@ -185,7 +187,7 @@ public class LibraryClasspathContainerSerializerTest {
     }
   }
 
-  private IClasspathEntry getClasspathEntry(final int entryKind, final String path,
+  private static IClasspathEntry newClasspathEntry(final int entryKind, final String path,
       final String sourceAttachmentPath, final IClasspathAttribute[] attributes,
       final IAccessRule[] accessRules, final boolean isExported) {
     return new IClasspathEntry() {
@@ -263,7 +265,7 @@ public class LibraryClasspathContainerSerializerTest {
     };
   }
 
-  private IClasspathAttribute getAttribute(final String name, final String value) {
+  private static IClasspathAttribute newAttribute(final String name, final String value) {
     return new IClasspathAttribute() {
 
       @Override
@@ -278,7 +280,7 @@ public class LibraryClasspathContainerSerializerTest {
     };
   }
 
-  private IAccessRule getAccessRule(final String pattern, final boolean accessible) {
+  private static IAccessRule newAccessRule(final String pattern, final boolean accessible) {
     return new IAccessRule() {
 
       @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainer.java
@@ -17,23 +17,24 @@
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import com.google.common.base.Preconditions;
+import java.util.List;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 
 public class LibraryClasspathContainer implements IClasspathContainer {
-  
+
   private final IPath containerPath;
   private final String description;
-  private final IClasspathEntry[] classpathEntries;
+  private final List<IClasspathEntry> classpathEntries;
 
   public LibraryClasspathContainer(IPath path, String description,
-      IClasspathEntry[] classpathEntries) {
+      List<IClasspathEntry> classpathEntries) {
     Preconditions.checkNotNull(path, "path is null");
     Preconditions.checkNotNull(description, "description is null");
     Preconditions.checkArgument(!description.isEmpty(), "description is empty");
     Preconditions.checkNotNull(classpathEntries, "classpathEntries is null");
-    
+
     this.containerPath = path;
     this.description = description;
     this.classpathEntries = classpathEntries;
@@ -42,10 +43,10 @@ public class LibraryClasspathContainer implements IClasspathContainer {
   /**
    * Creates a new {@link LibraryClasspathContainer} with the same path and description,
    * but with the <code>classpathEntries</code>.
-   * 
+   *
    * @param classpathEntries the classpath entries of the new container
    */
-  public LibraryClasspathContainer copyWithNewEntries(IClasspathEntry[] classpathEntries) {
+  public LibraryClasspathContainer copyWithNewEntries(List<IClasspathEntry> classpathEntries) {
     return new LibraryClasspathContainer(containerPath, description, classpathEntries);
   }
 
@@ -66,6 +67,6 @@ public class LibraryClasspathContainer implements IClasspathContainer {
 
   @Override
   public IClasspathEntry[] getClasspathEntries() {
-    return classpathEntries;
+    return classpathEntries.toArray(new IClasspathEntry[0]);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
@@ -92,8 +92,7 @@ public class LibraryClasspathContainerInitializer extends ClasspathContainerInit
 
   private static boolean jarPathsAreValid(LibraryClasspathContainer container) {
     IClasspathEntry[] classpathEntries = container.getClasspathEntries();
-    for (int i = 0; i < classpathEntries.length; i++) {
-      IClasspathEntry classpathEntry = classpathEntries[i];
+    for (IClasspathEntry classpathEntry : classpathEntries) {
       if (!classpathEntry.getPath().toFile().exists()
           || (classpathEntry.getSourceAttachmentPath() != null
           && !classpathEntry.getSourceAttachmentPath().toFile().exists())) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/SourceAttacherJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/SourceAttacherJob.java
@@ -1,6 +1,7 @@
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.persistence.LibraryClasspathContainerSerializer;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -55,37 +56,42 @@ public class SourceAttacherJob extends Job {
   protected IStatus run(IProgressMonitor monitor) {
     try {
       IClasspathContainer container = JavaCore.getClasspathContainer(containerPath, javaProject);
-      if (container instanceof LibraryClasspathContainer) {
-        logger.log(Level.FINE, Messages.getString("ContainerClassUnexpected",
-            container.getClass().getName(), LibraryClasspathContainer.class.getName()));
-        return Status.OK_STATUS;
-      };
+      LibraryClasspathContainer newContainer = attachSource(container);
 
-      LibraryClasspathContainer libraryClasspathContainer = (LibraryClasspathContainer) container;
-      IPath sourceArtifactPath = sourceArtifactPathProvider.call();
-      List<IClasspathEntry> newClasspathEntries = new ArrayList<>();
-
-      for (IClasspathEntry entry : libraryClasspathContainer.getClasspathEntries()) {
-        if (!entry.getPath().equals(libraryPath)) {
-          newClasspathEntries.add(entry);
-        } else {
-          newClasspathEntries.add(JavaCore.newLibraryEntry(
-              entry.getPath(), sourceArtifactPath, null /* sourceAttachmentRootPath */,
-              entry.getAccessRules(), entry.getExtraAttributes(), entry.isExported()));
-        }
+      if (newContainer != null) {
+        JavaCore.setClasspathContainer(containerPath, new IJavaProject[]{ javaProject },
+            new IClasspathContainer[]{ newContainer }, monitor);
+        serializer.saveContainer(javaProject, newContainer);
       }
-
-      LibraryClasspathContainer newContainer =
-          libraryClasspathContainer.copyWithNewEntries(newClasspathEntries);
-      JavaCore.setClasspathContainer(containerPath, new IJavaProject[]{ javaProject },
-                                     new IClasspathContainer[]{ newContainer }, monitor);
-      serializer.saveContainer(javaProject, newContainer);
-      return Status.OK_STATUS;
-
     } catch (Exception ex) {
       // it's not needed to be logged normally
       logger.log(Level.FINE, Messages.getString("SourceAttachmentFailed"), ex);
-      return Status.OK_STATUS;  // even if it fails, we should not display an error to the user
     }
+    return Status.OK_STATUS;  // even if it fails, we should not display an error to the user
+  }
+
+  @VisibleForTesting
+  LibraryClasspathContainer attachSource(IClasspathContainer container) throws Exception {
+    if (!(container instanceof LibraryClasspathContainer)) {
+      logger.log(Level.FINE, Messages.getString("ContainerClassUnexpected",
+          container.getClass().getName(), LibraryClasspathContainer.class.getName()));
+      return null;
+    };
+
+    LibraryClasspathContainer libraryClasspathContainer = (LibraryClasspathContainer) container;
+    IPath sourceArtifactPath = sourceArtifactPathProvider.call();
+    List<IClasspathEntry> newClasspathEntries = new ArrayList<>();
+
+    for (IClasspathEntry entry : libraryClasspathContainer.getClasspathEntries()) {
+      if (!entry.getPath().equals(libraryPath)) {
+        newClasspathEntries.add(entry);
+      } else {
+        newClasspathEntries.add(JavaCore.newLibraryEntry(
+            entry.getPath(), sourceArtifactPath, null /* sourceAttachmentRootPath */,
+            entry.getAccessRules(), entry.getExtraAttributes(), entry.isExported()));
+      }
+    }
+
+    return libraryClasspathContainer.copyWithNewEntries(newClasspathEntries);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
@@ -88,7 +88,7 @@ class LibraryFactory {
     }
   }
 
-  private static List<LibraryFile> getLibraryFiles(IConfigurationElement[] children) 
+  private static List<LibraryFile> getLibraryFiles(IConfigurationElement[] children)
       throws InvalidRegistryObjectException, URISyntaxException {
     List<LibraryFile> libraryFiles = new ArrayList<>();
     for (IConfigurationElement libraryFileElement : children) {
@@ -112,7 +112,7 @@ class LibraryFactory {
   }
 
   private static URI getUri(String uriString) throws URISyntaxException {
-    if (uriString == null || uriString.isEmpty()) {
+    if (Strings.isNullOrEmpty(uriString)) {
       return null;
     } else {
       return new URI(uriString);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableAccessRules.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableAccessRules.java
@@ -25,8 +25,8 @@ import org.eclipse.jdt.core.JavaCore;
  */
 public class SerializableAccessRules {
 
-  private AccessRuleKind ruleKind;
-  private String pattern;
+  private final AccessRuleKind ruleKind;
+  private final String pattern;
 
   public SerializableAccessRules(IAccessRule rule) {
     ruleKind = AccessRuleKind.forInt(rule.getKind());
@@ -38,11 +38,11 @@ public class SerializableAccessRules {
   }
 
   private static enum AccessRuleKind {
-    ACCESSIBLE(IAccessRule.K_ACCESSIBLE), 
-    DISCOURAGED(IAccessRule.K_DISCOURAGED), 
+    ACCESSIBLE(IAccessRule.K_ACCESSIBLE),
+    DISCOURAGED(IAccessRule.K_DISCOURAGED),
     FORBIDDEN(IAccessRule.K_NON_ACCESSIBLE);
 
-    int kind;
+    private final int kind;
 
     AccessRuleKind(int kind) {
       this.kind = kind;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableAttribute.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableAttribute.java
@@ -24,8 +24,8 @@ import org.eclipse.jdt.core.JavaCore;
  */
 public class SerializableAttribute {
 
-  private String name;
-  private String value;
+  private final String name;
+  private final String value;
 
   public SerializableAttribute(IClasspathAttribute attribute) {
     name = attribute.getName();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableClasspathEntry.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableClasspathEntry.java
@@ -111,22 +111,23 @@ public class SerializableClasspathEntry {
 
   private IPath restoreSourcePath(IPath baseDirectory, IPath sourceBaseDirectory) {
     Path path = new Path(sourceAttachmentPath);
-    if (path.segmentCount() > 0) {
-      switch (path.segment(0)) {
-        case SOURCE_REPO_RELATIVE_PREFIX:
-          return PathUtil.makePathAbsolute(path.removeFirstSegments(1), sourceBaseDirectory);
-        case BINARY_REPO_RELATIVE_PREFIX:
-          return PathUtil.makePathAbsolute(path.removeFirstSegments(1), baseDirectory);
-        default:
-          // Unknown prefix, use path only if valid
-          if (path.toFile().exists()) {
-            return path;
-          } else {
-            return null;
-          }
-      }
+    if (path.segmentCount() == 0) {
+      return path;
     }
-    return path;
+
+    switch (path.segment(0)) {
+      case SOURCE_REPO_RELATIVE_PREFIX:
+        return PathUtil.makePathAbsolute(path.removeFirstSegments(1), sourceBaseDirectory);
+      case BINARY_REPO_RELATIVE_PREFIX:
+        return PathUtil.makePathAbsolute(path.removeFirstSegments(1), baseDirectory);
+      default:
+        // Unknown prefix, use path only if valid
+        if (path.toFile().exists()) {
+          return path;
+        } else {
+          return null;
+        }
+    }
   }
 
   private IClasspathAttribute[] getAttributes() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.persistence;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainer;
+import java.util.ArrayList;
+import java.util.List;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -27,27 +29,26 @@ import org.eclipse.jdt.core.IClasspathEntry;
  */
 public class SerializableLibraryClasspathContainer {
 
-  private String description;
-  private String path;
-  private SerializableClasspathEntry[] entries;
+  private final String description;
+  private final String path;
+  private final List<SerializableClasspathEntry> entries = new ArrayList<>();
 
   public SerializableLibraryClasspathContainer(LibraryClasspathContainer container,
       IPath baseDirectory, IPath sourceBaseDirectory) {
     description = container.getDescription();
     path = container.getPath().toString();
-    IClasspathEntry[] classpathEntries = container.getClasspathEntries();
-    entries = new SerializableClasspathEntry[classpathEntries.length];
-    for (int i = 0; i < classpathEntries.length; i++) {
-      entries[i] =
-          new SerializableClasspathEntry(classpathEntries[i], baseDirectory, sourceBaseDirectory);
+
+    for (IClasspathEntry entry : container.getClasspathEntries()) {
+      entries.add(new SerializableClasspathEntry(entry, baseDirectory, sourceBaseDirectory));
     }
   }
 
   public LibraryClasspathContainer toLibraryClasspathContainer(IPath baseDirectory,
       IPath sourceBaseDirectory) {
-    IClasspathEntry[] classpathEntries = new IClasspathEntry[entries.length];
-    for (int i = 0; i < entries.length; i++) {
-      classpathEntries[i] = entries[i].toClasspathEntry(baseDirectory, sourceBaseDirectory);
+
+    List<IClasspathEntry> classpathEntries = new ArrayList<>();
+    for (SerializableClasspathEntry entry : entries) {
+      classpathEntries.add(entry.toClasspathEntry(baseDirectory, sourceBaseDirectory));
     }
     return new LibraryClasspathContainer(new Path(path), description, classpathEntries);
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/SerializableLibraryClasspathContainer.java
@@ -45,7 +45,6 @@ public class SerializableLibraryClasspathContainer {
 
   public LibraryClasspathContainer toLibraryClasspathContainer(IPath baseDirectory,
       IPath sourceBaseDirectory) {
-
     List<IClasspathEntry> classpathEntries = new ArrayList<>();
     for (SerializableClasspathEntry entry : entries) {
       classpathEntries.add(entry.toClasspathEntry(baseDirectory, sourceBaseDirectory));


### PR DESCRIPTION
I was looking at the code in .libraries and thought I could improve readability a bit, mainly by using `List` in place of primitive Java arrays.

@akerekes what do you think?