### PR TITLE
Fix build for Travis 'trusty'

### DIFF
--- a/.travis-toolchains.xml
+++ b/.travis-toolchains.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF8"?>
 <toolchains>
-  <!-- JDK toolchains on Travis-CI -->
+  <!-- JDK toolchains on Travis-CI `trusty` -->
   <toolchain>
     <type>jdk</type>
     <provides>
@@ -20,7 +20,7 @@
       <vendor>oracle</vendor>
     </provides>
     <configuration>
-      <jdkHome>/usr/lib/jvm/java-7-oracle/jre</jdkHome>
+      <jdkHome>/usr/lib/jvm/java-7-openjdk-amd64/jre</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=oxygen MAVEN_FLAGS=-Pjacoco
   global:
     - PATH=$PWD/google-cloud-sdk/bin:$PATH
+    # Our maven build typically reports about 512m
+    - MAVEN_OPTS=-Xmx700m
     - CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
     - DISPLAY=:99.0
 before_script:
@@ -26,7 +28,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
   - metacity --sm-disable --replace &
   - sleep 3 # give metacity some time to start
-script: ./mvnw -B -Ptravis --fail-at-end verify ${MAVEN_FLAGS}
+script: ./mvnw -V -B -Ptravis --fail-at-end verify ${MAVEN_FLAGS}
      ${ECLIPSE_TARGET:+-Declipse.target=${ECLIPSE_TARGET}}
      --toolchains=.travis-toolchains.xml
      -Dtoolchain.java.runtime=${JAVA_RUNTIME}


### PR DESCRIPTION
- Oracle JDK 7 is no longer present (EOL'd)
- Explicitly specify maximum heap size for Maven build to insulate from machine configuration changes
    - previous builds on Travis `precise` report using up to 512m of memory
