### PR TITLE
Simplify generating ide-target-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,17 +122,23 @@ through to set up a working development environment.
 The Eclipse IDE and Tycho both use a _Target Platform_ to manage
 the dependencies for the source bundles and features under development.
 Although Tycho can pull dependencies directly from Maven-style
-repositories, Eclipse cannot.  So we use Tycho to cobble together
-a target platform suitable for the Eclipse IDE.
+repositories (like [Maven Central](https://search.maven.org)), Eclipse
+cannot.  So we use Tycho to cobble together
+a target platform suitable for the Eclipse IDE with the following command.
 ```
-$ mvn -Pide-target-platform package
+$ (cd eclipse; mvn -Pide-target-platform package)
 ```
-This command builds the project, but also creates a local copy of the
+This command creates a local copy of the
 target platform, including any Maven dependencies, into
 [`eclipse/ide-target-platform/target/repository`](eclipse/ide-target-platform/target/repository).
+You will use this repository to create a target platform within the IDE,
+as described below.
 
-The target platform is affected by the `eclipse.target` property,
-described below.
+The Eclipse version used for the target platform is affected by the
+`eclipse.target` property, described below.
+
+You must regenerate the target platform and reconfigure the IDE's
+target platform whenever dependencies are updated.
 
 ### Steps to import into the Eclipse IDE
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ repositories (like [Maven Central](https://search.maven.org)), Eclipse
 cannot.  So we use Tycho to cobble together
 a target platform suitable for the Eclipse IDE with the following command.
 ```
-$ (cd eclipse; mvn -Pide-target-platform package)
+$ (cd eclipse; mvn package)        # may want -Declipse.target=XXX
 ```
 This command creates a local copy of the
 target platform, including any Maven dependencies, into

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.tools.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <artifactId>eclipse-setup</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>mars</module>
+    <module>neon</module>
+    <module>oxygen</module>
+    <module>ide-target-platform</module>
+  </modules>
+
+</project>


### PR DESCRIPTION
Add a `pom.xml` to `eclipse/` to allow generating the `ide-target-platform` without having to build the entire project.