### PR TITLE
Allow co-installing with ADT

### DIFF
--- a/build/verify-feature-completeness/pom.xml
+++ b/build/verify-feature-completeness/pom.xml
@@ -19,10 +19,13 @@
   </description>
 
   <properties>
-    <installIUs>org.eclipse.platform.feature.group,com.google.cloud.tools.eclipse.suite.e45.feature.feature.group</installIUs>
+    <installIUs>org.eclipse.platform.feature.group,com.google.cloud.tools.eclipse.suite.e45.feature.feature.group,${adt.featureIUs}</installIUs>
     <build.rootUri>${project.baseUri}/../..</build.rootUri>
     <eclipse.repoUrl>${build.rootUri}/eclipse/ide-target-platform/target/repository</eclipse.repoUrl>
     <gcp.repoUrl>${build.rootUri}/gcp-repo/target/repository</gcp.repoUrl>
+
+    <adt.repoUrl>http://dl-ssl.google.com/android/eclipse/</adt.repoUrl>
+    <adt.featureIUs>com.android.ide.eclipse.adt.feature.feature.group</adt.featureIUs>
   </properties>
 
   <dependencies>
@@ -66,7 +69,7 @@
             -consoleLog -nosplash
             -application org.eclipse.equinox.p2.director
             -destination ${project.build.directory}/p2-installation
-            -repository ${eclipse.repoUrl},${gcp.repoUrl} 
+            -repository ${eclipse.repoUrl},${gcp.repoUrl},${adt.repoUrl}
             -installIUs ${installIUs}
           </appArgLine>
           <repositories>

--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/p2.inf
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/p2.inf
@@ -23,32 +23,3 @@
  requires.4.min = 0
  requires.4.max = 0
 
- requires.5.namespace = org.eclipse.equinox.p2.iu
- requires.5.name = com.android.ide.eclipse.adt.feature.feature.group
- requires.5.min = 0
- requires.5.max = 0
-
- requires.6.namespace = org.eclipse.equinox.p2.iu
- requires.6.name = com.android.ide.eclipse.ddms.feature.feature.group
- requires.6.min = 0
- requires.6.max = 0
-
- requires.7.namespace = org.eclipse.equinox.p2.iu
- requires.7.name = com.android.ide.eclipse.gldebugger.feature.feature.group
- requires.7.min = 0
- requires.7.max = 0
-
- requires.8.namespace = org.eclipse.equinox.p2.iu
- requires.8.name = com.android.ide.eclipse.hierarchyviewer.feature.feature.group
- requires.8.min = 0
- requires.8.max = 0
-
- requires.9.namespace = org.eclipse.equinox.p2.iu
- requires.9.name = com.android.ide.eclipse.ndk.feature.feature.group
- requires.9.min = 0
- requires.9.max = 0
-
- requires.10.namespace = org.eclipse.equinox.p2.iu
- requires.10.name = com.android.ide.eclipse.traceview.feature.feature.group
- requires.10.min = 0
- requires.10.max = 0


### PR DESCRIPTION
Only forbid the GPE _New Android Cloud Project_ support.

Adds main ADT feature to the `build/verify-feature-completeness` to ensure it co-installs alongside ADT.

Fixes #1678