### PR TITLE
Configure Travis to cache Google Cloud SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,10 @@ before_install:
 install: 
   # use 3.3.9 to ensure faulty test exit states fail the build (#1276)
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
-  # download Cloud SDK (into .m2 so that it's cached)
-  - if [ ! -f .m2/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz ]; then
-      wget -o .m2/google-cloud-sdk-145.0.0-linux-x86_64.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
-    fi
-  - tar -xzf .m2/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
-  # update all Cloud SDK components
-  - gcloud components update --quiet
-  # add App Engine component to Cloud SDK
-  - gcloud components install app-engine-java --quiet
+  # download and install Cloud SDK (may be cached)
+  - build/install-cloudsdk.sh 147.0.0 $HOME
 env:
   global:
-    - CLOUDSDK_VERSION=145.0.0
     - PATH=$PWD/google-cloud-sdk/bin:$PATH
     - CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
     - DISPLAY=:99.0
@@ -43,6 +35,7 @@ addons:
 cache:
   directories:
    - $HOME/.m2
+   - $HOME/google-cloud-sdk
 after_success:
   # test req'd as we don't run coverage on all elements of the matrix
   - if [ -d build/jacoco/target ]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,18 @@ before_install:
 install: 
   # use 3.3.9 to ensure faulty test exit states fail the build (#1276)
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
-  # download Cloud SDK
-  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-145.0.0-linux-x86_64.tar.gz
-  - tar -xzf google-cloud-sdk-145.0.0-linux-x86_64.tar.gz
+  # download Cloud SDK (into .m2 so that it's cached)
+  - if [ ! -f .m2/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz ]; then
+      wget -o .m2/google-cloud-sdk-145.0.0-linux-x86_64.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
+    fi
+  - tar -xzf .m2/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
   # update all Cloud SDK components
   - gcloud components update --quiet
   # add App Engine component to Cloud SDK
   - gcloud components install app-engine-java --quiet
 env:
   global:
+    - CLOUDSDK_VERSION=145.0.0
     - PATH=$PWD/google-cloud-sdk/bin:$PATH
     - CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
     - DISPLAY=:99.0

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -27,6 +27,7 @@ elif [ -n "${currentVersion}" ]; then
 fi
 
 # Remove the install if we are killed
+# XXX can this be arranged to happen with `set -o errexit`?
 die() {
     if [ $# -gt 0 ]; then
         echo "$0: $*" 1>&2
@@ -40,7 +41,7 @@ die() {
 rm -rf ${CLOUDSDKDIR}
 
 echo ">> download google-cloud-sdk-${CLOUDSDK_VERSION}"
-wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz || die
 tar -xzf google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz -C ${INSTALLDIR} || die
 
 ## DISABLED: Updating to latest version should be done outside

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -17,15 +17,13 @@ INSTALLDIR=$2
 
 CLOUDSDKDIR=${INSTALLDIR}/google-cloud-sdk
 
-getCurrentVersion() {
-    if [ -d ${CLOUDSDKDIR} -a -f ${CLOUDSDKDIR}/VERSION ]; then
-        cat ${CLOUDSDKDIR}/VERSION
-    fi
-}
+currentVersion=$([ -f ${CLOUDSDKDIR}/VERSION ] && cat ${CLOUDSDKDIR}/VERSION)
 
-if [ "$(getCurrentVersion)" = "${CLOUDSDK_VERSION}" ]; then
+if [ "${currentVersion}" = "${CLOUDSDK_VERSION}" ]; then
     echo "Google Cloud SDK at version $(cat ${CLOUDSDKDIR}/VERSION)"
     exit 0
+elif [ -n "${currentVersion}" ]; then
+    echo "Replacing found Google Cloud SDK version ${currentVersion}"
 fi
 
 # Remove the install if we are killed

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Download and install the Google Cloud SDK
+
+if [ $# -ne 2 ]; then
+    echo "Ensure Google Cloud SDK in <install-dir>/google-cloud-sdk is"
+    echo "at desired version"
+    echo "use: $0 <cloudsdk-version> <install-dir>"
+    echo "ex: $0 147.0.0 /tmp"
+    exit 1
+fi
+
+# ensure we error out on failures and unset variables
+set -o pipefail,errexit,nounset
+
+CLOUDSDK_VERSION=$1
+INSTALLDIR=$2
+
+CLOUDSDKDIR=${INSTALLDIR}/google-cloud-sdk
+
+getCurrentVersion() {
+    if [ -d ${CLOUDSDKDIR} -a -f ${CLOUDSDKDIR}/VERSION ]; then
+        cat ${CLOUDSDKDIR}/VERSION
+    fi
+}
+
+if [ "$(getCurrentVersion)" = "${CLOUDSDK_VERSION}" ]; then
+    echo "Google Cloud SDK at version $(cat ${CLOUDSDKDIR}/VERSION)"
+    exit 0
+fi
+
+# Remove the install if we are killed
+trap "rm -rf ${CLOUDSDKDIR}" 1 2 15
+rm -rf ${CLOUDSDKDIR}
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
+tar -xzf google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz -C ${INSTALLDIR}
+
+## DISABLED: Updating to latest version should be done outside
+## update all Cloud SDK components
+# ${CLOUDSDKDIR}/bin/gcloud components update --quiet
+
+# add App Engine component to Cloud SDK
+${CLOUDSDKDIR}/bin/gcloud components install app-engine-java --quiet
+
+

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -31,14 +31,18 @@ fi
 # Remove the install if we are killed
 trap "rm -rf ${CLOUDSDKDIR}" 1 2 15
 rm -rf ${CLOUDSDKDIR}
+
+echo ">> download google-cloud-sdk-${CLOUDSDK_VERSION}"
 wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
 tar -xzf google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz -C ${INSTALLDIR}
 
 ## DISABLED: Updating to latest version should be done outside
 ## update all Cloud SDK components
+# echo ">> gcloud components update"
 # ${CLOUDSDKDIR}/bin/gcloud components update --quiet
 
 # add App Engine component to Cloud SDK
+echo ">> gcloud components install app-engine-java"
 ${CLOUDSDKDIR}/bin/gcloud components install app-engine-java --quiet
 
 

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -10,7 +10,7 @@ if [ $# -ne 2 ]; then
 fi
 
 # ensure we error out on failures and unset variables
-set -o pipefail -o errexit -o nounset
+set -o errexit -o nounset
 
 CLOUDSDK_VERSION=$1
 INSTALLDIR=$2

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -17,7 +17,7 @@ INSTALLDIR=$2
 
 CLOUDSDKDIR=${INSTALLDIR}/google-cloud-sdk
 
-currentVersion=$([ -f ${CLOUDSDKDIR}/VERSION ] && cat ${CLOUDSDKDIR}/VERSION)
+currentVersion=$(if [ -f ${CLOUDSDKDIR}/VERSION ]; then cat ${CLOUDSDKDIR}/VERSION; fi)
 
 if [ "${currentVersion}" = "${CLOUDSDK_VERSION}" ]; then
     echo "Google Cloud SDK at version $(cat ${CLOUDSDKDIR}/VERSION)"
@@ -27,20 +27,24 @@ elif [ -n "${currentVersion}" ]; then
 fi
 
 # Remove the install if we are killed
-trap "rm -rf ${CLOUDSDKDIR}" 1 2 15
+die() {
+    if [ $# -gt 0 ]; then echo "$0: $*" 1>&2; fi
+    rm -rf ${CLOUDSDKDIR}
+}
+
 rm -rf ${CLOUDSDKDIR}
 
 echo ">> download google-cloud-sdk-${CLOUDSDK_VERSION}"
 wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz
-tar -xzf google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz -C ${INSTALLDIR}
+tar -xzf google-cloud-sdk-${CLOUDSDK_VERSION}-linux-x86_64.tar.gz -C ${INSTALLDIR} || die
 
 ## DISABLED: Updating to latest version should be done outside
 ## update all Cloud SDK components
 # echo ">> gcloud components update"
-# ${CLOUDSDKDIR}/bin/gcloud components update --quiet
+# ${CLOUDSDKDIR}/bin/gcloud components update --quiet || die
 
 # add App Engine component to Cloud SDK
 echo ">> gcloud components install app-engine-java"
-${CLOUDSDKDIR}/bin/gcloud components install app-engine-java --quiet
+${CLOUDSDKDIR}/bin/gcloud components install app-engine-java --quiet || die
 
 

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -28,8 +28,13 @@ fi
 
 # Remove the install if we are killed
 die() {
-    if [ $# -gt 0 ]; then echo "$0: $*" 1>&2; fi
+    if [ $# -gt 0 ]; then
+        echo "$0: $*" 1>&2
+    else
+        echo "$0: ERROR" 1>&2
+    fi
     rm -rf ${CLOUDSDKDIR}
+    exit 1
 }
 
 rm -rf ${CLOUDSDKDIR}

--- a/build/install-cloudsdk.sh
+++ b/build/install-cloudsdk.sh
@@ -10,7 +10,7 @@ if [ $# -ne 2 ]; then
 fi
 
 # ensure we error out on failures and unset variables
-set -o pipefail,errexit,nounset
+set -o pipefail -o errexit -o nounset
 
 CLOUDSDK_VERSION=$1
 INSTALLDIR=$2


### PR DESCRIPTION
Rather than download and install the Google Cloud SDK & App Engine Java components for each build, cache the installation and only update when we configure a new version.

This is different than the previous behaviour which always did a `gcloud components update` to update to the latest version.

It's unclear if this will increase performance much, but it will insulate us from failures to download from google.com.

Oh, and this updates to 147.0.0.