### PR TITLE
Update Oxygen for RC2 (WTP RC3)

### DIFF
--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1492180496">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1496938268">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170126-1030"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20170126-1030"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
-      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20160921-2002"/>
-      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.1.20160831-1005"/>
-      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.1.20160831-1005"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.22.0.v20161206-0357"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170512-0500"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20170512-0500"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20170516-2043"/>
+      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20170516-2043"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.2.20170517-2015"/>
+      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.2.20170517-2015"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170411-1844"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201610131832"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.14.0.201701131441"/>
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.3.v20161205-0933"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.3.v20161205-0933"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.0.v20161208"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.0.v20161208"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.0.v20161208"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.0.v20161208"/>
-      <repository location="http://download.eclipse.org/releases/oxygen/201702031000/"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201705171652"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.5.v20170330-1232"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.5.v20170330-1232"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.5.v20170502"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.5.v20170502"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.5.v20170502"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.5.v20170502"/>
+      <repository location="http://download.eclipse.org/releases/oxygen/201705191000/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201701262152"/>
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201706011851"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201701262152"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201706011851"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.0.v201701262152"/>
-      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M5-20170201000249/repository"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201704201544"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0RC3-20170606120625/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
       <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/S20170120205402/repository/"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository"/>
     </location>
   </locations>
 </target>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -12,10 +12,11 @@
 target "GCP for Eclipse Oxygen" with source requirements
 
 location "http://download.eclipse.org/cbi/updates/license" {
-    org.eclipse.license.feature.group    
+    org.eclipse.license.feature.group
 }
 
-location "http://download.eclipse.org/releases/oxygen/201702031000/" {
+// 201705191000 = Oxygen RC2
+location "http://download.eclipse.org/releases/oxygen/201705191000/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -36,9 +37,8 @@ location "http://download.eclipse.org/releases/oxygen/201702031000/" {
 	org.eclipse.jetty.util
 }
 
-// /webtools/repository/oxygen currently has some issues
-// location "http://download.eclipse.org/webtools/repository/oxygen/" {
-location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M5-20170201000249/repository" {
+// WTP SDKs aren't exposed through the main release links
+location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0RC3-20170606120625/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
@@ -48,8 +48,8 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0M5-
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/S20170120205402/repository/" {
-    org.hamcrest
-	ch.qos.logback.slf4j
-	org.slf4j.log4j
+location "http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository" {
+   org.hamcrest
+   ch.qos.logback.slf4j
+   org.slf4j.log4j
 }

--- a/pom.xml
+++ b/pom.xml
@@ -271,41 +271,6 @@
           </jgit.ignore>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals><goal>enforce</goal></goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <excludes>
-                    <exclude>commons-collections:commons-collections:[3.2.1]</exclude>
-                  </excludes>
-                </bannedDependencies>
-                <bannedDependencies>
-                  <!--
-                    Ensure our bundles only use Guava 20.0.0.
-                    Tycho identifies p2-resolved bundles are of form:
-                    p2.eclipse-plugin:com.google.guava:jar:20.0.0:system
-                  -->
-                  <searchTransitive>false</searchTransitive>
-                  <excludes>
-                    <exclude>com.google.guava:guava</exclude>
-                    <exclude>*:com.google.guava</exclude>
-                  </excludes>
-                  <includes>
-                    <include>com.google.guava:guava:[20,21)</include>
-                    <include>*:com.google.guava:[20,21)</include>
-                  </includes>
-                </bannedDependencies>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -419,6 +384,42 @@
               </artifact>
             </target>
            </configuration>
+          </plugin>
+
+          <!-- ensure we don't have buggy commons-collections nor Java-8 Guava -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals><goal>enforce</goal></goals>
+                <configuration>
+                  <rules>
+                    <bannedDependencies>
+                      <excludes>
+                        <exclude>commons-collections:commons-collections:[3.2.1]</exclude>
+                      </excludes>
+                    </bannedDependencies>
+                    <bannedDependencies>
+                      <!--
+                        Ensure our bundles only use Guava 20.0.0.
+                        Tycho identifies p2-resolved bundles are of form:
+                        p2.eclipse-plugin:com.google.guava:jar:20.0.0:system
+                      -->
+                      <searchTransitive>false</searchTransitive>
+                      <excludes>
+                        <exclude>com.google.guava:guava</exclude>
+                        <exclude>*:com.google.guava</exclude>
+                      </excludes>
+                      <includes>
+                        <include>com.google.guava:guava:[20,21)</include>
+                        <include>*:com.google.guava:[20,21)</include>
+                      </includes>
+                    </bannedDependencies>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,10 @@
            </configuration>
           </plugin>
 
-          <!-- ensure we don't have buggy commons-collections nor Java-8 Guava -->
+          <!--
+            Ensure we don't have buggy commons-collections nor Java-8 Guava.
+            Must be done here as Oxygen has moved to Guava 21.
+          -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
Using Oxygen RC2 (…/releases/oxygen/XXX) as RC3 is being staged as we speak at a transient URL.
But WTP RC3 is at a stable URL.  There are no changes to the Platform from RC2 &rarr; RC3 that I can think of that will affect WTP RC2.