### PR TITLE
Use Files.listFiles() instead of DirectoryStream

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJobTest.java
@@ -23,16 +23,19 @@ import static org.mockito.Mockito.mock;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.Comparator;
-
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class CleanupOldDeploysJobTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Test
   public void testRun_withNoDirectories() throws IOException {
@@ -55,15 +58,13 @@ public class CleanupOldDeploysJobTest {
   }
 
   private void testRun(int directoryCount, String[] expectedDirectoriesToKeep) throws IOException {
-    Path tempDirectory = Files.createTempDirectory("cleanupolddeploysjobtest");
-    tempDirectory.toFile().deleteOnExit();
-    createTestDirectories(tempDirectory, directoryCount);
+    createTestDirectories(directoryCount);
 
-    IPath tempDirectoryPath = new org.eclipse.core.runtime.Path(tempDirectory.toAbsolutePath().toString());
-    CleanupOldDeploysJob job = new CleanupOldDeploysJob(tempDirectoryPath);
+    IPath tempFolderPath = new Path(tempFolder.getRoot().toString());
+    CleanupOldDeploysJob job = new CleanupOldDeploysJob(tempFolderPath);
     job.run(mock(IProgressMonitor.class));
 
-    File[] directoriesKept = tempDirectoryPath.toFile().listFiles();
+    File[] directoriesKept = tempFolder.getRoot().listFiles();
     Arrays.sort(directoriesKept, new Comparator<File>() {
 
       @Override
@@ -77,13 +78,13 @@ public class CleanupOldDeploysJobTest {
     }
   }
 
-  private void createTestDirectories(Path tempDirectory, int count) throws IOException {
+  private void createTestDirectories(int count) throws IOException {
     long now = System.currentTimeMillis();
     // most recent directory will be "1", oldest is "<count>"
     for (int i = count; i > 0; --i) {
-      Path path = tempDirectory.resolve(Integer.toString(i));
-      Files.createDirectories(path);
-      Files.setLastModifiedTime(path, FileTime.fromMillis(now - i * 1000L)); // to ensure correct ordering
+      File newFolder = tempFolder.newFolder(Integer.toString(i));
+      Files.setLastModifiedTime(
+          newFolder.toPath(), FileTime.fromMillis(now - i * 1000L)); // to ensure correct ordering
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CleanupOldDeploysJob.java
@@ -20,9 +20,7 @@ import com.google.cloud.tools.eclipse.util.io.DeleteAllVisitor;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -35,12 +33,11 @@ import org.eclipse.core.runtime.jobs.Job;
 
 public class CleanupOldDeploysJob extends Job {
 
-  private static String NAME = Messages.getString("cleanup.deploy.job.name"); //$NON-NLS-1$
-  private static int RECENT_DIRECTORIES_TO_KEEP = 2;
-  private IPath parentTempDir;
+  private static final int RECENT_DIRECTORIES_TO_KEEP = 2;
+  private final IPath parentTempDir;
 
   public CleanupOldDeploysJob(IPath parentTempDir) {
-    super(NAME);
+    super(Messages.getString("cleanup.deploy.job.name")); //$NON-NLS-1$
     this.parentTempDir = parentTempDir;
   }
 
@@ -56,11 +53,9 @@ public class CleanupOldDeploysJob extends Job {
   }
 
   private List<File> collectDirectories() throws IOException {
-    DirectoryStream<Path> newDirectoryStream =
-        Files.newDirectoryStream(parentTempDir.toFile().toPath());
     List<File> directories = new ArrayList<>();
-    for (Path path : newDirectoryStream) {
-      File file = path.toFile();
+    File[] files = parentTempDir.toFile().listFiles();
+    for (File file : files) {
       if (file.isDirectory()) {
         directories.add(file);
       }


### PR DESCRIPTION
Fixes #1807.

Fortunately, existing tests cover end-to-end testing.