### PR TITLE
Make TestProjectCreator create project lazily

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigratorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/GpeMigratorTest.java
@@ -90,8 +90,7 @@ public class GpeMigratorTest {
   }
 
   @Test
-  public void testRemoveGpeRuntimeAndFacets_metadataFileDoesNotExist()
-      throws CoreException {
+  public void testRemoveGpeRuntimeAndFacets_metadataFileDoesNotExist() throws CoreException {
     IFile metadataFile =
         gpeProject.getFile(".settings/org.eclipse.wst.common.project.facet.core.xml");
     metadataFile.delete(true, null);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -19,13 +19,11 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -56,7 +54,7 @@ public class XmlValidatorTest {
   @ClassRule public static TestProjectCreator appEngineStandardProjectCreator =
       new TestProjectCreator().withFacetVersions(JavaFacet.VERSION_1_7,
           WebFacetUtils.WEB_25, APPENGINE_STANDARD_FACET_VERSION_1);
-  
+
   @ClassRule public static TestProjectCreator dynamicWebProjectCreator =
       new TestProjectCreator().withFacetVersions(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25);
 
@@ -65,9 +63,9 @@ public class XmlValidatorTest {
     IProject project = dynamicWebProjectCreator.getProject();
     resource = project.getFile("WebContent/WEB-INF/web.xml");
   }
-  
+
   @Test
-  public void testValidate_appEngineStandard() throws CoreException {
+  public void testValidate_appEngineStandard() {
     IProject project = appEngineStandardProjectCreator.getProject();
     IFile file = project.getFile("src/main/webapp/WEB-INF/web.xml");
     ValidationFramework framework = ValidationFramework.getDefault();
@@ -80,9 +78,9 @@ public class XmlValidatorTest {
     }
     fail("webXmlValidator isn't applied to web.xml");
   }
-  
+
   @Test
-  public void testValidate_dynamicWebProject() throws CoreException {
+  public void testValidate_dynamicWebProject() {
     ValidationFramework framework = ValidationFramework.getDefault();
     Validator[] validators = framework.getValidatorsFor(resource);
     for (Validator validator : validators) {
@@ -92,27 +90,27 @@ public class XmlValidatorTest {
       }
     }
   }
-  
+
   @Test
   public void testValidate_badXml() throws IOException, CoreException {
     IProject project = dynamicWebProjectCreator.getProject();
     IFile file = project.getFile("src/test");
     byte[] bytes = BAD_XML.getBytes(StandardCharsets.UTF_8);
     file.create(new ByteArrayInputStream(bytes), true, null);
-    
+
     XmlValidator validator = new XmlValidator();
     validator.setHelper(new AppEngineWebXmlValidator());
-    
+
     // This method should not apply any markers for malformed XML
     validator.validate(file, bytes);
     IMarker[] emptyMarkers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
     assertEquals(0, emptyMarkers.length);
-    
+
     // This method should apply markers for malformed XML
     validator.xsdValidation(file);
     IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
     assertEquals(1, markers.length);
-    
+
     String resultMessage = (String) markers[0].getAttribute(IMarker.MESSAGE);
     assertEquals("XML document structures must start and end within the same entity.",
         resultMessage);
@@ -142,7 +140,7 @@ public class XmlValidatorTest {
     assertEquals("line 1", markers[0].getAttribute(IMarker.LOCATION));
     resource.deleteMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
   }
-  
+
   @Test
   public void testXsdValidation() throws CoreException {
     String xml = "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>"
@@ -159,7 +157,7 @@ public class XmlValidatorTest {
     IMarker[] markers = file.findMarkers(problemMarker, true, IResource.DEPTH_ZERO);
     assertEquals(1, markers.length);
   }
-  
+
   @Test
   public void testCreateMarker() throws CoreException {
     String message = "Project ID should be specified at deploy time.";

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltQuickFixTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XsltQuickFixTest.java
@@ -22,12 +22,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
 import java.io.IOException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -46,14 +47,11 @@ import org.mockito.Mockito;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
-
 /**
  * Must be run as a plugin test.
  */
 public class XsltQuickFixTest {
-  
+
   private static final String APPLICATION_XML =
       "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>"
       + "<application>"
@@ -66,8 +64,8 @@ public class XsltQuickFixTest {
       + "</appengine-web-app>";
   private IProject project;
   private IFile file;
-    
-  @Rule public TestProjectCreator projectCreator = 
+
+  @Rule public TestProjectCreator projectCreator =
       new TestProjectCreator().withFacetVersions(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25);
 
   @Before
@@ -75,24 +73,23 @@ public class XsltQuickFixTest {
     project = projectCreator.getProject();
     file = project.getFile("testdata.xml");
   }
-  
-  @Test 
+
+  @Test
   public void testGetLabel() {
     XsltQuickFix fix = new XsltQuickFix("/xslt/removeApplication.xsl",
         Messages.getString("remove.application.element"));
     assertEquals("Remove application element", fix.getLabel());
   }
-  
+
   @Test
   public void testRun_removeApplicationElement() throws IOException, ParserConfigurationException,
       SAXException, TransformerException, CoreException {
-    IProject project = projectCreator.getProject();
     IFile file = project.getFile("testdata.xml");
     file.create(ValidationTestUtils.stringToInputStream(APPLICATION_XML), IFile.FORCE, null);
-    
+
     IMarker marker = Mockito.mock(IMarker.class);
     Mockito.when(marker.getResource()).thenReturn(file);
-    
+
     XsltQuickFix fix = new XsltQuickFix("/xslt/removeApplication.xsl",
         Messages.getString("remove.application.element"));
     fix.run(marker);
@@ -103,7 +100,7 @@ public class XsltQuickFixTest {
     Document transformed = builder.parse(file.getContents());
     assertEquals(0, transformed.getDocumentElement().getChildNodes().getLength());
   }
-  
+
   @Test
   public void testRun_removeVersionElement() throws IOException, ParserConfigurationException,
       SAXException, TransformerException, CoreException {
@@ -111,7 +108,7 @@ public class XsltQuickFixTest {
         VERSION_XML), IFile.FORCE, null);
     IMarker marker = Mockito.mock(IMarker.class);
     Mockito.when(marker.getResource()).thenReturn(file);
-        
+
     XsltQuickFix fix = new XsltQuickFix("/xslt/removeVersion.xsl",
         Messages.getString("remove.version.element"));
     fix.run(marker);
@@ -121,63 +118,60 @@ public class XsltQuickFixTest {
     DocumentBuilder builder = builderFactory.newDocumentBuilder();
     Document transformed = builder.parse(file.getContents());
     assertEquals(0, transformed.getDocumentElement().getChildNodes().getLength());
-    
+
     assertTrue(file.isSynchronized(0));
     assertEquals(1, file.getHistory(null).length);
   }
-  
+
   @Test
   public void testRun_existingEditor()
       throws CoreException, ParserConfigurationException, SAXException, IOException {
-    
-    IProject project = projectCreator.getProject();
+
     IFile file = project.getFile("testdata.xml");
     file.create(ValidationTestUtils.stringToInputStream(APPLICATION_XML), IFile.FORCE, null);
-    
+
     IWorkbench workbench = PlatformUI.getWorkbench();
     IEditorPart editor = WorkbenchUtil.openInEditor(workbench, file);
-    
+
     IDocument preDocument = XsltQuickFix.getCurrentDocument(file);
     String preContents = preDocument.get();
     assertTrue(preContents.contains("application"));
-    
+
     IMarker marker = Mockito.mock(IMarker.class);
     Mockito.when(marker.getResource()).thenReturn(file);
     XsltQuickFix fix = new XsltQuickFix("/xslt/removeApplication.xsl",
         Messages.getString("remove.application.element"));
     fix.run(marker);
-    
+
     IDocument document = XsltQuickFix.getCurrentDocument(file);
     String contents = document.get();
     assertFalse(contents.contains("application"));
-    
+
     // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1527
     editor.doSave(new NullProgressMonitor());
   }
-  
+
   @Test
   public void testGetCurrentDocument_existingEditor() throws CoreException {
-    
-    IProject project = projectCreator.getProject();
+
     IFile file = project.getFile("testdata.xml");
     file.create(ValidationTestUtils.stringToInputStream(APPLICATION_XML), IFile.FORCE, null);
-    
+
     IWorkbench workbench = PlatformUI.getWorkbench();
     IEditorPart editor = WorkbenchUtil.openInEditor(workbench, file);
-    
+
     assertNotNull(XsltQuickFix.getCurrentDocument(file));
-    
+
     // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1527
     editor.doSave(new NullProgressMonitor());
   }
-  
+
   @Test
   public void testGetCurrentDocument_noEditor() throws CoreException {
-    
-    IProject project = projectCreator.getProject();
+
     IFile file = project.getFile("testdata.xml");
     file.create(ValidationTestUtils.stringToInputStream(APPLICATION_XML), IFile.FORCE, null);
-    
+
     assertNull(XsltQuickFix.getCurrentDocument(file));
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -112,27 +112,27 @@ public final class TestProjectCreator extends ExternalResource {
 
   private void createProjectIfNecessary() {
     if (project == null) {
-      createProject("test" + Math.random());
+      try {
+        createProject("test" + Math.random());
+      } catch (CoreException ex) {
+        fail("FATAL: cannot create a test project.");
+      }
     }
   }
 
-  private void createProject(String projectName) {
-    try {
-      IProjectDescription newProjectDescription =
-          ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
-      newProjectDescription.setNatureIds(
-          new String[] {FacetedProjectNature.NATURE_ID});
-      project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-      project.create(newProjectDescription, null);
-      project.open(null);
+  private void createProject(String projectName) throws CoreException {
+    IProjectDescription newProjectDescription =
+        ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+    newProjectDescription.setNatureIds(
+        new String[] {FacetedProjectNature.NATURE_ID});
+    project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+    project.create(newProjectDescription, null);
+    project.open(null);
 
-      addFacets();
-      addContainerPathToRawClasspath();
-      if (appEngineServiceId != null) {
-        setAppEngineServiceId(appEngineServiceId);
-      }
-    } catch (CoreException ex) {
-      fail("FATAL: cannot create a test project.");
+    addFacets();
+    addContainerPathToRawClasspath();
+    if (appEngineServiceId != null) {
+      setAppEngineServiceId(appEngineServiceId);
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -83,46 +83,56 @@ public final class TestProjectCreator extends ExternalResource {
   }
 
   @Override
-  protected void before() throws Throwable {
-    createProject("test" + Math.random());
-  }
-
-  @Override
   protected void after() {
-    // Wait for any jobs to complete as WTP validation runs without the workspace protection lock
-    ProjectUtils.waitForProjects(project);
-    try {
-      project.delete(true, null);
-    } catch (CoreException e) {
-      fail("Could not delete project");
+    if (project != null) {
+      // Wait for any jobs to complete as WTP validation runs without the workspace protection lock
+      ProjectUtils.waitForProjects(project);
+      try {
+        project.delete(true, null);
+      } catch (CoreException ex) {
+        fail("Could not delete project");
+      }
     }
   }
 
   public IModule getModule() {
+    createProjectIfNecessary();
     return ServerUtil.getModule(project);
   }
 
   public IJavaProject getJavaProject() {
+    createProjectIfNecessary();
     return javaProject;
   }
 
   public IProject getProject() {
+    createProjectIfNecessary();
     return project;
   }
 
-  private void createProject(String projectName) throws CoreException, JavaModelException {
-    IProjectDescription newProjectDescription =
-        ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
-    newProjectDescription.setNatureIds(
-        new String[] {FacetedProjectNature.NATURE_ID});
-    project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-    project.create(newProjectDescription, null);
-    project.open(null);
+  private void createProjectIfNecessary() {
+    if (project == null) {
+      createProject("test" + Math.random());
+    }
+  }
 
-    addFacets();
-    addContainerPathToRawClasspath();
-    if (appEngineServiceId != null) {
-      setAppEngineServiceId(appEngineServiceId);
+  private void createProject(String projectName) {
+    try {
+      IProjectDescription newProjectDescription =
+          ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+      newProjectDescription.setNatureIds(
+          new String[] {FacetedProjectNature.NATURE_ID});
+      project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+      project.create(newProjectDescription, null);
+      project.open(null);
+
+      addFacets();
+      addContainerPathToRawClasspath();
+      if (appEngineServiceId != null) {
+        setAppEngineServiceId(appEngineServiceId);
+      }
+    } catch (CoreException ex) {
+      fail("FATAL: cannot create a test project.");
     }
   }
 


### PR DESCRIPTION
`.localserver.test` takes more than 4 minutes on Travis, so I changed `TestProjectCreator`. Changes in all the other files are just dumb code clean-up.

Before: `[INFO] com.google.cloud.tools.eclipse.appengine.localserver.test SUCCESS [04:13 min]`

After: `[INFO] com.google.cloud.tools.eclipse.appengine.localserver.test SUCCESS [01:40 min]`