### PR TITLE
Show GCP preference page from Package Explorer too

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
@@ -39,7 +39,7 @@ public class PluginXmlTest extends BasePluginXmlTest {
     NodeList tests = getDocument().getElementsByTagName("test");
     Assert.assertEquals(3, tests.getLength());
     NodeList adapts = getDocument().getElementsByTagName("adapt");
-    Assert.assertEquals(1, adapts.getLength());
+    Assert.assertEquals(3, adapts.getLength());
 
     for (int i = 0; i < enabledWhen.getLength(); i++) {
       Element element = (Element) enabledWhen.item(i);
@@ -47,7 +47,7 @@ public class PluginXmlTest extends BasePluginXmlTest {
       assertThat(parent.getNodeName(), either(is("page")).or(is("handler")));
     }
 
-    Element adapt = (Element) adapts.item(0);
+    Element adapt = (Element) adapts.item(2);
     Assert.assertEquals("org.eclipse.core.resources.IProject", adapt.getAttribute("type"));
 
     NodeList adaptTestNodes = adapt.getElementsByTagName("test");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
@@ -62,7 +62,7 @@
         name="Google Cloud Platform"
         class="com.google.cloud.tools.eclipse.properties.GooglePropertyPage">
       <enabledWhen>
-        <instanceof value="org.eclipse.core.resources.IProject" />
+        <adapt type="org.eclipse.core.resources.IProject" />
       </enabledWhen>
     </page>
   </extension>
@@ -74,7 +74,7 @@
         category="com.google.cloud.tools.eclipse"
         class="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployPropertyPage">
       <enabledWhen>
-        <instanceof value="org.eclipse.core.resources.IProject" />
+        <adapt type="org.eclipse.core.resources.IProject" />
       </enabledWhen>
     </page>
   </extension>


### PR DESCRIPTION
Fixes #1650.

The reason is basically like in #482: the Java perspective uses Package Explorer, and the instance of a selected project in Package Explorer is `IJavaProject`, not `IProject`. Of course, `IJavaProject` can be adapted to `IProject`.