### PR TITLE
Refactor code

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/StandardDeployJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/StandardDeployJobTest.java
@@ -16,74 +16,60 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy;
 
-import com.google.cloud.tools.appengine.api.deploy.DefaultDeployConfiguration;
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardDeployJob;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class StandardDeployJobTest {
-  
+
   @Test
   public void testGetDeployedAppUrl_internal() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(true);
     AppEngineDeployOutput deployOutput =
         createDeployOutput("google.com:notable-torch", "version", "default");
 
     Assert.assertEquals("https://notable-torch.googleplex.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
+        StandardDeployJob.getDeployedAppUrl(true /* promoted */, deployOutput));
   }
-  
+
   @Test
   public void testGetDeployedAppUrl_withPartition() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(true);
     AppEngineDeployOutput deployOutput =
         createDeployOutput("s~google.com:notable-torch", "version", "default");
 
     Assert.assertEquals("https://notable-torch.googleplex.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
+        StandardDeployJob.getDeployedAppUrl(true /* promoted */, deployOutput));
   }
 
   @Test
   public void testGetDeployedAppUrl_promoteWithDefaultService() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(true);
     AppEngineDeployOutput deployOutput = createDeployOutput("testProject", "version", "default");
 
     Assert.assertEquals("https://testProject.appspot.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
+        StandardDeployJob.getDeployedAppUrl(true /* promoted */, deployOutput));
   }
 
   @Test
   public void testGetDeployedAppUrl_promoteWithNonDefaultService() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(true);
     AppEngineDeployOutput deployOutput = createDeployOutput("testProject", "version", "service");
 
     Assert.assertEquals("https://service-dot-testProject.appspot.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
+        StandardDeployJob.getDeployedAppUrl(true /* promoted */, deployOutput));
   }
 
   @Test
   public void testGetDeployedAppUrl_noPromoteWithDefaultService() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(false);
     AppEngineDeployOutput deployOutput = createDeployOutput("testProject", "version", "default");
 
     Assert.assertEquals("https://version-dot-testProject.appspot.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
+        StandardDeployJob.getDeployedAppUrl(false /* promoted */, deployOutput));
   }
 
   @Test
   public void testGetDeployedAppUrl_noPromoteWithNonDefaultService() {
-    StandardDeployJob standardDeployJob = createStandardDeployJob(false);
     AppEngineDeployOutput deployOutput = createDeployOutput("testProject", "version", "service");
 
     Assert.assertEquals("https://version-dot-service-dot-testProject.appspot.com",
-        standardDeployJob.getDeployedAppUrl(deployOutput));
-  }
-
-  private static StandardDeployJob createStandardDeployJob(boolean setPromote) {
-    DefaultDeployConfiguration config = new DefaultDeployConfiguration();
-    config.setPromote(setPromote);
-    config.setProject("testProject");
-    return new StandardDeployJob(null, null, null, null, null, config, false);
+        StandardDeployJob.getDeployedAppUrl(false /* promoted */, deployOutput));
   }
 
   private static AppEngineDeployOutput createDeployOutput(String project, String version,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/standard/StandardDeployJob.java
@@ -216,7 +216,8 @@ public class StandardDeployJob extends WorkspaceJob {
       String rawDeployOutput = deployStdoutLineListener.toString();
       AppEngineDeployOutput structuredOutput = AppEngineDeployOutput.parse(rawDeployOutput);
 
-      String appLocation = getDeployedAppUrl(structuredOutput);
+      boolean promoted = deployConfiguration.getPromote();
+      String appLocation = getDeployedAppUrl(promoted, structuredOutput);
       String project = deployConfiguration.getProject();
       String browserTitle = Messages.getString("browser.launch.title", project);
       WorkbenchUtil.openInBrowserInUiThread(appLocation, null, browserTitle, browserTitle);
@@ -243,8 +244,7 @@ public class StandardDeployJob extends WorkspaceJob {
   }
 
   @VisibleForTesting
-  public String getDeployedAppUrl(AppEngineDeployOutput deployOutput) {
-    boolean promoting = deployConfiguration.getPromote();
+  public static String getDeployedAppUrl(boolean promoted, AppEngineDeployOutput deployOutput) {
     String version = deployOutput.getVersion();
     String service = deployOutput.getService();
     String projectId = deployOutput.getProject();
@@ -257,11 +257,11 @@ public class StandardDeployJob extends WorkspaceJob {
       projectId = projectId.substring(colon + 1);
     }
 
-    if (promoting && usingDefaultService) {
+    if (promoted && usingDefaultService) {
       return "https://" + projectId + domain;
-    } else if (promoting && !usingDefaultService) {
+    } else if (promoted && !usingDefaultService) {
       return "https://" + service +  "-dot-"+  projectId + domain;
-    } else if (!promoting && usingDefaultService) {
+    } else if (!promoted && usingDefaultService) {
       return "https://" + version + "-dot-" + projectId + domain;
     } else {
       return "https://" + version + "-dot-" + service +  "-dot-"+  projectId + domain;


### PR DESCRIPTION
`StandardDeployJob` will become `abstract` (after renaming to `DeployJob`), so it didn't really seem fit to instantiate a concrete class in this test, where all the tests are about `getDeployAppUrl()`. It was easy to make it `static`, so I decided to go ahead not to instantiate concrete classes.