### PR TITLE
Avoid NPE in DataflowDependencyManager#hasPinnedDataflowDependency()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/DataflowDependencyManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/DataflowDependencyManagerTest.java
@@ -25,6 +25,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -43,9 +46,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Tests for {@link DataflowArtifactRetriever}.
@@ -193,6 +193,13 @@ public class DataflowDependencyManagerTest {
   }
 
   @Test
+  public void hasTrackedDependencyNoModel() {
+    when(projectRegistry.getProject(project)).thenReturn(null);
+
+    assertFalse(manager.hasTrackedDataflowDependency(project));
+  }
+
+  @Test
   public void hasTrackedDependencyNoDependency() {
     when(model.getDependencies()).thenReturn(ImmutableList.<Dependency>of());
 
@@ -213,6 +220,13 @@ public class DataflowDependencyManagerTest {
         .thenReturn(ImmutableList.<Dependency>of(trackedDataflowDependency()));
 
     assertTrue(manager.hasTrackedDataflowDependency(project));
+  }
+
+  @Test
+  public void hasPinnedDependencyNoModel() {
+    when(projectRegistry.getProject(project)).thenReturn(null);
+
+    assertFalse(manager.hasPinnedDataflowDependency(project));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/DataflowDependencyManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/DataflowDependencyManager.java
@@ -20,6 +20,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.TreeMap;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -34,10 +38,6 @@ import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMaven;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.NavigableSet;
-import java.util.TreeMap;
 
 /**
  * {@link DataflowDependencyManager} provides {@code Dependency} instances for Dataflow and the
@@ -92,6 +92,9 @@ public class DataflowDependencyManager {
    */
   public boolean hasPinnedDataflowDependency(IProject project) {
     Model model = getModelFromProject(project);
+    if (model == null) {
+      return false;
+    }
     Dependency dependency = getDataflowDependencyFromModel(model);
     if (dependency == null
         || Artifact.LATEST_VERSION.equals(dependency.getVersion())


### PR DESCRIPTION
Use same pattern as is present in `hasTrackedDataflowDependency()`.

Fixes #1799 