### PR TITLE
Set auto-restart based on launch mode, and max-modules=1  in debug mode

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegateTest.java
@@ -61,7 +61,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
   private LocalAppEngineServerBehaviour serverBehavior;
 
   @Before
-  public void setUp() {
+  public void setUp() throws CoreException {
     when(server.loadAdapter(any(Class.class), any(IProgressMonitor.class)))
         .thenReturn(serverBehavior);
   }
@@ -274,6 +274,23 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
     assertEquals(Arrays.asList("a", "b", "c d"), config.getJvmFlags());
     verify(launchConfiguration)
         .getAttribute(eq(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS), anyString());
+  }
+
+
+  @Test
+  public void testGenerateRunConfiguration_restart_run() throws CoreException {
+    when(launchConfiguration.getAttribute(anyString(), anyString())).thenReturn("");
+    DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
+    assertTrue(config.getAutomaticRestart());
+  }
+
+  @Test
+  public void testGenerateRunConfiguration_restart_debug() throws CoreException {
+    when(launchConfiguration.getAttribute(anyString(), anyString())).thenReturn("");
+    DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.DEBUG_MODE);
+    assertFalse(config.getAutomaticRestart());
   }
 
   // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1609

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegateTest.java
@@ -40,6 +40,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.wst.server.core.IServer;
 import org.junit.Before;
@@ -183,7 +184,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
     DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-        .generateServerRunConfiguration(launchConfiguration, server);
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
     assertNull(config.getHost());
     assertEquals((Integer) LocalAppEngineServerBehaviour.DEFAULT_SERVER_PORT, config.getPort());
     assertNull(config.getApiPort());
@@ -199,7 +200,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
     when(server.getHost()).thenReturn("example.com");
     DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-        .generateServerRunConfiguration(launchConfiguration, server);
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
     assertEquals("example.com", config.getHost());
     verify(server, atLeastOnce()).getHost();
   }
@@ -213,7 +214,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
             .thenReturn(9999);
 
     DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-        .generateServerRunConfiguration(launchConfiguration, server);
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
 
     assertNotNull(config.getPort());
     assertEquals(9999, (int) config.getPort());
@@ -231,7 +232,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
             .thenReturn(9999);
 
     DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-        .generateServerRunConfiguration(launchConfiguration, server);
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
 
     assertNull(config.getAdminPort());
     verify(launchConfiguration, never())
@@ -254,7 +255,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
     // dev_appserver waits on localhost by default
     try (ServerSocket socket = new ServerSocket(8080, 100, InetAddress.getLoopbackAddress())) {
       DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-          .generateServerRunConfiguration(launchConfiguration, server);
+          .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
 
       assertNull(config.getAdminPort());
     }
@@ -267,7 +268,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
         anyString())).thenReturn("a b \"c d\"");
 
     DefaultRunConfiguration config = new LocalAppEngineServerLaunchConfigurationDelegate()
-        .generateServerRunConfiguration(launchConfiguration, server);
+        .generateServerRunConfiguration(launchConfiguration, server, ILaunchManager.RUN_MODE);
 
     assertNotNull(config.getJvmFlags());
     assertEquals(Arrays.asList("a", "b", "c d"), config.getJvmFlags());
@@ -283,6 +284,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegateTest {
     when(launch.getLaunchConfiguration()).thenReturn(null);
 
     new LocalAppEngineServerLaunchConfigurationDelegate()
-        .checkConflictingLaunches(null, mock(DefaultRunConfiguration.class), launches);
+        .checkConflictingLaunches(null, ILaunchManager.RUN_MODE,
+            mock(DefaultRunConfiguration.class), launches);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
 import com.google.cloud.tools.appengine.api.devserver.DefaultStopConfiguration;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer1;
+import com.google.cloud.tools.appengine.cloudsdk.CloudSdkAppEngineDevServer2;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
@@ -365,7 +366,9 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
         .async(true)
         .build();
 
-    devServer = new CloudSdkAppEngineDevServer1(cloudSdk);
+    devServer = LocalAppEngineServerLaunchConfigurationDelegate.DEV_APPSERVER2
+        ? new CloudSdkAppEngineDevServer2(cloudSdk)
+        : new CloudSdkAppEngineDevServer1(cloudSdk);
     moduleToUrlMap.clear();
   }
   

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -94,8 +94,7 @@ import org.eclipse.wst.server.core.ServerUtil;
 public class LocalAppEngineServerLaunchConfigurationDelegate
     extends AbstractJavaLaunchConfigurationDelegate {
 
-  static final boolean DEV_APPSERVER2 =
-      "2".equals(System.getProperty("com.google.cloud.tools.eclipse.appengine.devappserver", "1"));
+  static final boolean DEV_APPSERVER2 = false;
   
   private static final Logger logger =
       Logger.getLogger(LocalAppEngineServerLaunchConfigurationDelegate.class.getName());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -241,13 +241,14 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
       devServerRunConfiguration.setPort(serverPort);
     }
 
+
+    // only restart server on on-disk changes detected when in RUN mode
+    devServerRunConfiguration.setAutomaticRestart(ILaunchManager.RUN_MODE.equals(mode));
+
     if (DEV_APPSERVER2) {
       if (ILaunchManager.DEBUG_MODE.equals(mode)) {
         // default to 1 instance to simplify debugging
         devServerRunConfiguration.setMaxModuleInstances(1);
-
-        // don't restart server when on-disk changes detected
-        devServerRunConfiguration.setAutomaticRestart(false);
       }
       
       String adminHost = getAttribute(LocalAppEngineServerBehaviour.ADMIN_HOST_ATTRIBUTE_NAME,


### PR DESCRIPTION
Change `LocalAppEngineServerLaunchConfigurationDelegate` to:
  - set _automatic-restart=true_ when launching in run mode, and _false_ in debug mode
  - only set _max-modules=1_ when launching in debug mode (only relevant for devappserver2; devappserver1 only has a single module)

Makes devappserver 1 or 2 selectable by setting `com.google.cloud.tools.eclipse.appengine.devappserver` property to `1` (default) or `2`.

Requires https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/435
Fixes #1428 
Fixes #2111 