### PR TITLE
Refactoring and code simplification

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJob.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy;
 
+import com.google.cloud.tools.eclipse.util.io.DeleteAllVisitor;
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -25,15 +27,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-
-import com.google.cloud.tools.eclipse.util.io.DeleteAllVisitor;
-import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 
 public class CleanupOldDeploysJob extends Job {
 
@@ -52,13 +50,14 @@ public class CleanupOldDeploysJob extends Job {
       List<File> directories = collectDirectories();
       deleteDirectories(directories);
       return Status.OK_STATUS;
-    } catch (IOException e) {
-      return StatusUtil.error(this, Messages.getString("cleanup.deploy.job.error"), e); //$NON-NLS-1$
+    } catch (IOException ex) {
+      return StatusUtil.error(this, Messages.getString("cleanup.deploy.job.error"), ex); //$NON-NLS-1$
     }
   }
 
   private List<File> collectDirectories() throws IOException {
-    DirectoryStream<Path> newDirectoryStream = Files.newDirectoryStream(parentTempDir.toFile().toPath());
+    DirectoryStream<Path> newDirectoryStream =
+        Files.newDirectoryStream(parentTempDir.toFile().toPath());
     List<File> directories = new ArrayList<>();
     for (Path path : newDirectoryStream) {
       File file = path.toFile();
@@ -75,9 +74,10 @@ public class CleanupOldDeploysJob extends Job {
       Files.walkFileTree(directories.get(i).toPath(), new DeleteAllVisitor());
     }
   }
+
   /**
-   * Comparator that sorts files on reversed order of last modification, i.e. the file that was modified
-   * more recently will be "smaller"
+   * Comparator that sorts files on reversed order of last modification, i.e. the file that was
+   * modified more recently will be "smaller".
    */
   private final class ReverseLastModifiedComparator implements Comparator<File> {
     @Override
@@ -85,6 +85,5 @@ public class CleanupOldDeploysJob extends Job {
       return - Long.compare(o1.lastModified(), o2.lastModified());
     }
   }
-
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.flex.test/src/com/google/cloud/tools/eclipse/appengine/flex/FlexFacetInstallDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.flex.test/src/com/google/cloud/tools/eclipse/appengine/flex/FlexFacetInstallDelegateTest.java
@@ -19,9 +19,6 @@ package com.google.cloud.tools.eclipse.appengine.flex;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FlexFacetInstallDelegate;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
-
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -43,14 +40,14 @@ public class FlexFacetInstallDelegateTest {
   @Test
   public void testFacetInstall() throws CoreException {
     IProject project = projectCreator.getProject();
-    
+
     IProgressMonitor monitor = new NullProgressMonitor();
     IProjectFacet appEngineFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
     IProjectFacetVersion appEngineFacetVersion =
         appEngineFacet.getVersion(AppEngineFlexFacet.VERSION);
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     facetedProject.installProjectFacet(appEngineFacetVersion, null /* config */, monitor);
-    
+
     Assert.assertTrue(AppEngineFlexFacet.hasFacet(facetedProject));
     Assert.assertTrue(project.getFile("src/main/appengine/app.yaml").exists());
   }

--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/CredentialHelperTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/CredentialHelperTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.eclipse.login;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -27,7 +29,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Path;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -45,10 +46,10 @@ public class CredentialHelperTest {
     try (InputStream in = new FileInputStream(jsonFile.toFile());
         Reader reader = new InputStreamReader(in)) {
       CredentialType credentialType = new Gson().fromJson(reader, CredentialType.class);
-      Assert.assertEquals(credentialType.client_id, Constants.getOAuthClientId());
-      Assert.assertEquals(credentialType.client_secret, Constants.getOAuthClientSecret());
-      Assert.assertEquals(credentialType.refresh_token, "fake_refresh_token");
-      Assert.assertEquals(credentialType.type, "authorized_user");
+      assertEquals(Constants.getOAuthClientId(), credentialType.client_id);
+      assertEquals(Constants.getOAuthClientSecret(), credentialType.client_secret);
+      assertEquals("fake_refresh_token", credentialType.refresh_token);
+      assertEquals("authorized_user", credentialType.type);
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/CredentialHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/CredentialHelper.java
@@ -18,11 +18,15 @@ package com.google.cloud.tools.eclipse.login;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.gson.Gson;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Helper class to work with {@link Credential} objects
+ * Helper class to work with {@link Credential} objects.
  */
 public class CredentialHelper {
 
@@ -33,16 +37,17 @@ public class CredentialHelper {
   private static final String GCLOUD_USER_TYPE = "authorized_user";
 
   /**
-   * Writes a {@link Credential} object in the JSON format expected by gcloud's <code>credential-file-override</code>
-   * feature
+   * Writes a {@link Credential} object to a file in the JSON format expected by gcloud's
+   * {@code credential-file-override} feature.
    */
-  public String toJson(Credential credential) {
+  public static void toJsonFile(Credential credential, Path toFile) throws IOException {
     Map<String, String> credentialMap = new HashMap<>();
     credentialMap.put(CLIENT_ID_LABEL, Constants.getOAuthClientId());
     credentialMap.put(CLIENT_SECRET_LABEL, Constants.getOAuthClientSecret());
     credentialMap.put(REFRESH_TOKEN_LABEL, credential.getRefreshToken());
     credentialMap.put(GCLOUD_USER_TYPE_LABEL, GCLOUD_USER_TYPE);
 
-    return new Gson().toJson(credentialMap);
+    String json = new Gson().toJson(credentialMap);
+    Files.write(toFile, json.getBytes(StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
One notable change is that I removed the `credentialFile` clean-up in the `finally` block. Anything (including the credential file) in the `workDirectory` will be cleaned up by [`CleanupOldDeploysJob`](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/v1.0.2/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJobTest.java), so there is no point in deleting only the credential file here.