### PR TITLE
Make the current flex facet require WTP 

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
@@ -18,7 +18,11 @@ package com.google.cloud.tools.eclipse.appengine.facets;
 
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import java.util.Arrays;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.eclipse.wst.common.project.facet.core.IConstraint;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IProjectFacet;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
@@ -64,5 +68,54 @@ public class AppEngineFlexFacetTest {
   public void testFacetLabel() {
     IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
     Assert.assertEquals("App Engine Java Flexible Environment", projectFacet.getLabel());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava8Servlet25() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_25));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava8Servlet30() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_30));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava8Servlet31() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithNoJava() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(WebFacetUtils.WEB_31));
+    Assert.assertFalse(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithNoServlet() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8));
+    Assert.assertFalse(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithJava7Servlet31() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_31));
+    Assert.assertFalse(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithJava8Servlet24() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_24));
+    Assert.assertFalse(result.isOK());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
@@ -73,21 +73,21 @@ public class AppEngineFlexFacetTest {
   @Test
   public void testInstallConstraints_okWithJava7Servlet25() {
     IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
-    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_25));
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava7Servlet30() {
     IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
-    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_30));
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_30));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava7Servlet31() {
     IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
-    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31));
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_31));
     Assert.assertTrue(result.isOK());
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexFacetTest.java
@@ -71,6 +71,27 @@ public class AppEngineFlexFacetTest {
   }
 
   @Test
+  public void testInstallConstraints_okWithJava7Servlet25() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_25));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava7Servlet30() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_30));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava7Servlet31() {
+    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
   public void testInstallConstraints_okWithJava8Servlet25() {
     IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_25));
@@ -106,14 +127,7 @@ public class AppEngineFlexFacetTest {
   }
 
   @Test
-  public void testInstallConstraints_notOkWithJava7Servlet31() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
-    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_31));
-    Assert.assertFalse(result.isOK());
-  }
-
-  @Test
-  public void testInstallConstraints_notOkWithJava8Servlet24() {
+  public void testInstallConstraints_notOkWithServlet24() {
     IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_24));
     Assert.assertFalse(result.isOK());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegateTest.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.FlexFacetInstallDelegate;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.IProjectFacet;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
@@ -31,11 +31,9 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Tests for {@link FlexFacetInstallDelegate}
- */
 public class FlexFacetInstallDelegateTest {
-  @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
+  @Rule public TestProjectCreator projectCreator = new TestProjectCreator().withFacetVersions(
+          JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25);
 
   @Test
   public void testFacetInstall() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -120,25 +120,15 @@
       <constraint>
         <and>
           <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.standard"/>
-          <requires group="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.servlet"/>
-          <requires group="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.jre"/>
+          <requires facet="jst.web"
+                    version="2.5,3.0,3.1">
+          </requires>
+          <requires facet="java"
+                    version="1.7,1.8">
+          </requires>
         </and>
       </constraint>
     </project-facet-version>
-  </extension>
-  <extension point="org.eclipse.wst.common.project.facet.core.groups">
-    <group id="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.servlet">
-      <label>supported Dynamic Web Module APIs</label>
-      <include facet="jst.web"
-               versions="2.5,3.0,3.1">
-      </include>
-    </group>
-    <group id="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.jre">
-      <label>supported Java Runtimes</label>
-      <include facet="java"
-               versions="1.8">
-      </include>
-    </group>
   </extension>
 
   <extension point="org.eclipse.wst.common.project.facet.core.facets">

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -113,14 +113,32 @@
   <!-- begin App Engine flex facet -->
   <extension point="org.eclipse.wst.common.project.facet.core.facets">
     <project-facet id="com.google.cloud.tools.eclipse.appengine.facets.flex">
-       <label>%flexFacetName</label>
-       <description>%flexFacetDescription</description>
+      <label>%flexFacetName</label>
+      <description>%flexFacetDescription</description>
     </project-facet>
     <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.flex" version="1">
-       <constraint>
+      <constraint>
+        <and>
           <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.standard"/>
-        </constraint>
+          <requires group="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.servlet"/>
+          <requires group="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.jre"/>
+        </and>
+      </constraint>
     </project-facet-version>
+  </extension>
+  <extension point="org.eclipse.wst.common.project.facet.core.groups">
+    <group id="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.servlet">
+      <label>supported Dynamic Web Module APIs</label>
+      <include facet="jst.web"
+               versions="2.5,3.0,3.1">
+      </include>
+    </group>
+    <group id="com.google.cloud.tools.eclipse.appengine.facets.flex.constraints.jre">
+      <label>supported Java Runtimes</label>
+      <include facet="java"
+               versions="1.8">
+      </include>
+    </group>
   </extension>
 
   <extension point="org.eclipse.wst.common.project.facet.core.facets">


### PR DESCRIPTION
Fixes #2034. As discussed in https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2034#issuecomment-307829079, we will make the current flex facet require WTP.