### PR TITLE
Check web.xml version support against App Engine facet

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -16,10 +16,17 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.eclipse.wst.server.core.IRuntimeType;
 import org.junit.Assert;
@@ -31,10 +38,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AppEngineStandardFacetTest {
+  private static final IProjectFacetVersion APPENGINE_STANDARD_FACET = ProjectFacetsManager
+      .getProjectFacet(AppEngineStandardFacet.ID).getVersion(AppEngineStandardFacet.VERSION);
+
   @Mock private org.eclipse.wst.server.core.IRuntime serverRuntime;
   @Mock private IRuntimeType runtimeType;
 
-  @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
+  @Rule
+  public TestProjectCreator baseProjectCreator = new TestProjectCreator();
+
+  @Rule
+  public TestProjectCreator appEngineProjectCreator =
+      new TestProjectCreator().withFacetVersions(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25,
+          APPENGINE_STANDARD_FACET);
 
   @Test
   public void testStandardFacetExists() {
@@ -63,5 +79,39 @@ public class AppEngineStandardFacetTest {
     IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineStandardFacet.ID);
 
     Assert.assertEquals("App Engine Java Standard Environment", projectFacet.getLabel());
+  }
+
+  @Test
+  public void testGetProjectFacetVersion_noFacet() {
+    IProjectFacetVersion facetVersion =
+        AppEngineStandardFacet.getProjectFacetVersion(baseProjectCreator.getProject());
+    assertNull(facetVersion);
+  }
+
+  @Test
+  public void testGetProjectFacetVersion_withFacet() {
+    IProjectFacetVersion facetVersion =
+        AppEngineStandardFacet.getProjectFacetVersion(appEngineProjectCreator.getProject());
+    assertEquals(APPENGINE_STANDARD_FACET, facetVersion);
+  }
+
+  @Test
+  public void testCheckServletApiSupport_blankVersion() {
+    assertFalse(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, ""));
+  }
+
+  @Test
+  public void testCheckServletApiSupport_invalidVersion() {
+    assertFalse(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, "2.6"));
+  }
+
+  @Test
+  public void testCheckServletApiSupport_sameVersion() {
+    assertTrue(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, "2.5"));
+  }
+
+  @Test
+  public void testCheckServletApiSupport_earlierVersion() {
+    assertTrue(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, "2.4"));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -96,8 +96,20 @@ public class AppEngineStandardFacetTest {
   }
 
   @Test
-  public void testCheckServletApiSupport_blankVersion() {
-    assertFalse(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, ""));
+  public void testCheckServletApiSupport_noFacet() {
+    assertFalse(
+        AppEngineStandardFacet.checkServletApiSupport(baseProjectCreator.getProject(), "2.5"));
+  }
+
+  @Test
+  public void testCheckServletApiSupport_withFacet() {
+    assertTrue(
+        AppEngineStandardFacet.checkServletApiSupport(appEngineProjectCreator.getProject(), "2.5"));
+  }
+
+  @Test
+  public void testCheckServletApiSupport_nullVersion() {
+    assertFalse(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, null));
   }
 
   @Test
@@ -112,6 +124,6 @@ public class AppEngineStandardFacetTest {
 
   @Test
   public void testCheckServletApiSupport_earlierVersion() {
-    assertTrue(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, "2.4"));
+    assertFalse(AppEngineStandardFacet.checkServletApiSupport(APPENGINE_STANDARD_FACET, "2.4"));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -95,10 +95,9 @@ public class AppEngineStandardFacetTest {
     assertEquals(APPENGINE_STANDARD_FACET, facetVersion);
   }
 
-  @Test
+  @Test(expected = NullPointerException.class)
   public void testCheckServletApiSupport_noFacet() {
-    assertFalse(
-        AppEngineStandardFacet.checkServletApiSupport(baseProjectCreator.getProject(), "2.5"));
+    AppEngineStandardFacet.checkServletApiSupport(baseProjectCreator.getProject(), "2.5");
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -17,11 +17,13 @@
 package com.google.cloud.tools.eclipse.appengine.facets;
 
 import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
@@ -62,6 +64,53 @@ public class AppEngineStandardFacet {
   public static boolean hasFacet(IFacetedProject project) {
     return FacetedProjectHelper.projectHasFacet(project, ID);
   }
+
+  /**
+   * Return the App Engine standard facet for the given project, or {@code null} if none.
+   */
+  public static IProjectFacetVersion getProjectFacetVersion(IProject project) {
+    try {
+      IFacetedProject facetedProject = ProjectFacetsManager.create(project);
+      if (facetedProject == null) {
+        return null;
+      }
+      IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(ID);
+      return facetedProject.getProjectFacetVersion(projectFacet);
+    } catch (CoreException ex) {
+      return null;
+    }
+  }
+
+  /**
+   * Check that the given Servlet API version string (expected to be from the
+   * <tt>&lt;web-app version="xxx"&gt;</tt> attribute), is compatible with this project's App Engine
+   * settings.
+   * 
+   * @return {@code true} if supported or {@code false} otherwise
+   */
+  public static boolean checkServletApiSupport(IProject project, String servletApiVersion) {
+    IProjectFacetVersion appEngineFacetVersion = getProjectFacetVersion(project);
+    if (appEngineFacetVersion == null) {
+      return false;
+    }
+    return checkServletApiSupport(appEngineFacetVersion, servletApiVersion);
+  }
+
+  @VisibleForTesting
+  static boolean checkServletApiSupport(IProjectFacetVersion appEngineFacetVersion,
+      String servletApiVersion) {
+    // Assumes that App Engine Standard facet constraints are properly set up, so look up
+    // corresponding jst.web version and check for conflicts
+    IProjectFacetVersion dynamicWebFacetVersion = null;
+    try {
+      dynamicWebFacetVersion = WebFacetUtils.WEB_FACET.getVersion(servletApiVersion);
+    } catch (IllegalArgumentException ex) {
+      // ignore: invalid version specified (e.g., "2.6")
+    }
+    return dynamicWebFacetVersion != null
+        && !appEngineFacetVersion.conflictsWith(dynamicWebFacetVersion);
+  }
+
 
   /**
    * Returns true if {@code facetRuntime} is an App Engine Standard runtime and false otherwise.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -99,16 +99,17 @@ public class AppEngineStandardFacet {
   @VisibleForTesting
   static boolean checkServletApiSupport(IProjectFacetVersion appEngineFacetVersion,
       String servletApiVersion) {
-    // Assumes that App Engine Standard facet constraints are properly set up, so look up
+    // Assume that App Engine Standard facet constraints are properly set up, so look up
     // corresponding jst.web version and check for conflicts
-    IProjectFacetVersion dynamicWebFacetVersion = null;
     try {
-      dynamicWebFacetVersion = WebFacetUtils.WEB_FACET.getVersion(servletApiVersion);
+      IProjectFacetVersion dynamicWebFacetVersion =
+          WebFacetUtils.WEB_FACET.getVersion(servletApiVersion);
+      return dynamicWebFacetVersion != null
+          && !appEngineFacetVersion.conflictsWith(dynamicWebFacetVersion);
     } catch (IllegalArgumentException ex) {
       // ignore: invalid version specified (e.g., "2.6")
+      return false;
     }
-    return dynamicWebFacetVersion != null
-        && !appEngineFacetVersion.conflictsWith(dynamicWebFacetVersion);
   }
 
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -87,12 +87,11 @@ public class AppEngineStandardFacet {
    * settings.
    * 
    * @return {@code true} if supported or {@code false} otherwise
+   * @throws NullPointerException if the project does not have an App Engine Standard facet
    */
   public static boolean checkServletApiSupport(IProject project, String servletApiVersion) {
     IProjectFacetVersion appEngineFacetVersion = getProjectFacetVersion(project);
-    if (appEngineFacetVersion == null) {
-      return false;
-    }
+    Preconditions.checkNotNull(appEngineFacetVersion, "Missing App Engine Standard facet");
     return checkServletApiSupport(appEngineFacetVersion, servletApiVersion);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -252,4 +252,12 @@ public class FacetUtil {
     return webInfFolders;
   }
 
+  /**
+   * Check the the Dynamic Web Project facet version is compatible with the <tt>version</tt>.
+   */
+  public static boolean checkDeploymentDescriptorCompatibility(IProject project, String version) {
+    // TODO Auto-generated method stub
+    return false;
+  }
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -252,12 +252,4 @@ public class FacetUtil {
     return webInfFolders;
   }
 
-  /**
-   * Check the the Dynamic Web Project facet version is compatible with the <tt>version</tt>.
-   */
-  public static boolean checkDeploymentDescriptorCompatibility(IProject project, String version) {
-    // TODO Auto-generated method stub
-    return false;
-  }
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidatorTest.java
@@ -17,13 +17,18 @@
 package com.google.cloud.tools.eclipse.appengine.validation;
 
 import static org.junit.Assert.assertEquals;
-import java.util.ArrayList;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.util.ArrayList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import org.eclipse.core.resources.IResource;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Document;
@@ -31,6 +36,11 @@ import org.w3c.dom.Element;
 
 public class WebXmlValidatorTest {
  
+  @Rule
+  public TestProjectCreator projectCreator = new TestProjectCreator()
+      .withFacetVersions(WebFacetUtils.WEB_25, JavaFacet.VERSION_1_7, ProjectFacetsManager
+          .getProjectFacet(AppEngineStandardFacet.ID).getVersion(AppEngineStandardFacet.VERSION));
+
   private final WebXmlValidator validator = new WebXmlValidator();
   
   @Test
@@ -45,6 +55,7 @@ public class WebXmlValidatorTest {
     document.appendChild(element);
     
     IResource resource = Mockito.mock(IResource.class);
+    Mockito.when(resource.getProject()).thenReturn(projectCreator.getProject());
     ArrayList<BannedElement> blacklist = validator.checkForElements(resource, document);
     
     assertEquals(1, blacklist.size());
@@ -64,6 +75,7 @@ public class WebXmlValidatorTest {
     document.appendChild(element);
     
     IResource resource = Mockito.mock(IResource.class);
+    Mockito.when(resource.getProject()).thenReturn(projectCreator.getProject());
     ArrayList<BannedElement> blacklist = validator.checkForElements(resource, document);
     
     assertEquals(0, blacklist.size());
@@ -100,6 +112,7 @@ public class WebXmlValidatorTest {
     document.appendChild(webApp);
     
     IResource resource = Mockito.mock(IResource.class);
+    Mockito.when(resource.getProject()).thenReturn(projectCreator.getProject());
     ArrayList<BannedElement> blacklist = validator.checkForElements(resource, document);
     assertEquals(1, blacklist.size());
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlSourceValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlSourceValidatorTest.java
@@ -19,14 +19,13 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -127,6 +126,7 @@ public class XmlSourceValidatorTest {
     validator.setHelper(new WebXmlValidator());
     String xml = "<web-app xmlns='http://xmlns.jcp.org/xml/ns/javaee' version='3.1'></web-app>";
     IFile file = Mockito.mock(IFile.class);
+    when(file.getProject()).thenReturn(appEngineStandardProject.getProject());
     validator.validate(reporter, file, xml.getBytes(StandardCharsets.UTF_8));
     assertEquals(1, reporter.getMessages().size());
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidator.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.eclipse.appengine.validation;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,7 +29,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -47,8 +49,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 
 /**
  * Validator for web.xml.
@@ -66,7 +66,7 @@ public class WebXmlValidator implements XmlValidationHelper {
     this.document = document;
     this.resource = resource;
     this.blacklist = new ArrayList<>();
-    validateJavaServlet();
+    validateJavaServletVersion();
     validateServletClass();
     validateServletMapping();
     validateJsp();
@@ -76,7 +76,7 @@ public class WebXmlValidator implements XmlValidationHelper {
   /**
    * Validates that web.xml uses Java Servlet 2.5 deployment descriptor.
    */
-  private void validateJavaServlet() {
+  private void validateJavaServletVersion() {
     NodeList webAppList = document.getElementsByTagName("web-app");
     for (int i = 0; i < webAppList.getLength(); i++) {
       Element webApp = (Element) webAppList.item(i);
@@ -84,7 +84,8 @@ public class WebXmlValidator implements XmlValidationHelper {
       String version = (String) webApp.getUserData("version");
       if ("http://xmlns.jcp.org/xml/ns/javaee".equals(namespace)
           || "http://java.sun.com/xml/ns/javaee".equals(namespace)) {
-        if (!"2.5".equals(version)) {
+        // Check that web.xml version is compatible with our supported Dynamic Web Project versions
+        if (!AppEngineStandardFacet.checkServletApiSupport(resource.getProject(), version)) {
           DocumentLocation location = (DocumentLocation) webApp.getUserData("location");
           BannedElement element = new JavaServletElement(location, 0);
           blacklist.add(element);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/WebXmlValidator.java
@@ -66,7 +66,7 @@ public class WebXmlValidator implements XmlValidationHelper {
     this.document = document;
     this.resource = resource;
     this.blacklist = new ArrayList<>();
-    validateJavaServletVersion();
+    validateServletVersion();
     validateServletClass();
     validateServletMapping();
     validateJsp();
@@ -74,9 +74,9 @@ public class WebXmlValidator implements XmlValidationHelper {
   }
   
   /**
-   * Validates that web.xml uses Java Servlet 2.5 deployment descriptor.
+   * Validates that web.xml specifies a compatible deployment descriptor version.
    */
-  private void validateJavaServletVersion() {
+  private void validateServletVersion() {
     NodeList webAppList = document.getElementsByTagName("web-app");
     for (int i = 0; i < webAppList.getLength(); i++) {
       Element webApp = (Element) webAppList.item(i);


### PR DESCRIPTION
Relax the `web.xml` version validation from checking just `version="2.5"` to instead verify that it is compatible with the App Engine standard facet.  Required for Java 8 support (#1057).