### PR TITLE
Make TestProjectCreator wait for project only when adding GAE standard facet

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -132,15 +132,15 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     // The virtual component model is very flexible, but we assume that
     // the WEB-INF/appengine-web.xml isn't a virtual file remapped elsewhere
     IFolder webInfDir = WebProjectUtil.getWebInfDirectory(project);
-    
+
     if (webInfDir == null) {
       webInfDir =
           project.getFolder(WebProjectUtil.DEFAULT_WEB_PATH).getFolder(WebProjectUtil.WEB_INF);
       ResourceUtils.createFolders(webInfDir, progress.newChild(3));
     }
-    
+
     progress.worked(1);
-    
+
     IFile appEngineWebXml = webInfDir.getFile(APPENGINE_WEB_XML);
 
     if (appEngineWebXml.exists()) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.test.util.project;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.common.base.Preconditions;
@@ -162,8 +163,10 @@ public final class TestProjectCreator extends ExternalResource {
     }
     facetUtil.install(null);
 
-    // App Engine runtime is added via a Job, so wait.
-    ProjectUtils.waitForProjects(getProject());
+    if (facetedProject.hasProjectFacet(AppEngineStandardFacet.FACET)) {
+      // App Engine runtime is added via a Job, so wait.
+      ProjectUtils.waitForProjects(getProject());
+    }
 
     if (facetedProject.hasProjectFacet(JavaFacet.FACET)) {
       javaProject = JavaCore.create(project);
@@ -173,16 +176,12 @@ public final class TestProjectCreator extends ExternalResource {
 
   public void setAppEngineServiceId(String serviceId) throws CoreException {
     IFolder webinf = WebProjectUtil.getWebInfDirectory(getProject());
-    IFile descriptorFile = webinf.getFile("appengine-web.xml");
-    assertTrue("Project should have AppEngine Standard facet", descriptorFile.exists());
-    StringBuilder newAppEngineWebDescriptor = new StringBuilder();
-    newAppEngineWebDescriptor
-        .append("<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n");
-    newAppEngineWebDescriptor.append("<service>").append(serviceId).append("</service>\n");
-    newAppEngineWebDescriptor.append("</appengine-web-app>\n");
-    InputStream contents = new ByteArrayInputStream(
-        newAppEngineWebDescriptor.toString().getBytes(StandardCharsets.UTF_8));
-    descriptorFile.setContents(contents, IFile.FORCE, null);
+    IFile appEngineWebXml = webinf.getFile("appengine-web.xml");
+    assertTrue("Project should have AppEngine Standard facet", appEngineWebXml.exists());
+    String contents = "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n"
+        + "<service>" + serviceId + "</service>\n</appengine-web-app>\n";
+    InputStream in = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
+    appEngineWebXml.setContents(in, IFile.FORCE, null);
   }
 
 }


### PR DESCRIPTION
Might be just a tiny difference, but I hope this will help reduce the running time.

The changes in `setAppEngineServiceId` are simple variable renaming and replacing `StringBuilder` with `String`.