### PR TITLE
Add org.eclipse.rcp dep to .dataflow.ui.test/pom.xml to silence Event Admin build log clutters

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/pom.xml
@@ -29,7 +29,7 @@
 
   <artifactId>com.google.cloud.tools.eclipse.dataflow.ui.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -41,7 +41,23 @@
           <product>org.eclipse.platform.ide</product>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <!-- needed for org.eclipse.equinox.event -->
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-  
+
 </project>


### PR DESCRIPTION
Since `<useUIHarness>` in #1816, `.dataflow.ui.test` throws too much garbage in build logs due to #1105, to the point of Travis not being able to display the whole log: https://travis-ci.org/GoogleCloudPlatform/google-cloud-eclipse/jobs/223416573. Adding `org.eclipse.rcp` takes care of it. 