### PR TITLE
Simplify code that empties Combo items

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -318,6 +318,7 @@ public class RunOptionsDefaultsComponent {
       try {
         SortedSet<String> stagingLocations = stagingLocationsFuture.get();
         messageTarget.clear();
+        // Don't use "removeAll()", as it will clear the text field too.
         stagingLocationInput.remove(0, stagingLocationInput.getItemCount() - 1);
         for (String location : stagingLocations) {
           stagingLocationInput.add(location);

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -47,7 +47,6 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
@@ -319,17 +318,11 @@ public class RunOptionsDefaultsComponent {
       try {
         SortedSet<String> stagingLocations = stagingLocationsFuture.get();
         messageTarget.clear();
-        String currentValue = stagingLocationInput.getText();
-        Point currentSelection = stagingLocationInput.getSelection();
-        int startSelection = currentSelection.x;
-        int endSelection = currentSelection.y;
-        stagingLocationInput.removeAll();
+        stagingLocationInput.remove(0, stagingLocationInput.getItemCount() - 1);
         for (String location : stagingLocations) {
           stagingLocationInput.add(location);
         }
-        stagingLocationInput.setText(currentValue);
         completionListener.setContents(stagingLocations);
-        stagingLocationInput.setSelection(new Point(startSelection, endSelection));
       } catch (InterruptedException | ExecutionException ex) {
         messageTarget.setError("Could not retrieve buckets for project " + projectInput.getText());
         DataflowUiPlugin.logError(ex, "Exception while retrieving potential staging locations");


### PR DESCRIPTION
`Combo.removeAll()` removes all combo list items + any text typed into the field. Javadoc:

```
 * Removes all of the items from the receiver's list and clear the
 * contents of receiver's text field.
```

Therefore, the previous code had to restore the typed text and any text selection. However, we can use `Combo.remove(start, end)` just to remove the combo list items. Javadoc:

```
 * Removes the items from the receiver's list which are
 * between the given zero-relative start and end
 * indices (inclusive).
 ...
 * @exception IllegalArgumentException <ul>
 *    <li>ERROR_INVALID_RANGE - if either the start or end are not between 0 and the number of elements in the list minus 1 (inclusive)</li>
```