### PR TITLE
Validate service name field in AppEngineWizardPage

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.facets;
 
 import com.google.cloud.tools.eclipse.util.FacetedProjectHelper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
@@ -252,6 +253,7 @@ public class AppEngineStandardFacet {
     IRuntimeType appEngineRuntimeType =
         ServerCore.findRuntimeType(AppEngineStandardFacet.DEFAULT_RUNTIME_ID);
     if (appEngineRuntimeType == null) {
+      logger.warning("RuntimeTypes: " + Joiner.on(",").join(ServerCore.getRuntimeTypes()));
       throw new NullPointerException(
           "Could not find " + AppEngineStandardFacet.DEFAULT_RUNTIME_NAME + " runtime type");
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -135,7 +135,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
     IStatus packageStatus = JavaPackageValidator.validate(packageName);
     if (!packageStatus.isOK()) {
       String message = Messages.getString("illegal.package.name",  //$NON-NLS-1$
-          packageStatus.getMessage());
+          packageName, packageStatus.getMessage());
       setErrorMessage(message);
       return false;
     }
@@ -144,7 +144,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
     boolean serviceNameValid =
         serviceName.isEmpty() || ServiceNameValidator.validate(serviceName);
     if (!serviceNameValid) {
-      String message = Messages.getString("illegal.service.name"); //$NON-NLS-1$
+      String message = Messages.getString("illegal.service.name", serviceName); //$NON-NLS-1$
       setErrorMessage(message);
       return false;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -20,6 +20,8 @@ import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.cloud.tools.eclipse.appengine.ui.LibrarySelectorGroup;
+import com.google.cloud.tools.project.ServiceNameValidator;
+import com.google.common.base.Strings;
 import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
@@ -111,7 +113,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
     Label serviceNameLabel = new Label(parent, SWT.LEAD);
     serviceNameLabel.setText(Messages.getString("app.engine.service"));
     serviceNameField = new Text(parent, SWT.BORDER);
-    serviceNameField.setMessage("default");  //$NON-NLS-1$
+    serviceNameField.setMessage("default"); //$NON-NLS-1$
     serviceNameField.addModifyListener(pageValidator);
 
     GridDataFactory.fillDefaults().grab(true, false).applyTo(serviceNameField);
@@ -135,6 +137,15 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
     if (!packageStatus.isOK()) {
       String message = Messages.getString("illegal.package.name",  //$NON-NLS-1$
           packageStatus.getMessage());
+      setErrorMessage(message);
+      return false;
+    }
+
+    String serviceName = serviceNameField.getText();
+    boolean serviceNameValid =
+        Strings.isNullOrEmpty(serviceName) || ServiceNameValidator.validate(serviceName);
+    if (!serviceNameValid) {
+      String message = Messages.getString("illegal.service.name"); //$NON-NLS-1$
       setErrorMessage(message);
       return false;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.cloud.tools.eclipse.appengine.ui.LibrarySelectorGroup;
 import com.google.cloud.tools.project.ServiceNameValidator;
-import com.google.common.base.Strings;
 import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
@@ -143,7 +142,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
 
     String serviceName = serviceNameField.getText();
     boolean serviceNameValid =
-        Strings.isNullOrEmpty(serviceName) || ServiceNameValidator.validate(serviceName);
+        serviceName.isEmpty() || ServiceNameValidator.validate(serviceName);
     if (!serviceNameValid) {
       String message = Messages.getString("illegal.service.name"); //$NON-NLS-1$
       setErrorMessage(message);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
@@ -6,6 +6,7 @@ create.app.engine.standard.project=Create a new Eclipse project for App Engine s
 project.creation.failed=Failed to create project
 java.package=Java package:
 illegal.package.name=Illegal package name: {0}
+illegal.service.name=A service name may contain up to 63 numbers, letters, and hyphens with no leading or trailing hyphens.
 enter.project.name=Enter a project name.
 project.location.exists: Project location already exists: {0}
 package.ends.with.period: {0} ends with a period.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
@@ -5,8 +5,10 @@ app.engine.standard.project=App Engine Standard Project
 create.app.engine.standard.project=Create a new Eclipse project for App Engine standard environment development.
 project.creation.failed=Failed to create project
 java.package=Java package:
-illegal.package.name=Illegal package name: {0}
-illegal.service.name=A service name may contain up to 63 numbers, letters, and hyphens, with no leading or trailing hyphens.
+# illegal.package.name: the validation message {1} already includes the package name
+illegal.package.name=Illegal package name: {1}
+illegal.service.name=Illegal service name ''{0}'': A service name may contain up to 63 numbers, \
+ letters, and hyphens, with no leading or trailing hyphens.
 enter.project.name=Enter a project name.
 project.location.exists: Project location already exists: {0}
 package.ends.with.period: {0} ends with a period.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/messages.properties
@@ -6,7 +6,7 @@ create.app.engine.standard.project=Create a new Eclipse project for App Engine s
 project.creation.failed=Failed to create project
 java.package=Java package:
 illegal.package.name=Illegal package name: {0}
-illegal.service.name=A service name may contain up to 63 numbers, letters, and hyphens with no leading or trailing hyphens.
+illegal.service.name=A service name may contain up to 63 numbers, letters, and hyphens, with no leading or trailing hyphens.
 enter.project.name=Enter a project name.
 project.location.exists: Project location already exists: {0}
 package.ends.with.period: {0} ends with a period.


### PR DESCRIPTION
Use appengine-plugins-core's `ServiceNameValidator` which unfortunately doesn't provide a helpful message to describe the validation error.  Any suggestions to shorten the service-name description message?

Works around #1830
