### PR TITLE
Delete JSP files in tearDown() in tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.junit;bundle-version="4.12.0"
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.ui.util,
+ com.google.cloud.tools.eclipse.util.io,
  org.eclipse.core.runtime.jobs,
  org.eclipse.jst.common.project.facet.core,
  org.eclipse.jst.j2ee.web.project.facet,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/ValidationTestUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/ValidationTestUtils.java
@@ -16,16 +16,11 @@
 
 package com.google.cloud.tools.eclipse.appengine.validation;
 
+import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextViewer;
@@ -36,42 +31,30 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.ResourceUtil;
 
-import com.google.cloud.tools.eclipse.ui.util.WorkbenchUtil;
-
 public class ValidationTestUtils {
-  
+
   static IDocument getDocument(IFile file) {
     IWorkbench workbench = PlatformUI.getWorkbench();
     WorkbenchUtil.openInEditor(workbench, file);
     ITextViewer viewer = ValidationTestUtils.getViewer(file);
     return viewer.getDocument();
   }
-  
+
   static ITextViewer getViewer(IFile file) {
     IWorkbench workbench = PlatformUI.getWorkbench();
     IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
     IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
     IEditorPart editorPart = ResourceUtil.findEditor(activePage, file);
-    
+
     ITextOperationTarget target = editorPart.getAdapter(ITextOperationTarget.class);
     if (target instanceof ITextViewer) {
       return (ITextViewer) target;
     }
     return null;
   }
-  
+
   static InputStream stringToInputStream(String string) {
     return new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
   }
-  
-  static void createFolders(IContainer parent, IPath path) throws CoreException {
-    if (!path.isEmpty()) {
-      IFolder folder = parent.getFolder(new Path(path.segment(0)));
-      if (!folder.exists()) {
-        folder.create(true,  true,  null);
-      }
-      createFolders(folder, path.removeFirstSegments(1));
-    }
-  }
-  
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -29,7 +30,6 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.wst.validation.ValidationFramework;
@@ -145,7 +145,7 @@ public class XmlValidatorTest {
     XmlValidator validator = new XmlValidator();
     validator.setHelper(new AppEngineWebXmlValidator());
     IProject project = appEngineStandardProjectCreator.getProject();
-    ValidationTestUtils.createFolders(project, new Path("src/main/webapp/WEB-INF"));
+    ResourceUtils.createFolders(project.getFolder("src/main/webapp/WEB-INF"), null);
     IFile file = project.getFile("src/main/webapp/WEB-INF/appengine-web.xml");
     file.create(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), true, null);
     validator.xsdValidation(file);


### PR DESCRIPTION
Fixes #1916.

The cause looks like some JSP-specific builder job is run after the test project is deleted. So, the solution here is to delete `InWebContent.jsp` and `InSrc.jsp` before project deletion.

(Other changes are minor simplification.)