### PR TITLE
Change conflicting service message

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
@@ -7,7 +7,7 @@ PORT_OUT_OF_RANGE=Port must be between 0 and 65535.
 
 CREATE_APP_ENGINE_RUNTIME_WIZARD_DESCRIPTION=The App Engine Standard runtime requires the Google Cloud SDK
 CREATE_APP_ENGINE_RUNTIME_WIZARD_TITLE=App Engine Standard Runtime
-SERVICES_HAVE_SAME_ID="{0}" and "{1}" have same App Engine Service ID: {2}
+SERVICE_CONFLICTS=Cannot add "{0}" as project "{1}" has App Engine Service ID: {2}
 OPEN_CLOUD_SDK_PREFERENCE_BUTTON=Open the Cloud SDK Location preference page when the wizard closes
 RUNTIME_WIZARD_CLOUD_SDK_NOT_FOUND=Cannot find the Google Cloud SDK.
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
@@ -121,9 +121,9 @@ public class LocalAppEngineServerDelegate extends ServerDelegate implements IURL
     for (IModule module : current) {
       String moduleServiceId = getServiceId(module);
       if (currentServiceIds.containsKey(moduleServiceId)) {
-        // uh oh, we have a conflict within the already-defined modules
-        return StatusUtil.error(this, Messages.getString("SERVICES_HAVE_SAME_ID", //$NON-NLS-1$
-            currentServiceIds.get(moduleServiceId).getName(), module.getName(), moduleServiceId));
+        // should never happen: we have a conflict within the already-defined modules
+        return StatusUtil.error(this, Messages.getString("SERVICE_CONFLICTS", //$NON-NLS-1$
+            module.getName(), currentServiceIds.get(moduleServiceId).getName(), moduleServiceId));
       }
       currentServiceIds.put(moduleServiceId, module);
     }
@@ -142,8 +142,8 @@ public class LocalAppEngineServerDelegate extends ServerDelegate implements IURL
         }
         String moduleServiceId = getServiceId(module);
         if (currentServiceIds.containsKey(moduleServiceId)) {
-          return StatusUtil.error(this, Messages.getString("SERVICES_HAVE_SAME_ID", //$NON-NLS-1$
-              currentServiceIds.get(moduleServiceId).getName(), module.getName(), moduleServiceId));
+          return StatusUtil.error(this, Messages.getString("SERVICE_CONFLICTS", //$NON-NLS-1$
+              module.getName(), currentServiceIds.get(moduleServiceId).getName(), moduleServiceId));
         }
         currentServiceIds.put(moduleServiceId, module);
       }


### PR DESCRIPTION
Clarify message shown when attempting to add a module/project to a server with a module with same Service ID.

> {project} and {project} have same App Engine Service ID: {service}

to

> Cannot add "{project}" as project "{project}" has App Engine Service ID: {service}

Fixes #1030 (as best we can)