### PR TITLE
Fix gcp-repo/metadata.p2.inf so that category is published in normal Maven builds

### DIFF
--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -8,13 +8,17 @@
 # Follows the approach shown in
 # http://help.eclipse.org/neon/topic/org.eclipse.platform.doc.isv/guide/p2_customizing_metadata.html?cp=2_0_20_1_2#categoryGen
 
+# Pull in the IU that provides a definition; the definition version
+# is never shown in the UI and doesn't matter
 requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=com.google.cloud.tools.eclipse.category
-requires.1.range=[1.0.0,1.2.0]
+requires.1.name=com.google.cloud.tools.eclipse.category.definition
+requires.1.range=[1.0.0,1.0.0]
 requires.1.greedy=true
 
+# Define the 'Google Cloud Tools for Eclipse' category IU
+# Note that the IU version is shown in the UI, not the .definition version.
 units.1.id=com.google.cloud.tools.eclipse.category
-units.1.version=1.2.0
+units.1.version=$version$
 units.1.properties.1.name=org.eclipse.equinox.p2.type.category
 units.1.properties.1.value=true
 units.1.properties.2.name=org.eclipse.equinox.p2.name
@@ -25,9 +29,6 @@ units.1.properties.4.name=org.eclipse.equinox.p2.contact
 units.1.properties.4.value=https://github.com/GoogleCloudPlatform/google-cloud-eclipse
 units.1.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.1.properties.5.value=https://cloud.google.com/eclipse/docs/
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=com.google.cloud.tools.eclipse.category
-units.1.provides.1.version=1.2.0
 units.1.copyright =Copyright 2016, 2017 Google Inc.
 units.1.licenses.0 =\
 Cloud Tools for Eclipse is made available under the Apache License, Version 2.0. \
@@ -37,3 +38,6 @@ units.1.licenses.0.location = https://www.apache.org/licenses/LICENSE-2.0
 units.1.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.1.requires.1.name=com.google.cloud.tools.eclipse.suite.e45.feature.feature.group
 units.1.requires.1.greedy=true
+units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
+units.1.provides.1.name=com.google.cloud.tools.eclipse.category.definition
+units.1.provides.1.version=1.0.0


### PR DESCRIPTION
Our CT4E category doesn't appear in the `gcp-repo` p2 repository when built from Maven.  It does appear in our release builds as we explicitly re-publish artifacts as part of the release.  

This fixes our `metadata.p2.inf` to specify an exact range to pull in the category definition.  It also changes some naming to distinguish between the category IU and the capabilities: 
- Use `$version$` to use the version of the `.product`: no need to change the `.p2.inf` file for releases
- Append `.definition` to the capability name, used to pull in the category IU from the product IU, to avoid confusion with the actual category IU.  This capability is required as Tycho's [`assemble-repository` plugin only traverses the _modules_ actually defined in this project](https://www.eclipse.org/tycho/sitedocs/tycho-p2/tycho-p2-repository-plugin/assemble-repository-mojo.html), and it doesn't track the additional IUs defined in the `.p2.inf`.
- Change the category capability to always be version 1.0.0
- Change the requirement to be an exact version

(`assemble-repository`'s docs](https://www.eclipse.org/tycho/sitedocs/tycho-p2/tycho-p2-repository-plugin/assemble-repository-mojo.html) note that it only follows IUs that are included, and 
> Dependencies with a strict version range, i.e. a range which only matches exactly one version of an artifact, are also considered as inclusions.
And perhaps the `[1.0.0,1.2.0]` range is considered open-ended, vs the `[1.0.0,1.0.0]` which is an exact specification.

Identified as part of #2027