### PR TITLE
Reset latest query job references

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/StandardDeployPreferencesPanel.java
@@ -490,6 +490,7 @@ public class StandardDeployPreferencesPanel extends DeployPreferencesPanel {
 
   private void refreshProjectsForSelectedCredential() {
     projectSelector.setProjects(Collections.<GcpProject>emptyList());
+    latestGcpProjectQueryJob = null;
 
     Credential selectedCredential = accountSelector.getSelectedCredential();
     if (selectedCredential != null) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/ProjectSelectorSelectionChangedListener.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/ProjectSelectorSelectionChangedListener.java
@@ -61,6 +61,7 @@ public class ProjectSelectorSelectionChangedListener implements ISelectionChange
   @Override
   public void selectionChanged(SelectionChangedEvent event) {
     projectSelector.clearStatusLink();
+    latestQueryJob = null;
 
     IStructuredSelection selection = (IStructuredSelection) event.getSelection();
     if (selection.isEmpty()) {


### PR DESCRIPTION
Fixes #1726.

Because this is a concurrency issue, it's very difficult to write a test, unless we torture the code that deals with concurrency to become test-centric, which I don't think is a good idea.