### PR TITLE
Ensure no overlap between source paths and WEB-INF location

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
@@ -64,7 +64,7 @@ public class AppEngineStandardProjectConvertJobTest {
     // Java 1.7 facet sets the source path to src/ which will overlap with the
     // default src/main/webapp used in the AppEngineStandardFacet installer
     IPath webInfPath = webInfFolder.getProjectRelativePath();
-    List<IPath> sourcePaths = WebProjectUtil.getSourcePaths(project);
+    List<IPath> sourcePaths = WebProjectUtil.getJavaSourcePaths(project);
     for (IPath sourcePath : sourcePaths) {
       assertFalse(sourcePath.isPrefixOf(webInfPath));
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
@@ -16,13 +16,20 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets.convert;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
@@ -40,10 +47,26 @@ public class AppEngineStandardProjectConvertJobTest {
 
   @Test
   public void testAppEngineFacetAdded() throws CoreException, InterruptedException {
-    IFacetedProject facetedProject = ProjectFacetsManager.create(projectCreator.getProject());
+    IProject project = projectCreator.getProject();
+    IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     Job convertJob = new AppEngineStandardProjectConvertJob(facetedProject);
     convertJob.schedule();
     convertJob.join();
     assertTrue(AppEngineStandardFacet.hasAppEngineFacet(facetedProject));
+
+    // verify App Engine standard files are present
+    IFolder webInfFolder = WebProjectUtil.getWebInfDirectory(project);
+    assertTrue(webInfFolder.exists());
+    assertTrue(webInfFolder.exists(Path.fromPortableString("web.xml")));
+    assertTrue(webInfFolder.exists(Path.fromPortableString("appengine-web.xml")));
+
+    // verify no overlap in WEB-INF and source paths
+    // Java 1.7 facet sets the source path to src/ which will overlap with the
+    // default src/main/webapp used in the AppEngineStandardFacet installer
+    IPath webInfPath = webInfFolder.getProjectRelativePath();
+    List<IPath> sourcePaths = WebProjectUtil.getSourcePaths(project);
+    for (IPath sourcePath : sourcePaths) {
+      assertFalse(sourcePath.isPrefixOf(webInfPath));
+    }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -118,9 +118,13 @@ public class FacetUtil {
     }
 
     String webAppDirectory = "src/main/webapp";
+    if (overlapsWithJavaSourcePaths(facetedProject, Path.fromPortableString(webAppDirectory))) {
+      logger.info("Default webapp directory overlaps source directory; using WebContent");
+      webAppDirectory = "WebContent"; // WTP's default
+    }
     IPath webAppDirectoryFound = findMainWebAppDirectory(facetedProject.getProject());
     if (webAppDirectoryFound != null) {
-      webAppDirectory = webAppDirectoryFound.toOSString();
+      webAppDirectory = webAppDirectoryFound.toString();
     }
 
     IDataModel webModel = DataModelFactory.createDataModel(new WebFacetInstallDataModelProvider());
@@ -134,9 +138,24 @@ public class FacetUtil {
   }
 
   /**
+   * Return true if the given project is a Java project and has a source path that overlaps with the
+   * given path.
+   */
+  public static boolean overlapsWithJavaSourcePaths(IFacetedProject facetedProject,
+      IPath relativePath) {
+    List<IPath> sourcePaths = WebProjectUtil.getSourcePaths(facetedProject.getProject());
+    for (IPath sourcePath : sourcePaths) {
+      if (sourcePath.isPrefixOf(relativePath)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Adds an install action for {@code facet} with its {@code config} to the list of actions
-   * performed when {@link FacetUtil#install(IProgressMonitor)} is called, if {@code facet} does
-   * not already exist in the configured project.
+   * performed when {@link FacetUtil#install(IProgressMonitor)} is called, if {@code facet} does not
+   * already exist in the configured project.
    *
    * @param facet the facet to be installed
    * @param config the configuration object or null

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -143,7 +143,7 @@ public class FacetUtil {
    */
   public static boolean overlapsWithJavaSourcePaths(IFacetedProject facetedProject,
       IPath relativePath) {
-    List<IPath> sourcePaths = WebProjectUtil.getSourcePaths(facetedProject.getProject());
+    List<IPath> sourcePaths = WebProjectUtil.getJavaSourcePaths(facetedProject.getProject());
     for (IPath sourcePath : sourcePaths) {
       if (sourcePath.isPrefixOf(relativePath)) {
         return true;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
@@ -82,7 +82,7 @@ public class WebProjectUtil {
    * Return the set of Java source paths for the given project, relative to the project. Return an
    * empty list if not a Java project.
    */
-  public static List<IPath> getSourcePaths(IProject project) {
+  public static List<IPath> getJavaSourcePaths(IProject project) {
     IJavaProject javaProject = JavaCore.create(project);
     if (!javaProject.exists()) {
       return Collections.emptyList();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtil.java
@@ -16,10 +16,17 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.wst.common.componentcore.ComponentCore;
 import org.eclipse.wst.common.componentcore.resources.IVirtualComponent;
 import org.eclipse.wst.common.componentcore.resources.IVirtualFolder;
@@ -69,6 +76,30 @@ public class WebProjectUtil {
     }
     IFile file = webInfFolder.getFile(filePath);
     return file.exists() ? file : null;
+  }
+
+  /**
+   * Return the set of Java source paths for the given project, relative to the project. Return an
+   * empty list if not a Java project.
+   */
+  public static List<IPath> getSourcePaths(IProject project) {
+    IJavaProject javaProject = JavaCore.create(project);
+    if (!javaProject.exists()) {
+      return Collections.emptyList();
+    }
+    try {
+      IClasspathEntry[] classpathEntries = javaProject.getRawClasspath();
+      List<IPath> paths = new ArrayList<>();
+      for (IClasspathEntry entry : classpathEntries) {
+        if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+          // source paths are absolute to the root folder of the project
+          paths.add(entry.getPath().removeFirstSegments(1));
+        }
+      }
+      return paths;
+    } catch (JavaModelException ex) {
+      return Collections.emptyList();
+    }
   }
 
 }


### PR DESCRIPTION
Update `AppEngineStandardFacet` install-facet to use `WebContent` if the desired `src/main/webapp` default overlaps with the project's source folders (e.g., `src`).  `WebContent` is the default location used by the WTP _Dynamic Web Facet_.

Fixes #1647 