### PR TITLE
Let data binding auto-select single account

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanelTest.java
@@ -93,8 +93,6 @@ public class StandardDeployPreferencesPanelTest {
     deployPanel = createPanel(true /* requireValues */);
     assertThat(deployPanel.getSelectedCredential(), is(credential));
 
-    // todo? assertTrue(deployPanel.getAccountSelector().isAutoSelectAccountIfNone()
-
     // verify not in error
     IStatus status = getAccountSelectorValidationStatus();
     assertTrue("account selector is in error: " + status.getMessage(), status.isOK());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -172,12 +172,15 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     UpdateValueStrategy modelToTarget =
         new UpdateValueStrategy().setConverter(new Converter(String.class, String.class) {
           @Override
-          public Object convert(Object expectedEmail) {
-            // Expected to be an email address, but must also ensure is a currently logged-in
-            // account
-            if (expectedEmail instanceof String
-                && accountSelector.isEmailAvailable((String) expectedEmail)) {
-              return expectedEmail;
+          public Object convert(Object savedEmail) {
+            Preconditions.checkArgument(savedEmail instanceof String);
+            // Check if the saved email is available in AccountSelector (i.e., logged in).
+            if (accountSelector.isEmailAvailable((String) savedEmail)) {
+              return savedEmail;
+            // Let data binding auto-select an account if it's the only available one.
+            // (However, if we don't require values, then don't auto-select.)
+            } else if (requireValues && accountSelector.getAccountCount() == 1) {
+              return accountSelector.getFirstEmail();
             } else {
               return null;
             }
@@ -318,9 +321,8 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
     accountLabel.setText(Messages.getString("deploy.preferences.dialog.label.selectAccount"));
     accountLabel.setToolTipText(Messages.getString("tooltip.account"));
 
-    // If we don't require values, then don't auto-select accounts
     accountSelector = new AccountSelector(this, loginService,
-        Messages.getString("deploy.preferences.dialog.accountSelector.login"), requireValues);
+        Messages.getString("deploy.preferences.dialog.accountSelector.login"));
     accountSelector.setToolTipText(Messages.getString("tooltip.account"));
     GridData accountSelectorGridData = new GridData(SWT.FILL, SWT.CENTER, true, false);
     accountSelector.setLayoutData(accountSelectorGridData);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -174,11 +174,8 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
           @Override
           public Object convert(Object savedEmail) {
             Preconditions.checkArgument(savedEmail instanceof String);
-            // Check if the saved email is available in AccountSelector (i.e., logged in).
             if (accountSelector.isEmailAvailable((String) savedEmail)) {
               return savedEmail;
-            // Let data binding auto-select an account if it's the only available one.
-            // (However, if we don't require values, then don't auto-select.)
             } else if (requireValues && accountSelector.getAccountCount() == 1) {
               return accountSelector.getFirstEmail();
             } else {

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -32,7 +32,6 @@ import com.google.cloud.tools.login.Account;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCombo;
 import org.junit.Before;
@@ -315,7 +314,7 @@ public class AccountSelectorTest {
   @Test
   public void testInitialItemOrder() {
     when(loginService.getAccounts())
-        .thenReturn(new LinkedHashSet<>(Arrays.asList(account3, account2, account1)));
+        .thenReturn(new HashSet<>(Arrays.asList(account3, account2, account1)));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(4, selector.combo.getItemCount());
     assertEquals(account1.getEmail(), selector.combo.getItem(0));
@@ -339,7 +338,7 @@ public class AccountSelectorTest {
   @Test
   public void testGetFirstEmail_threeAccounts() {
     when(loginService.getAccounts())
-       .thenReturn(new LinkedHashSet<>(Arrays.asList(account3, account2, account1)));
+       .thenReturn(new HashSet<>(Arrays.asList(account3, account2, account1)));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(account1.getEmail(), selector.getFirstEmail());  // Accounts are sorted.
   }

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import com.google.cloud.tools.login.Account;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import org.eclipse.swt.widgets.Shell;
@@ -85,7 +86,7 @@ public class AccountSelectorTest {
 
   @Test
   public void testComboSetup_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1)));
+    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
 
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(-1, selector.combo.getSelectionIndex());
@@ -285,7 +286,7 @@ public class AccountSelectorTest {
 
   @Test
   public void testIsSignedIn_signedIn() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1)));
+    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertTrue(selector.isSignedIn());
   }
@@ -298,7 +299,7 @@ public class AccountSelectorTest {
 
   @Test
   public void testGetAccountCount_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1)));
+    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(1, selector.getAccountCount());
   }
@@ -322,7 +323,7 @@ public class AccountSelectorTest {
     assertEquals(account3.getEmail(), selector.combo.getItem(2));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = IllegalStateException.class)
   public void testGetFirstEmail_noAccount() {
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     selector.getFirstEmail();
@@ -330,8 +331,7 @@ public class AccountSelectorTest {
 
   @Test
   public void testGetFirstEmail_oneAccount() {
-    when(loginService.getAccounts())
-        .thenReturn(new LinkedHashSet<>(Arrays.asList(account2)));
+    when(loginService.getAccounts()).thenReturn(Collections.singleton(account2));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
     assertEquals(account2.getEmail(), selector.getFirstEmail());
   }

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -173,6 +173,19 @@ public class AccountSelectorTest {
   }
 
   @Test
+  public void testSelectAccount_nonExistingEmailClearsSelection() {
+    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+
+    selector.selectAccount("some-email-2@example.com");
+    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+
+    selector.selectAccount("non-existing-email@example.com");
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+  }
+
+  @Test
   public void testSelectAccount_nonExistingEmail() {
     when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
@@ -182,19 +195,6 @@ public class AccountSelectorTest {
 
     selector.selectAccount("non-existing-email@example.com");
 
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testSelectAccount_nonExistingEmailClearsSelection() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
-
-    selector.selectAccount("some-email-2@example.com");
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-
-    selector.selectAccount("non-existing-email@example.com");
     assertEquals(-1, selector.combo.getSelectionIndex());
     assertTrue(selector.getSelectedEmail().isEmpty());
   }

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -156,6 +156,19 @@ public class AccountSelectorTest {
   }
 
   @Test
+  public void testSelectAccount_nonExistingEmailClearsSelection() {
+    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+
+    selector.selectAccount("some-email-2@example.com");
+    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+
+    selector.selectAccount("non-existing-email@example.com");
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+  }
+
+  @Test
   public void testSelectAccount() {
     when(loginService.getAccounts())
         .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
@@ -170,19 +183,6 @@ public class AccountSelectorTest {
     assertNotEquals(-1, selector.combo.getSelectionIndex());
     assertEquals("some-email-2@example.com", selector.getSelectedEmail());
     assertEquals(credential2, selector.getSelectedCredential());
-  }
-
-  @Test
-  public void testSelectAccount_nonExistingEmailClearsSelection() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
-
-    selector.selectAccount("some-email-2@example.com");
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-
-    selector.selectAccount("non-existing-email@example.com");
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -187,6 +187,19 @@ public class AccountSelectorTest {
   }
 
   @Test
+  public void testSelectAccount_nonExistingEmailClearsSelection() {
+    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+
+    selector.selectAccount("some-email-2@example.com");
+    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
+
+    selector.selectAccount("non-existing-email@example.com");
+    assertEquals(-1, selector.combo.getSelectionIndex());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+  }
+
+  @Test
   public void testSelectAccount_nullOrEmptyEmail() {
     when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
     AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -206,93 +206,6 @@ public class AccountSelectorTest {
   }
 
   @Test
-  public void testSelectAccountInSingleAccountSelectMode_multipleAccounts() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-
-    selector.selectAccount("some-email-2@example.com");
-    assertEquals(1, selector.combo.getSelectionIndex());
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-    assertEquals(credential2, selector.getSelectedCredential());
-  }
-
-  @Test
-  public void testSelectAccountInSingleAccountSelectMode_multipleAccountsNonExistingEmail() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-
-    selector.selectAccount("non-existing-email@example.com");
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testSelectAccountInSingleAccountSelectMode_multipleAccountsNullOrEmptyEmail() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-
-    selector.selectAccount(null);
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-
-    selector.selectAccount("");
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testAutoSelectAccount_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1)));
-
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-    assertEquals(0, selector.combo.getSelectionIndex());
-    assertEquals(credential1, selector.getSelectedCredential());
-    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
-  }
-
-  @Test
-  public void testAutoSelectAccount_nullAccount() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1)));
-
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-    assertEquals(0, selector.combo.getSelectionIndex());
-    assertEquals(credential1, selector.getSelectedCredential());
-    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
-
-    selector.selectAccount("some-email-1@example.com");
-
-    assertEquals(0, selector.combo.getSelectionIndex());
-    assertEquals(credential1, selector.getSelectedCredential());
-    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
-
-    selector.selectAccount(null);
-
-    assertEquals(0, selector.combo.getSelectionIndex());
-    assertEquals(credential1, selector.getSelectedCredential());
-    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
-  }
-
-  @Test
-  public void testAutoSelectAccount_threeAccounts() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-
-    AccountSelector selector =
-        new AccountSelector(shell, loginService, "<select this to login>", true);
-    // should not select any element if more than one account
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertNull(selector.getSelectedCredential());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-
-  @Test
   public void testLogin_itemAddedAtTopAndSelected() {
     when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
     when(loginService.logIn(anyString())).thenReturn(account3);
@@ -394,6 +307,28 @@ public class AccountSelectorTest {
     assertEquals(account1.getEmail(), selector.combo.getItem(0));
     assertEquals(account2.getEmail(), selector.combo.getItem(1));
     assertEquals(account3.getEmail(), selector.combo.getItem(2));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFirstEmail_noAccount() {
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+    selector.getFirstEmail();
+  }
+
+  @Test
+  public void testGetFirstEmail_oneAccount() {
+    when(loginService.getAccounts())
+        .thenReturn(new LinkedHashSet<>(Arrays.asList(account2)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+    assertEquals(account2.getEmail(), selector.getFirstEmail());
+  }
+
+  @Test
+  public void testGetFirstEmail_threeAccounts() {
+    when(loginService.getAccounts())
+       .thenReturn(new LinkedHashSet<>(Arrays.asList(account3, account2, account1)));
+    AccountSelector selector = new AccountSelector(shell, loginService, "<select this to login>");
+    assertEquals(account1.getEmail(), selector.getFirstEmail());  // Accounts are sorted.
   }
 
   private void simulateSelect(AccountSelector selector, int index) {

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
@@ -95,9 +95,11 @@ public class AccountSelector extends Composite {
     return combo.getText();
   }
 
-  /** @exception IllegalArgumentException if there is no account logged in */
+  /**
+   * @exception IllegalArgumentException if there is no account logged in
+   */
   public String getFirstEmail() {
-    Preconditions.checkArgument(getAccountCount() > 0);
+    Preconditions.checkState(getAccountCount() > 0);
     return combo.getItem(0);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
@@ -103,10 +103,8 @@ public class AccountSelector extends Composite {
 
   /**
    * Selects an account corresponding to the given {@code email} and returns its index of the combo
-   * item. If there is no account corresponding to the {@code email}, <b>and</b> there is exactly 1
-   * known account and {@link #selectDefaultSingleAccount} is true, then we automatically select
-   * that single account; otherwise this method does returns -1 while retaining current selection
-   * (if any).
+   * item. If there is no account corresponding to the {@code email}, clears any selection and
+   * returns -1.
    *
    * @param email email address to use to select an account
    * @return index of the newly selected combo item; -1 if {@code email} is {@code null} or the


### PR DESCRIPTION
Fixes #1656, primarily. Fixes #1566 too.

Now the entity that auto-selects a single account is the deploy panel, not the `AccountSelector` itself. We already have a test in the panel if an account is auto-selected, so we are covered.