### PR TITLE
Refactor DeployCommandHandler

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
@@ -49,6 +49,8 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.window.Window;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
@@ -111,7 +113,9 @@ public class DeployCommandHandler extends AbstractHandler {
     DeployPreferences deployPreferences = new DeployPreferences(project);
     DeployConsole messageConsole =
         MessageConsoleUtilities.createConsole(getConsoleName(deployPreferences.getProjectId()),
-                                              new DeployConsole.Factory(), true /* showConsole */);
+                                              new DeployConsole.Factory());
+    IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+    consoleManager.showConsoleView(messageConsole);
 
     IPath workDirectory = createWorkDirectory();
     MessageConsoleStream outputStream = messageConsole.newMessageStream();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
@@ -111,7 +111,7 @@ public class DeployCommandHandler extends AbstractHandler {
     DeployPreferences deployPreferences = new DeployPreferences(project);
     DeployConsole messageConsole =
         MessageConsoleUtilities.createConsole(getConsoleName(deployPreferences.getProjectId()),
-                                              new DeployConsole.Factory(), true /* show */);
+                                              new DeployConsole.Factory(), true /* showConsole */);
 
     IPath workDirectory = createWorkDirectory();
     MessageConsoleStream outputStream = messageConsole.newMessageStream();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
@@ -49,8 +49,6 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.window.Window;
-import org.eclipse.ui.console.ConsolePlugin;
-import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
@@ -110,17 +108,16 @@ public class DeployCommandHandler extends AbstractHandler {
     AnalyticsPingManager.getInstance().sendPing(
         AnalyticsEvents.APP_ENGINE_DEPLOY, AnalyticsEvents.APP_ENGINE_DEPLOY_STANDARD, null);
 
-    IPath workDirectory = createWorkDirectory();
-
-    DefaultDeployConfiguration deployConfiguration = getDeployConfiguration(project);
+    DeployPreferences deployPreferences = new DeployPreferences(project);
     DeployConsole messageConsole =
-        MessageConsoleUtilities.createConsole(getConsoleName(deployConfiguration.getProject()),
-                                              new DeployConsole.Factory());
+        MessageConsoleUtilities.createConsole(getConsoleName(deployPreferences.getProjectId()),
+                                              new DeployConsole.Factory(), true /* show */);
 
+    IPath workDirectory = createWorkDirectory();
     MessageConsoleStream outputStream = messageConsole.newMessageStream();
-
+    DefaultDeployConfiguration deployConfiguration = toDeployConfiguration(deployPreferences);
     boolean includeOptionalConfigurationFiles =
-        new DeployPreferences(project).isIncludeOptionalConfigurationFiles();
+        deployPreferences.isIncludeOptionalConfigurationFiles();
 
     DeployJob deploy = new DeployJob(project, credential, workDirectory,
         new MessageConsoleWriterOutputLineListener(outputStream),
@@ -139,9 +136,6 @@ public class DeployCommandHandler extends AbstractHandler {
       }
     });
     deploy.schedule();
-
-    IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-    consoleManager.showConsoleView(messageConsole);
   }
 
   private static String getConsoleName(String projectId) {
@@ -156,9 +150,8 @@ public class DeployCommandHandler extends AbstractHandler {
                                 nowString);
   }
 
-  private static DefaultDeployConfiguration getDeployConfiguration(IProject project)
-                                                                        throws ExecutionException {
-    DeployPreferences deployPreferences = new DeployPreferences(project);
+  private static DefaultDeployConfiguration toDeployConfiguration(
+      DeployPreferences deployPreferences) throws ExecutionException {
     if (deployPreferences.getProjectId() == null || deployPreferences.getProjectId().isEmpty()) {
       throw new ExecutionException(Messages.getString("error.projectId.missing"));
     }

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/MessageConsoleUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/MessageConsoleUtilities.java
@@ -95,15 +95,11 @@ public class MessageConsoleUtilities {
     return console;
   }
 
-  public static <C extends MessageConsole> C createConsole(String name, ConsoleFactory<C> factory,
-      boolean showConsole) {
+  public static <C extends MessageConsole> C createConsole(String name, ConsoleFactory<C> factory) {
     ConsolePlugin plugin = ConsolePlugin.getDefault();
     IConsoleManager manager = plugin.getConsoleManager();
     C console = factory.createConsole(name);
     manager.addConsoles(new IConsole[]{console});
-    if (showConsole) {
-      manager.showConsoleView(console);
-    }
     return console;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/MessageConsoleUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.util/src/com/google/cloud/tools/eclipse/ui/util/MessageConsoleUtilities.java
@@ -95,11 +95,15 @@ public class MessageConsoleUtilities {
     return console;
   }
 
-  public static <C extends MessageConsole> C createConsole(String name, ConsoleFactory<C> factory) {
+  public static <C extends MessageConsole> C createConsole(String name, ConsoleFactory<C> factory,
+      boolean showConsole) {
     ConsolePlugin plugin = ConsolePlugin.getDefault();
     IConsoleManager manager = plugin.getConsoleManager();
     C console = factory.createConsole(name);
     manager.addConsoles(new IConsole[]{console});
+    if (showConsole) {
+      manager.showConsoleView(console);
+    }
     return console;
   }
 


### PR DESCRIPTION
Minor code refactoring. Couldn't resist doing this. Grouping code more locally: now the first part of `launchDeployJob()` is to create and show a console, and the next part is to prepare arguments (`workDirectory`, etc.) for `new DeployJob()`.