### PR TITLE
Switch to XPath

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/PomXmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/PomXmlValidatorTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -26,33 +27,42 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 
 public class PomXmlValidatorTest {
 
   @Test
-  public void testCheckForElements() throws ParserConfigurationException {
+  public void testCheckForElements() throws ParserConfigurationException, SAXException, IOException {
+
     DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
     DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
     Document document = documentBuilder.newDocument();
-    
-    Element plugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
-    plugin.setUserData("location", new DocumentLocation(1, 1), null);
-    
+
     Element groupId = document.createElementNS("http://maven.apache.org/POM/4.0.0", "groupId");
     groupId.setUserData("location", new DocumentLocation(2, 1), null);
     groupId.setTextContent("com.google.appengine");
-    plugin.appendChild(groupId);
     
     Element artifactId = document.createElementNS("http://maven.apache.org/POM/4.0.0", "artifactId");
     artifactId.setUserData("location", new DocumentLocation(3, 1), null);
     artifactId.setTextContent("appengine-maven-plugin");
-    plugin.appendChild(artifactId);
-
-    document.appendChild(plugin);
     
+    Element plugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
+    plugin.setUserData("location", new DocumentLocation(1, 1), null);
+    plugin.appendChild(groupId);
+    plugin.appendChild(artifactId);
+    
+    Element plugins = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugins");
+    plugins.setUserData("location", new DocumentLocation(1, 1), null);
+    plugins.appendChild(plugin);
+    
+    Element build = document.createElementNS("http://maven.apache.org/POM/4.0.0", "build");
+    build.setUserData("location", new DocumentLocation(1, 1), null);
+    build.appendChild(plugins);
+
+    document.appendChild(build);
+  
     PomXmlValidator validator = new PomXmlValidator();
     ArrayList<BannedElement> blacklist = validator.checkForElements(null, document);
-    
     assertEquals(1, blacklist.size());
     String markerId = "com.google.cloud.tools.eclipse.appengine.validation.mavenPluginMarker";
     assertEquals(markerId, blacklist.get(0).getMarkerId());
@@ -91,7 +101,6 @@ public class PomXmlValidatorTest {
     DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
     Document document = documentBuilder.newDocument();
     Element rootPlugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugins");
-    document.appendChild(rootPlugin);
     
     //plugin #1
     Element markedPlugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
@@ -111,35 +120,36 @@ public class PomXmlValidatorTest {
     
     //plugin #2
     Element ignoredPlugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
-    markedPlugin.setUserData("location", new DocumentLocation(1, 1), null);
+    ignoredPlugin.setUserData("location", new DocumentLocation(4, 1), null);
     
     Element groupId2 = document.createElementNS("http://maven.apache.org/POM/4.0.0", "groupId");
-    groupId2.setUserData("location", new DocumentLocation(2, 1), null);
+    groupId2.setUserData("location", new DocumentLocation(5, 1), null);
     groupId2.setTextContent("com.google.cloud.tools");
-    markedPlugin.appendChild(groupId2);
+    ignoredPlugin.appendChild(groupId2);
     
     Element artifactId2 = document.createElementNS("http://maven.apache.org/POM/4.0.0", "artifactId");
-    artifactId2.setUserData("location", new DocumentLocation(3, 1), null);
+    artifactId2.setUserData("location", new DocumentLocation(6, 1), null);
     artifactId2.setTextContent("appengine-maven-plugin");
-    markedPlugin.appendChild(artifactId2);
+    ignoredPlugin.appendChild(artifactId2);
 
     rootPlugin.appendChild(ignoredPlugin);
     
     //plugin #3
     Element ignoredPlugin2 = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
-    markedPlugin.setUserData("location", new DocumentLocation(1, 1), null);
+    markedPlugin.setUserData("location", new DocumentLocation(7, 1), null);
     
     Element groupId3 = document.createElementNS("http://maven.apache.org/POM/4.0.0", "groupId");
-    groupId3.setUserData("location", new DocumentLocation(2, 1), null);
+    groupId3.setUserData("location", new DocumentLocation(8, 1), null);
     groupId3.setTextContent("com.google.appengine");
-    markedPlugin.appendChild(groupId3);
+    ignoredPlugin2.appendChild(groupId3);
     
     Element artifactId3 = document.createElementNS("http://maven.apache.org/POM/4.0.0", "artifactId");
-    artifactId3.setUserData("location", new DocumentLocation(3, 1), null);
+    artifactId3.setUserData("location", new DocumentLocation(9, 1), null);
     artifactId3.setTextContent("ignore this case");
-    markedPlugin.appendChild(artifactId3);
-
+    ignoredPlugin2.appendChild(artifactId3);
     rootPlugin.appendChild(ignoredPlugin2);
+    
+    document.appendChild(rootPlugin);
     
     PomXmlValidator validator = new PomXmlValidator();
     ArrayList<BannedElement> blacklist = validator.checkForElements(null, document);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/PomXmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/PomXmlValidatorTest.java
@@ -47,16 +47,16 @@ public class PomXmlValidatorTest {
     artifactId.setTextContent("appengine-maven-plugin");
     
     Element plugin = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugin");
-    plugin.setUserData("location", new DocumentLocation(1, 1), null);
+    plugin.setUserData("location", new DocumentLocation(4, 1), null);
     plugin.appendChild(groupId);
     plugin.appendChild(artifactId);
     
     Element plugins = document.createElementNS("http://maven.apache.org/POM/4.0.0", "plugins");
-    plugins.setUserData("location", new DocumentLocation(1, 1), null);
+    plugins.setUserData("location", new DocumentLocation(5, 1), null);
     plugins.appendChild(plugin);
     
     Element build = document.createElementNS("http://maven.apache.org/POM/4.0.0", "build");
-    build.setUserData("location", new DocumentLocation(1, 1), null);
+    build.setUserData("location", new DocumentLocation(6, 1), null);
     build.appendChild(plugins);
 
     document.appendChild(build);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/MavenContext.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/MavenContext.java
@@ -1,0 +1,31 @@
+package com.google.cloud.tools.eclipse.appengine.validation;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.xml.namespace.NamespaceContext;
+
+import com.google.common.base.Preconditions;
+
+public class MavenContext implements NamespaceContext {
+
+  @Override
+  public String getNamespaceURI(String prefix) {
+    return "http://maven.apache.org/POM/4.0.0";
+  }
+
+  @Override
+  public String getPrefix(String namespaceURI) {
+    return "prefix";
+  }
+
+  @Override
+  public Iterator<String> getPrefixes(String namespaceURI) {
+    Preconditions.checkNotNull(namespaceURI);
+    Set<String> set = new HashSet<>(Arrays.asList("prefix"));
+    return set.iterator();
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/MavenContext.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/MavenContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.eclipse.appengine.validation;
 
 import java.util.Arrays;
@@ -9,7 +25,7 @@ import javax.xml.namespace.NamespaceContext;
 
 import com.google.common.base.Preconditions;
 
-public class MavenContext implements NamespaceContext {
+class MavenContext implements NamespaceContext {
 
   @Override
   public String getNamespaceURI(String prefix) {
@@ -17,13 +33,13 @@ public class MavenContext implements NamespaceContext {
   }
 
   @Override
-  public String getPrefix(String namespaceURI) {
+  public String getPrefix(String namespaceUri) {
     return "prefix";
   }
 
   @Override
-  public Iterator<String> getPrefixes(String namespaceURI) {
-    Preconditions.checkNotNull(namespaceURI);
+  public Iterator<String> getPrefixes(String namespaceUri) {
+    Preconditions.checkNotNull(namespaceUri);
     Set<String> set = new HashSet<>(Arrays.asList("prefix"));
     return set.iterator();
   }


### PR DESCRIPTION
Uses XPath in pom.xml validation to select groupId elements instead of manually traversing the element tree.

@elharo @meltsufin 