### PR TITLE
Hook in Java 8 support for the build

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Google Cloud Tools for App Engine Standard Java 8 Tests
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.standard.java8.test
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.standard.java8
-Bundle-Version: 0.0.1.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Google, Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.cloud.tools.appengine;version="0.2.11",

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/pom.xml
@@ -8,7 +8,7 @@
     <version>0.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
-  <artifactId>com.google.cloud.tools.eclipse.welcome.test</artifactId>
+  <artifactId>com.google.cloud.tools.eclipse.appengine.standard.java8.test</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/build.properties
@@ -1,7 +1,7 @@
-source.. = src/,\
-           src-test/
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               xslt/
 additional.bundles = org.eclipse.equinox.common, org.junit

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/pom.xml
@@ -17,6 +17,7 @@
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
     <version>4.12</version>
+    <scope>test</scope>
     </dependency>
   </dependencies>
   
@@ -46,6 +47,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
         <executions>
           <execution>
             <id>compiletests</id>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src-test/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineXsltTransformTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src-test/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineXsltTransformTest.java
@@ -40,7 +40,7 @@ import org.xml.sax.SAXException;
 /**
  * Test the appengine-web.xml XSLT transforms
  */
-public class AppEngineXsltTransformTests {
+public class AppEngineXsltTransformTest {
 
   @Test
   public void testAddBare() {
@@ -130,7 +130,7 @@ public class AppEngineXsltTransformTests {
 
   private Document transform(String templateFile, String inputValue) {
     try {
-      URL xslPath = AppEngineXsltTransformTests.class.getResource(templateFile);
+      URL xslPath = AppEngineXsltTransformTest.class.getResource(templateFile);
       if (xslPath == null) {
         File xslFile = new File("." + templateFile);
         assertTrue(xslFile.exists());

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
     <module>plugins/com.google.cloud.tools.eclipse.appengine.validation.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.appengine.ui</module>
     <module>plugins/com.google.cloud.tools.eclipse.appengine.ui.test</module>
+    <module>plugins/com.google.cloud.tools.eclipse.appengine.standard.java8</module>
+    <module>plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.bugreport</module>
     <module>plugins/com.google.cloud.tools.eclipse.bugreport.test</module>
     <module>plugins/com.google.cloud.tools.eclipse.googleapis</module>


### PR DESCRIPTION
  - ensure XSL templates are being packaged into the bundle
  - rename test classes so are picked up by surefire
  - specify maven-compiler-plugin source levels
  - remove test source from main source