### PR TITLE
Update build/jacoco for new bundles & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The tests need to find the Google Cloud SDK.  You can either:
 
 By default, the build is targeted against Eclipse Mars / 4.5. 
 You can explicitly set the `eclipse.target` property to 
-`neon` (4.6).
+`neon` (4.6) or `oxygen` (4.7).
 ```
 $ mvn -Declipse.target=neon package
 ```
@@ -97,6 +97,17 @@ indicate a misconfigured _jdkHome_.
 
 You can disable the use of toolchains by setting the `tycho.toolchains`
 property to `SYSTEM`.
+
+### Adding a new bundle/fragment
+
+We normally put production code into a bundle and tests as a fragment hosted
+by that bundle, put under the `plugins/` directory. 
+For now we have been committing both the `pom.xml` and Eclipse's
+`.project`, `.classpath`, and `.settings/` files.
+
+Our CI process is configured to run our tests with JaCoCo, which requires
+some additional configuration to add new bundles and fragments
+in `build/jacoco/`.
 
 
 ## Import into Eclipse
@@ -259,6 +270,7 @@ This is currently:
 
   - Eclipse Mars (4.5 SR2): [`eclipse/mars/gcp-eclipse-mars.target`](eclipse/mars/gcp-eclipse-mars.target) 
   - Eclipse Neon (4.6): [`eclipse/neon/gcp-eclipse-neon.target`](eclipse/neon/gcp-eclipse-neon.target)
+  - Eclipse Oxygen (4.7): [`eclipse/oxygen/gcp-eclipse-oxygen.target`](eclipse/oxygen/gcp-eclipse-oxygen.target)
 
 These `.target` files are generated and *should not be manually updated*.
 Updating `.target` files directly becomes a chore once it has more than a 

--- a/build/jacoco/pom.xml
+++ b/build/jacoco/pom.xml
@@ -100,6 +100,18 @@
     </dependency>
     <dependency>
       <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>com.google.cloud.tools.eclipse.appengine.flex.test</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>com.google.cloud.tools.eclipse.appengine.flex</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
       <artifactId>com.google.cloud.tools.eclipse.appengine.libraries.test</artifactId>
       <version>0.1.0-SNAPSHOT</version>
       <scope>test</scope>
@@ -179,6 +191,18 @@
     <dependency>
       <groupId>com.google.cloud.tools.eclipse</groupId>
       <artifactId>com.google.cloud.tools.eclipse.appengine.validation</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>com.google.cloud.tools.eclipse.googleapis.test</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.eclipse</groupId>
+      <artifactId>com.google.cloud.tools.eclipse.googleapis</artifactId>
       <version>0.1.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
- add `com.google.cloud.tools.eclipse.googleapis` and `com.google.cloud.tools.eclipse.appengine.flex`
- tweak `README.md` to add note about including new bundles and fragments in `build/jacoco`