### PR TITLE
Give emptyProjectCreator sufficient lead time

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/RunAppEngineShortcutTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/RunAppEngineShortcutTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 
 public class RunAppEngineShortcutTest {
 
-  @Rule public TestProjectCreator javaProjectCreator = new TestProjectCreator();
+  @Rule public TestProjectCreator emptyProjectCreator = new TestProjectCreator();
   @Rule public TestProjectCreator appEngineProjectCreator = new TestProjectCreator()
       .withFacetVersions(
           JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineStandardFacet.FACET_VERSION);
@@ -58,13 +58,15 @@ public class RunAppEngineShortcutTest {
 
   @Test
   public void testRunAppEngine_hiddenForPlainProject() {
-    IProject project = javaProjectCreator.getProject();
+    IProject project = emptyProjectCreator.getProject();
     assertFalse(appEngineMenuExists(project));
   }
 
   // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1556
   @Test
   public void testRunAppEngine_hiddenEvenIfAppEngineProjectFileIsOpen() throws CoreException {
+    IProject emptyProject = emptyProjectCreator.getProject();
+
     // Create an empty file in the App Engine project, and open it in an editor.
     IProject appEngineProject = appEngineProjectCreator.getProject();
     IFile file = appEngineProject.getFile("textfile.txt");
@@ -73,8 +75,7 @@ public class RunAppEngineShortcutTest {
     IWorkbench workbench = PlatformUI.getWorkbench();
     assertNotNull(WorkbenchUtil.openInEditor(workbench, file));
 
-    IProject javaProject = javaProjectCreator.getProject();
-    assertFalse(appEngineMenuExists(javaProject));
+    assertFalse(appEngineMenuExists(emptyProject));
   }
 
   // We need regex matching, since the actual menu name is "<number> App Engine".


### PR DESCRIPTION
Fixes #1995. I don't really understand #1995; it's a bit mysterious. However, I decided not to waste too much time on it. I'm sure we need some lead time for the SWTBot to work properly in this case, and creating it before setting up an App Engine project will do.