### PR TITLE
Avoid nullness warnings and NPEs in Dataflow

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/MajorVersionPipelineRunnerConfigurationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/MajorVersionPipelineRunnerConfigurationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.dataflow.core.launcher;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.tools.eclipse.dataflow.core.project.MajorVersion;
+import java.util.Arrays;
+import java.util.Set;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test that each {@link MajorVersion} has associated configuration settings in the
+ * {@link PipelineRunner#RUNNERS_IN_VERSION} mapping table and {@link PipelineLaunchConfiguration}.
+ */
+@RunWith(Parameterized.class)
+public class MajorVersionPipelineRunnerConfigurationTest {
+
+  @Parameters(name = "{0}")
+  public static Iterable<? extends Object> majorVersions() {
+    return Arrays.asList(MajorVersion.values());
+  }
+
+  private final MajorVersion majorVersion;
+
+  public MajorVersionPipelineRunnerConfigurationTest(MajorVersion majorVersion) {
+    this.majorVersion = majorVersion;
+  }
+
+  @Test
+  public void testHasDefaultRunner() {
+    PipelineRunner defaultRunner = PipelineLaunchConfiguration.defaultRunner(majorVersion);
+    assertNotNull(defaultRunner);
+  }
+
+  @Test
+  public void testHasConfiguredRunners() {
+    Set<PipelineRunner> runners = PipelineRunner.inMajorVersion(majorVersion);
+    assertNotEquals(0, runners.size());
+  }
+
+  @Test
+  public void testDefaultRunnerInConfiguredRunners() {
+    PipelineRunner defaultRunner = PipelineLaunchConfiguration.defaultRunner(majorVersion);
+    assertNotNull(defaultRunner);
+    Set<PipelineRunner> runners = PipelineRunner.inMajorVersion(majorVersion);
+    assertThat(runners, CoreMatchers.hasItem(defaultRunner));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineRunner.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineRunner.java
@@ -63,6 +63,7 @@ public enum PipelineRunner {
         ImmutableSetMultimap.builder();
     for (PipelineRunner runner : PipelineRunner.values()) {
       runnersByName.put(runner.getRunnerName(), runner);
+      runnersInVersion.put(MajorVersion.ALL, runner); // ALL is special
       for (MajorVersion supported : runner.supportedVersions) {
         runnersInVersion.put(supported, runner);
       }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
@@ -127,7 +127,7 @@ public class JavaProjectPipelineOptionsHierarchy implements PipelineOptionsHiera
   public NavigableMap<PipelineOptionsType, Set<PipelineOptionsProperty>> getOptionsHierarchy(
       String... typeNames) {
     NavigableMap<PipelineOptionsType, Set<PipelineOptionsProperty>> result =
-        new TreeMap<>(new PipelineOptionsTypeWeightOrdering().nullsFirst());
+        new TreeMap<>(new PipelineOptionsTypeWeightOrdering());
     Queue<PipelineOptionsType> optionsTypesToAdd = new ArrayDeque<>();
     for (String typeName : typeNames) {
       if (!Strings.isNullOrEmpty(typeName)) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.dataflow.core.launcher.options;
 
 import com.google.cloud.tools.eclipse.dataflow.core.DataflowCorePlugin;
 import com.google.cloud.tools.eclipse.dataflow.core.project.MajorVersion;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
@@ -126,7 +127,7 @@ public class JavaProjectPipelineOptionsHierarchy implements PipelineOptionsHiera
   public NavigableMap<PipelineOptionsType, Set<PipelineOptionsProperty>> getOptionsHierarchy(
       String... typeNames) {
     NavigableMap<PipelineOptionsType, Set<PipelineOptionsProperty>> result =
-        new TreeMap<>(new PipelineOptionsTypeWeightOrdering());
+        new TreeMap<>(new PipelineOptionsTypeWeightOrdering().nullsFirst());
     Queue<PipelineOptionsType> optionsTypesToAdd = new ArrayDeque<>();
     for (String typeName : typeNames) {
       if (!Strings.isNullOrEmpty(typeName)) {
@@ -228,6 +229,8 @@ public class JavaProjectPipelineOptionsHierarchy implements PipelineOptionsHiera
   private static class PipelineOptionsTypeWeightOrdering extends Ordering<PipelineOptionsType> {
     @Override
     public int compare(PipelineOptionsType o1, PipelineOptionsType o2) {
+      Preconditions.checkNotNull(o1, "use with nullsFirst() or nullsLast()");
+      Preconditions.checkNotNull(o2, "use with nullsFirst() or nullsLast()");
       return ComparisonChain.start()
           .compare(o1.getWeight(), o2.getWeight())
           .compare(o1.getName(), o2.getName())

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/PipelineOptionsNamespaces.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/PipelineOptionsNamespaces.java
@@ -37,6 +37,7 @@ public final class PipelineOptionsNamespaces {
           .put(MajorVersion.QUALIFIED_TWO, BEAM_OPTIONS_BASE + ".")
           .put(MajorVersion.TWO, BEAM_OPTIONS_BASE + ".")
           .put(MajorVersion.THREE_PLUS, BEAM_OPTIONS_BASE + ".")
+          .put(MajorVersion.ALL, BEAM_OPTIONS_BASE + ".")
           .build();
   private static final String VALIDATION_ANNOTATION = "Validation.Required";
   private static final String VALIDATION_REQUIRED_GROUPS = "groups";

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -36,7 +36,6 @@ import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonCo
 import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonSelectionListener;
 import com.google.cloud.tools.eclipse.dataflow.ui.util.DisplayExecutor;
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.SettableFuture;
@@ -436,10 +435,9 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
   }
 
   private boolean validateRequiredGroups(MissingRequiredProperties validationFailures) {
-    if (!validationFailures.getMissingGroups().isEmpty()) {
-      Map.Entry<String, Set<PipelineOptionsProperty>> missingGroupEntry =
-          Iterables.getFirst(validationFailures.getMissingGroups().entrySet(), null);
-      Preconditions.checkNotNull(missingGroupEntry); // should be impossible
+    Map.Entry<String, Set<PipelineOptionsProperty>> missingGroupEntry =
+        Iterables.getFirst(validationFailures.getMissingGroups().entrySet(), null);
+    if (missingGroupEntry != null) {
       StringBuilder errorBuilder = new StringBuilder("Missing value for group ");
       errorBuilder.append(missingGroupEntry.getKey());
       errorBuilder.append(". Properties satisfying group requirement are ");
@@ -456,10 +454,9 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
   }
 
   private boolean validateRequiredProperties(MissingRequiredProperties validationFailures) {
-    if (!validationFailures.getMissingProperties().isEmpty()) {
-      PipelineOptionsProperty missingProperty =
-          Iterables.getFirst(validationFailures.getMissingProperties(), null);
-      Preconditions.checkNotNull(missingProperty); // should be impossible
+    PipelineOptionsProperty missingProperty =
+        Iterables.getFirst(validationFailures.getMissingProperties(), null);
+    if (missingProperty != null) {
       setErrorMessage("Missing required property " + missingProperty.getName());
       return false;
     }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -36,6 +36,7 @@ import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonCo
 import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonSelectionListener;
 import com.google.cloud.tools.eclipse.dataflow.ui.util.DisplayExecutor;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.SettableFuture;
@@ -439,6 +440,7 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
     if (!validationFailures.getMissingGroups().isEmpty()) {
       Map.Entry<String, Set<PipelineOptionsProperty>> missingGroupEntry =
           Iterables.getFirst(validationFailures.getMissingGroups().entrySet(), null);
+      Preconditions.checkNotNull(missingGroupEntry); // should be impossible
       StringBuilder errorBuilder = new StringBuilder("Missing value for group ");
       errorBuilder.append(missingGroupEntry.getKey());
       errorBuilder.append(". Properties satisfying group requirement are ");
@@ -458,6 +460,7 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
     if (!validationFailures.getMissingProperties().isEmpty()) {
       PipelineOptionsProperty missingProperty =
           Iterables.getFirst(validationFailures.getMissingProperties(), null);
+      Preconditions.checkNotNull(missingProperty); // should be impossible
       setErrorMessage("Missing required property " + missingProperty.getName());
       return false;
     }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -333,10 +333,9 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
     PipelineRunner runner = launchConfiguration.getRunner();
     Button runnerButton = runnerButtons.get(runner);
     if (runnerButton == null) {
-      runnerButtons
-          .get(PipelineLaunchConfiguration.defaultRunner(majorVersion))
-          .setSelection(true);
-    } else {
+      runnerButton = runnerButtons.get(PipelineLaunchConfiguration.defaultRunner(majorVersion));
+    }
+    if (runnerButton != null) {
       runnerButton.setSelection(true);
     }
     runnerGroup.getParent().redraw();

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -36,6 +36,7 @@ import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonCo
 import com.google.cloud.tools.eclipse.dataflow.ui.page.component.TextAndButtonSelectionListener;
 import com.google.cloud.tools.eclipse.dataflow.ui.util.DisplayExecutor;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.SettableFuture;
@@ -334,9 +335,8 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
     if (runnerButton == null) {
       runnerButton = runnerButtons.get(PipelineLaunchConfiguration.defaultRunner(majorVersion));
     }
-    if (runnerButton != null) {
-      runnerButton.setSelection(true);
-    }
+    Preconditions.checkNotNull(runnerButton,
+        "runners for %s should always include the default runner", majorVersion);
     runnerGroup.getParent().redraw();
   }
 


### PR DESCRIPTION
Some fixes for the Dataflow plugins from some quick testing (#2108).
Added some `Preconditions` tests to keep Eclipse nullness checking happy.

Fixes #2108 