### PR TITLE
Use FULL_SELECTION in Project Selector table

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelector.java
@@ -54,7 +54,7 @@ public class ProjectSelector extends Composite {
     tableComposite.setLayout(tableColumnLayout);
     GridDataFactory.fillDefaults().grab(true, true).applyTo(tableComposite);
 
-    tableViewer = new TableViewer(tableComposite, SWT.SINGLE | SWT.BORDER);
+    tableViewer = new TableViewer(tableComposite, SWT.SINGLE | SWT.BORDER | SWT.FULL_SELECTION);
     createColumns(tableColumnLayout);
     tableViewer.getTable().setHeaderVisible(true);
     input = WritableList.withElementType(GcpProject.class);


### PR DESCRIPTION
Verified on Windows.  Note that Table in OS X always uses `FULL_SELECTION`.

Fixes #2089 