### PR TITLE
Implement LibraryClasspathContainerInitializer#getComparisonID()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -229,6 +231,18 @@ public class LibraryClasspathContainerInitializerTest {
       }
     }
     fail("classpath entry not found");
+  }
+
+  @Test
+  public void testComparisonIDUnique() throws IOException, CoreException {
+    LibraryClasspathContainerInitializer containerInitializer =
+        new LibraryClasspathContainerInitializer();
+    assertEquals("comparisonID should be equal for same paths",
+        containerInitializer.getComparisonID(new Path(TEST_CONTAINER_PATH + "/1"), null),
+        containerInitializer.getComparisonID(new Path(TEST_CONTAINER_PATH + "/1"), null));
+    assertNotEquals("comparisonID should not be equal for different paths",
+        containerInitializer.getComparisonID(new Path(TEST_CONTAINER_PATH + "/1"), null),
+        containerInitializer.getComparisonID(new Path(TEST_CONTAINER_PATH + "/2"), null));
   }
 
   private IStatus verifyContainerResolvedFromScratch() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -256,7 +256,7 @@
               artifactId="gax"
               groupId="com.google.api"
               version="1.4.1" />
-      </libraryFile>
+     </libraryFile>
      <libraryFile>
         <mavenCoordinates
               artifactId="api-common"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -192,23 +192,30 @@
           siteUri="https://googlecloudplatform.github.io/google-cloud-java/" >
       <libraryDependency id="googleapiclient" />
       <libraryFile
-            javadocUri="https://googlecloudplatform.github.io/google-cloud-java/0.10.0/apidocs/">
+            javadocUri="https://googlecloudplatform.github.io/google-cloud-java/0.20.1/apidocs/">
         <mavenCoordinates
               artifactId="google-cloud-core"
               groupId="com.google.cloud"
-              version="1.0.0" />
+              version="1.2.1" />
+      </libraryFile>
+      <libraryFile
+            javadocUri="https://googlecloudplatform.github.io/google-cloud-java/0.20.1/apidocs/">
+        <mavenCoordinates
+              artifactId="google-cloud-core-http"
+              groupId="com.google.cloud"
+              version="1.2.1" />
       </libraryFile>
       <libraryFile>  <!-- todo javadoc if it's published -->
         <mavenCoordinates
               artifactId="google-auth-library-oauth2-http"
               groupId="com.google.auth"
-              version="0.6.1" />
+              version="0.7.0" />
       </libraryFile>
       <libraryFile> <!-- todo javadoc if it's published -->
         <mavenCoordinates
               artifactId="google-auth-library-credentials"
               groupId="com.google.auth"
-              version="0.6.1" />
+              version="0.7.0" />
       </libraryFile>
       <libraryFile javadocUri="http://www.joda.org/joda-time/apidocs/">
         <mavenCoordinates
@@ -216,39 +223,52 @@
               groupId="joda-time"
               version="2.9.2" />
       </libraryFile>
-       <libraryFile javadocUri="https://stleary.github.io/JSON-java/">
+      <libraryFile javadocUri="https://stleary.github.io/JSON-java/">
         <mavenCoordinates
               artifactId="json"
               groupId="org.json"
-              version="20151123" />
+              version="20160810" />
       </libraryFile>
       <libraryFile
             javadocUri="https://developers.google.com/protocol-buffers/docs/reference/java/">
         <mavenCoordinates
               artifactId="protobuf-java"
               groupId="com.google.protobuf"
-              version="3.0.0" />
+              version="3.3.0" />
       </libraryFile>
       <libraryFile
             javadocUri="https://developers.google.com/protocol-buffers/docs/reference/java/">
         <mavenCoordinates
               artifactId="protobuf-java-util"
               groupId="com.google.protobuf"
-              version="3.0.0" />
+              version="3.3.0" />
       </libraryFile>
       <libraryFile
             javadocUri="https://google.github.io/guava/releases/19.0/api/docs/">
         <mavenCoordinates
               artifactId="guava"
               groupId="com.google.guava"
-              version="19.0" />
+              version="20.0" />
       </libraryFile>
      <!-- todo javadoc -->
      <libraryFile>
         <mavenCoordinates
               artifactId="gax"
               groupId="com.google.api"
-              version="1.0.0" />
+              version="1.4.1" />
+      </libraryFile>
+     <libraryFile>
+        <mavenCoordinates
+              artifactId="api-common"
+              groupId="com.google.api"
+              version="1.1.0" />
+      </libraryFile>
+      <libraryFile>
+        <!-- pulled in by gax-rpc but used by google-cloud-core -->
+        <mavenCoordinates
+              artifactId="threetenbp"
+              groupId="org.threeten"
+              version="1.3.3" />
       </libraryFile>
     </library>
     
@@ -260,18 +280,18 @@
           siteUri="https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-java" >
       <libraryDependency id="googlecloudcore" />
       <libraryFile
-            javadocUri="https://googlecloudplatform.github.io/google-cloud-java/0.10.0/apidocs/">
+            javadocUri="https://googlecloudplatform.github.io/google-cloud-java/0.20.1/apidocs/">
         <mavenCoordinates
               artifactId="google-cloud-storage"
               groupId="com.google.cloud"
-              version="1.0.0" />
+              version="1.2.1" />
       </libraryFile>
       <libraryFile
             javadocUri="https://developers.google.com/resources/api-libraries/documentation/storage/v1/java/latest/index.html">
         <mavenCoordinates
               artifactId="google-api-services-storage"
               groupId="com.google.apis"
-              version="v1-rev102-1.22.0" />
+              version="v1-rev100-1.22.0" />
       </libraryFile>
     </library>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
@@ -101,4 +101,10 @@ public class LibraryClasspathContainerInitializer extends ClasspathContainerInit
     }
     return true;
   }
+
+  public Object getComparisonID(IPath containerPath, IJavaProject project) {
+    // used to collapse duplicate classpath entries; we use the full path to identify libraries
+    return containerPath;
+  }
+
 }


### PR DESCRIPTION
And update Google Cloud Core and Storage library definitions from 1.0.0 to 1.2.1.
Note that `google-api-services-storage` is *downgraded* to `v1-rev100-1.22.0` so as 
to correspond to the definition in [`google-cloud-storage` 1.2.1's `pom.xml`](https://repo1.maven.org/maven2/com/google/cloud/google-cloud-storage/1.2.1/google-cloud-storage-1.2.1.pom).


Fixes #2095 
Fixes #2097 