### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   # use mvn ≥ 3.3.9 to ensure faulty test exit states fail the build (#1276)
   - mvn -B -N io.takari:maven:wrapper -Dmaven=3.5.0
   # download and install Cloud SDK (may be cached)
-  - build/install-cloudsdk.sh 151.0.1 $HOME
+  - build/install-cloudsdk.sh 161.0.1 $HOME
 # Tycho ≥ 0.26 requires Java 8
 jdk: oraclejdk8
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   # use mvn ≥ 3.3.9 to ensure faulty test exit states fail the build (#1276)
   - mvn -B -N io.takari:maven:wrapper -Dmaven=3.5.0
   # download and install Cloud SDK (may be cached)
-  - build/install-cloudsdk.sh 161.0.1 $HOME
+  - build/install-cloudsdk.sh 161.0.0 $HOME
 # Tycho ≥ 0.26 requires Java 8
 jdk: oraclejdk8
 env:

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1496938268">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1498749691">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
       <repository location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170512-0500"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20170512-0500"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170612-1255"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20170612-0950"/>
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20170516-2043"/>
       <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20170516-2043"/>
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.2.20170517-2015"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.2.20170517-2015"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170411-1844"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201610131832"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170503-0014"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.100.v201705180510"/>
       <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.14.0.201701131441"/>
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201705171652"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.5.v20170330-1232"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.5.v20170330-1232"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.5.v20170613-1207"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.5.v20170613-1207"/>
       <unit id="org.eclipse.jetty.http" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.servlet" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.server" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.util" version="9.4.5.v20170502"/>
-      <repository location="http://download.eclipse.org/releases/oxygen/201705191000/"/>
+      <repository location="http://download.eclipse.org/releases/oxygen/201706281000/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201706011851"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201706011851"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201706011953"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.0.v201701262152"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201704201544"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0RC3-20170606120625/repository"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/R-3.9.0-20170613094504/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -15,8 +15,8 @@ location "http://download.eclipse.org/cbi/updates/license" {
     org.eclipse.license.feature.group
 }
 
-// 201705191000 = Oxygen RC2
-location "http://download.eclipse.org/releases/oxygen/201705191000/" {
+// 201706281000 = Oxygen.0
+location "http://download.eclipse.org/releases/oxygen/201706281000/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -38,7 +38,7 @@ location "http://download.eclipse.org/releases/oxygen/201705191000/" {
 }
 
 // WTP SDKs aren't exposed through the main release links
-location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/S-3.9.0RC3-20170606120625/repository" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/R-3.9.0-20170613094504/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -36,5 +36,7 @@ Export-Package: org.mockito;provider=google;version="1.10.19";mandatory:=provide
  org.mockito.verification;provider=google;version="1.10.19";mandatory:=provider
 Require-Bundle: org.hamcrest;bundle-version="1.1.0",
  org.junit;bundle-version="4.12.0",
- org.eclipse.jst.standard.schemas;bundle-version="1.2.201",
- org.eclipse.wst.standard.schemas;bundle-version="1.0.700"
+ org.eclipse.jst.standard.schemas;bundle-version="[1.2,2.0)",
+ org.eclipse.wst.standard.schemas;bundle-version="[1.0,2.0)",
+ org.eclipse.xsd;bundle-version="[2.11,3.0)",
+ org.eclipse.wst.xsd.core;bundle-version="[1.1,2.0)"


### PR DESCRIPTION
- Bump Google Cloud SDK to 161
- Use official Eclipse Oxygen.0 repositories
- Add dependencies to `.test.dependencies` to pull in XML Schema XSD and DTD for validation (#1196, #2091)

Fixes #1196
Fixes #2091 