### PR TITLE
Proper way to validate app.yaml path in flex deploy dialog

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/AppEngineDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/AppEngineDeployPreferencesPanel.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.deploy.ui;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.tools.eclipse.appengine.deploy.DeployPreferences;
+import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.FixedMultiValidator;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.ProjectSelectorSelectionChangedListener;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.login.ui.AccountSelector;
@@ -48,13 +49,10 @@ import org.eclipse.core.databinding.ObservablesManager;
 import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.beans.PojoProperties;
 import org.eclipse.core.databinding.conversion.Converter;
-import org.eclipse.core.databinding.observable.Observables;
-import org.eclipse.core.databinding.observable.list.IObservableList;
 import org.eclipse.core.databinding.observable.value.ComputedValue;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.WritableValue;
 import org.eclipse.core.databinding.validation.IValidator;
-import org.eclipse.core.databinding.validation.MultiValidator;
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IStatus;
@@ -596,17 +594,6 @@ public abstract class AppEngineDeployPreferencesPanel extends DeployPreferencesP
         }
       }
       return ValidationStatus.ok();
-    }
-  }
-
-  // BUGFIX: https://bugs.eclipse.org/bugs/show_bug.cgi?id=312785
-  private abstract static class FixedMultiValidator extends MultiValidator {
-    @Override
-    public IObservableList getTargets() {
-      if (isDisposed()) {
-        return Observables.emptyObservableList();
-      }
-      return super.getTargets();
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
@@ -81,10 +81,8 @@ public class FlexDeployPreferencesPanel extends AppEngineDeployPreferencesPanel 
     ISWTObservableValue fieldValue = WidgetProperties.text(SWT.Modify).observe(appYamlField);
     IObservableValue modelValue = PojoProperties.value("appYamlPath").observe(model);
 
-    if (!requireValues) {
-      bindingContext.bindValue(fieldValue, modelValue);
-    } else {
-      bindingContext.bindValue(fieldValue, modelValue);
+    bindingContext.bindValue(fieldValue, modelValue);
+    if (requireValues) {
       bindingContext.addValidationStatusProvider(
           new AppYamlPathValidator(project.getLocation(), fieldValue));
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.AppYamlPathVa
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.RelativeFileFieldSetter;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.projectselector.ProjectRepository;
-import org.eclipse.core.databinding.UpdateValueStrategy;
 import org.eclipse.core.databinding.beans.PojoProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.resources.IProject;
@@ -85,11 +84,9 @@ public class FlexDeployPreferencesPanel extends AppEngineDeployPreferencesPanel 
     if (!requireValues) {
       bindingContext.bindValue(fieldValue, modelValue);
     } else {
-      UpdateValueStrategy updateStrategy = new UpdateValueStrategy()
-          .setAfterGetValidator(new AppYamlPathValidator(project.getLocation()));
-      bindingContext.bindValue(fieldValue, modelValue, updateStrategy, updateStrategy);
-      // Force setting the path field even if validation fails.
-      appYamlField.setText((String) modelValue.getValue());
+      bindingContext.bindValue(fieldValue, modelValue);
+      bindingContext.addValidationStatusProvider(
+          new AppYamlPathValidator(project.getLocation(), fieldValue));
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlPathValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlPathValidator.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.eclipse.appengine.deploy.ui.internal;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
 import com.google.common.base.Preconditions;
 import java.io.File;
-import org.eclipse.core.databinding.validation.IValidator;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
@@ -32,19 +32,21 @@ import org.eclipse.core.runtime.IStatus;
  *
  * @see #AppYamlPathValidator(IPath)
  */
-public class AppYamlPathValidator implements IValidator {
+public class AppYamlPathValidator extends FixedMultiValidator {
 
   private final IPath basePath;
+  private final IObservableValue appYamlPath;
 
-  public AppYamlPathValidator(IPath basePath) {
-    Preconditions.checkArgument(basePath.isAbsolute());
+  public AppYamlPathValidator(IPath basePath, IObservableValue appYamlPath) {
+    Preconditions.checkArgument(basePath.isAbsolute(), "basePath is not absolute.");
+    Preconditions.checkArgument(String.class.equals(appYamlPath.getValueType()));
     this.basePath = basePath;
+    this.appYamlPath = appYamlPath;
   }
 
   @Override
-  public IStatus validate(Object value) {
-    Preconditions.checkArgument(value instanceof String);
-    File appYaml = new File((String) value);
+  protected IStatus validate() {
+    File appYaml = new File((String) appYamlPath.getValue());
     if (!appYaml.isAbsolute()) {
       appYaml = new File(basePath + "/" + appYaml);
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/FixedMultiValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/FixedMultiValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.internal;
+
+import org.eclipse.core.databinding.observable.Observables;
+import org.eclipse.core.databinding.observable.list.IObservableList;
+import org.eclipse.core.databinding.validation.MultiValidator;
+
+//BUGFIX: https://bugs.eclipse.org/bugs/show_bug.cgi?id=312785
+public abstract class FixedMultiValidator extends MultiValidator {
+
+  @Override
+  public IObservableList getTargets() {
+    if (isDisposed()) {
+      return Observables.emptyObservableList();
+    }
+    return super.getTargets();
+  }
+}


### PR DESCRIPTION
I believe this is a better and maybe proper way to validate the `app.yaml` path field.

The gist of the change is that you call `bindingContext.addValidationStatusProvider()` instead of `bindingContext.bindValue()` to supply a validator in the deploy dialog code. That way, I don't have to force setting the `app.yaml` path field awkwardly. (`bindValue()` addded validators through `UpdateStrategy`, which doesn't allow updating values if there are validation errors.)

Other changes are cascading changes mostly in tests, and luckily, simplify test code. (For example, no need to mock account selection and project selection to suppress any possible validation errors on them, because now I can pinpoint an `app.yaml` validation error status.)