### PR TITLE
Change deploy() signature for flex deploy preparation

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
@@ -56,7 +56,7 @@ public class AppEngineProjectDeployerTest {
   }
 
   @Test
-  public void testComputeDeployables_noConfigFilesAndDoNotIncludeFiles() {
+  public void testComputeDeployables_nullConfigDirectoryPath() {
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
         stagingDirectory, null /* don't include files */);
     assertEquals(1, deployables.size());
@@ -64,7 +64,7 @@ public class AppEngineProjectDeployerTest {
   }
 
   @Test
-  public void testComputeDeployables_noConfigFilesAndIncludeFiles() {
+  public void testComputeDeployables_noConfigFilesInConfigDirectory() {
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
         stagingDirectory, optionalConfigurationFilesDirectory);
     assertEquals(1, deployables.size());
@@ -72,7 +72,8 @@ public class AppEngineProjectDeployerTest {
   }
 
   @Test
-  public void testComputeDeployables_configFilesExistAndDoNotIncludeFiles() throws IOException {
+  public void testComputeDeployables_configFilesExistButNullConfigDirectoryPath()
+      throws IOException {
     createFakeConfigFiles();
 
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
@@ -82,7 +83,7 @@ public class AppEngineProjectDeployerTest {
   }
 
   @Test
-  public void testComputeDeployables_configFilesExistAndIncludeFiles() throws IOException {
+  public void testComputeDeployables_configFilesExist() throws IOException {
     createFakeConfigFiles();
 
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployerTest.java
@@ -34,11 +34,15 @@ public class AppEngineProjectDeployerTest {
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   private IPath stagingDirectory;
+  private IPath optionalConfigurationFilesDirectory;
 
   @Before
   public void setUp() throws IOException {
     stagingDirectory = new Path(tempFolder.getRoot().toString());
     tempFolder.newFile("app.yaml");
+
+    optionalConfigurationFilesDirectory = stagingDirectory.append("WEB-INF/appengine-generated");
+    tempFolder.newFolder("WEB-INF", "appengine-generated");
   }
 
   @Test
@@ -54,7 +58,7 @@ public class AppEngineProjectDeployerTest {
   @Test
   public void testComputeDeployables_noConfigFilesAndDoNotIncludeFiles() {
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
-        stagingDirectory, false /* don't include files */);
+        stagingDirectory, null /* don't include files */);
     assertEquals(1, deployables.size());
     assertEquals(stagingDirectory.append("app.yaml").toFile(), deployables.get(0));
   }
@@ -62,17 +66,7 @@ public class AppEngineProjectDeployerTest {
   @Test
   public void testComputeDeployables_noConfigFilesAndIncludeFiles() {
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
-        stagingDirectory, true /* include files */);
-    assertEquals(1, deployables.size());
-    assertEquals(stagingDirectory.append("app.yaml").toFile(), deployables.get(0));
-  }
-
-  @Test
-  public void testComputeDeployables_configFilesExistAndIncludeFiles() throws IOException {
-    createFakeConfigFiles();
-
-    List<File> deployables = AppEngineProjectDeployer.computeDeployables(
-        stagingDirectory, false /* don't include files */);
+        stagingDirectory, optionalConfigurationFilesDirectory);
     assertEquals(1, deployables.size());
     assertEquals(stagingDirectory.append("app.yaml").toFile(), deployables.get(0));
   }
@@ -82,7 +76,17 @@ public class AppEngineProjectDeployerTest {
     createFakeConfigFiles();
 
     List<File> deployables = AppEngineProjectDeployer.computeDeployables(
-        stagingDirectory, true/* include files */);
+        stagingDirectory, null /* don't include files */);
+    assertEquals(1, deployables.size());
+    assertEquals(stagingDirectory.append("app.yaml").toFile(), deployables.get(0));
+  }
+
+  @Test
+  public void testComputeDeployables_configFilesExistAndIncludeFiles() throws IOException {
+    createFakeConfigFiles();
+
+    List<File> deployables = AppEngineProjectDeployer.computeDeployables(
+        stagingDirectory, optionalConfigurationFilesDirectory);
     assertEquals(6, deployables.size());
     assertTrue(deployables.contains(stagingDirectory.append("app.yaml").toFile()));
     assertTrue(deployables.contains(stagingDirectory.append(
@@ -98,7 +102,6 @@ public class AppEngineProjectDeployerTest {
   }
 
   private void createFakeConfigFiles() throws IOException {
-    tempFolder.newFolder("WEB-INF", "appengine-generated");
     tempFolder.newFile("WEB-INF/appengine-generated/cron.yaml");
     tempFolder.newFile("WEB-INF/appengine-generated/index.yaml");
     tempFolder.newFile("WEB-INF/appengine-generated/dispatch.yaml");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployStagingTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployStagingTest.java
@@ -124,7 +124,9 @@ public class DeployStagingTest {
     IPath explodedWarDirectory = project.getFolder("WebContent").getRawLocation();
     DeployStaging.stageStandard(explodedWarDirectory, stagingDirectory, cloudSdk, monitor);
 
-    IPath stagingGenerated = stagingDirectory.append("WEB-INF/appengine-generated");
+    IPath stagingGenerated = stagingDirectory.append(
+        DeployStaging.STANDARD_STAGING_GENERATED_FILES_DIRECTORY);
+    assertTrue(stagingGenerated.toFile().isDirectory());
     assertTrue(stagingGenerated.append("cron.yaml").toFile().exists());
     assertTrue(stagingGenerated.append("index.yaml").toFile().exists());
     assertTrue(stagingGenerated.append("dispatch.yaml").toFile().exists());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
@@ -43,7 +43,7 @@ public class AppEngineProjectDeployer {
 
   /**
    * @param optionalConfigurationFilesDirectory if not {@code null}, searches optional configuration
-   * files (such as {@code cron.yaml}) in this directory and deploy them together
+   * files (such as {@code cron.yaml}) in this directory and deploys them together
    */
   public void deploy(IPath stagingDirectory, CloudSdk cloudSdk,
                      DefaultDeployConfiguration configuration,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/AppEngineProjectDeployer.java
@@ -41,9 +41,13 @@ public class AppEngineProjectDeployer {
   static final List<String> APP_ENGINE_CONFIG_FILES = Collections.unmodifiableList(Arrays.asList(
       "cron.yaml", "dispatch.yaml", "dos.yaml", "index.yaml", "queue.yaml"));
 
+  /**
+   * @param optionalConfigurationFilesDirectory if not {@code null}, searches optional configuration
+   * files (such as {@code cron.yaml}) in this directory and deploy them together
+   */
   public void deploy(IPath stagingDirectory, CloudSdk cloudSdk,
                      DefaultDeployConfiguration configuration,
-                     boolean includeOptionalConfigurationFiles, IProgressMonitor monitor) {
+                     IPath optionalConfigurationFilesDirectory, IProgressMonitor monitor) {
     if (monitor.isCanceled()) {
       throw new OperationCanceledException();
     }
@@ -52,7 +56,7 @@ public class AppEngineProjectDeployer {
     progress.setTaskName(Messages.getString("task.name.deploy.project")); //$NON-NLS-1$
     try {
       List<File> deployables =
-          computeDeployables(stagingDirectory, includeOptionalConfigurationFiles);
+          computeDeployables(stagingDirectory, optionalConfigurationFilesDirectory);
       configuration.setDeployables(deployables);
       CloudSdkAppEngineDeployment deployment = new CloudSdkAppEngineDeployment(cloudSdk);
       deployment.deploy(configuration);
@@ -63,14 +67,13 @@ public class AppEngineProjectDeployer {
 
   @VisibleForTesting
   static List<File> computeDeployables(
-      IPath stagingDirectory, boolean includeOptionalConfigurationFiles) {
+      IPath stagingDirectory, IPath optionalConfigurationFilesDirectory) {
     List<File> deployables = new ArrayList<>();
     deployables.add(stagingDirectory.append("app.yaml").toFile()); //$NON-NLS-1$
 
-    if (includeOptionalConfigurationFiles) {
+    if (optionalConfigurationFilesDirectory != null) {
       for (String configFile : APP_ENGINE_CONFIG_FILES) {
-        File file = stagingDirectory.append("WEB-INF/appengine-generated") //$NON-NLS-1$
-            .append(configFile).toFile();
+        File file = optionalConfigurationFilesDirectory.append(configFile).toFile();
         if (file.exists()) {
           deployables.add(file);
         }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployStaging.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployStaging.java
@@ -31,6 +31,9 @@ import org.eclipse.core.runtime.SubMonitor;
  */
 public class DeployStaging {
 
+  public static final String STANDARD_STAGING_GENERATED_FILES_DIRECTORY =
+      "WEB-INF/appengine-generated";
+
   /**
    * @param explodedWarDirectory the input of the staging operation
    * @param stagingDirectory where the result of the staging operation will be written

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -183,8 +183,15 @@ public class StandardDeployJob extends WorkspaceJob {
       IProgressMonitor monitor) {
     RecordProcessError deployExitListener = new RecordProcessError();
     CloudSdk cloudSdk = getCloudSdk(credentialFile, deployStdoutLineListener, deployExitListener);
+
+    IPath optionalConfigurationFiles = null;
+    if (includeOptionalConfigurationFiles) {
+      optionalConfigurationFiles = stagingDirectory.append(
+          DeployStaging.STANDARD_STAGING_GENERATED_FILES_DIRECTORY);
+    }
+
     new AppEngineProjectDeployer().deploy(stagingDirectory, cloudSdk, deployConfiguration,
-        includeOptionalConfigurationFiles, monitor);
+        optionalConfigurationFiles, monitor);
     return deployExitListener.getExitStatus();
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -184,14 +184,14 @@ public class StandardDeployJob extends WorkspaceJob {
     RecordProcessError deployExitListener = new RecordProcessError();
     CloudSdk cloudSdk = getCloudSdk(credentialFile, deployStdoutLineListener, deployExitListener);
 
-    IPath optionalConfigurationFiles = null;
+    IPath optionalConfigurationFilesDirectory = null;
     if (includeOptionalConfigurationFiles) {
-      optionalConfigurationFiles = stagingDirectory.append(
+      optionalConfigurationFilesDirectory = stagingDirectory.append(
           DeployStaging.STANDARD_STAGING_GENERATED_FILES_DIRECTORY);
     }
 
     new AppEngineProjectDeployer().deploy(stagingDirectory, cloudSdk, deployConfiguration,
-        optionalConfigurationFiles, monitor);
+        optionalConfigurationFilesDirectory, monitor);
     return deployExitListener.getExitStatus();
   }
 


### PR DESCRIPTION
For #1685.

Change the signature of `deploy()` to accept the directory containing the optional config files (`cron.yaml`, `queue.yaml`, etc.).

Details:
For flex deploy, we need to pass the original source locations of the config files when calling `gcloud app deploy`. (Unlike standard, flex staging never copies those files when staging.)