### PR TITLE
check for duplicate project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -323,7 +323,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
   }
 
   /**
-   * Check that we won't overwrite an existing location. Expects a valid Maven Artifact ID.
+   * Check that we won't overwrite an existing location. Expects a valid Maven artifact ID.
    */
   private boolean validateGeneratedProjectLocation() {
     String artifactId = getArtifactId();
@@ -353,7 +353,7 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
       setErrorMessage(Messages.getString("ILLEGAL_ARTIFACT_ID", artifactId)); //$NON-NLS-1$
       return false;
     } else if (ResourcesPlugin.getWorkspace().getRoot().getProject(artifactId).exists()) {
-      setErrorMessage(artifactId + " project already exists in this workspace"); //$NON-NLS-1$
+      setErrorMessage(Messages.getString("PROJECT_ALREADY_EXISTS", artifactId)); //$NON-NLS-1$
       return false;
     }
     String version = getVersion();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenAppEngineStandardWizardPage.java
@@ -352,6 +352,9 @@ public class MavenAppEngineStandardWizardPage extends WizardPage {
     } else if (!MavenCoordinatesValidator.validateArtifactId(artifactId)) {
       setErrorMessage(Messages.getString("ILLEGAL_ARTIFACT_ID", artifactId)); //$NON-NLS-1$
       return false;
+    } else if (ResourcesPlugin.getWorkspace().getRoot().getProject(artifactId).exists()) {
+      setErrorMessage(artifactId + " project already exists in this workspace"); //$NON-NLS-1$
+      return false;
     }
     String version = getVersion();
     if (version.isEmpty()) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.maven/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/messages.properties
@@ -30,3 +30,5 @@ ARTIFACT_VERSION=Version:
 GROUP_ID_TOOLTIP=The Maven Group ID. Should be an alphanumeric path separated by periods.
 ARTIFACT_ID_TOOLTIP=The Maven Artifact ID. Should be an alphanumeric name separated by dashes.
 PROJECT_CREATION_FAILED=Failed to create project
+PROJECT_ALREADY_EXISTS=A project named {0} already exists in this workspace.
+


### PR DESCRIPTION
@chanseokoh fix #1906, maybe.

I'm not sure this is the right approach. Other options include:

1. Add a separate Project name field.
2. add a "-2", "-3" suffix to the eclipse project name if the artifact doubles up. 

I'm not sure it shoudl be impossible to create two eclipse projects in a workspace that have the same Maven artifact ID. They might have different group Ids, for example. 
