### PR TITLE
Allow setting GCS paths with object in Dataflow run options

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClientTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClientTest.java
@@ -35,6 +35,13 @@ public class GcsDataflowProjectClientTest {
   }
 
   @Test
+  public void testToGcsLocationUri_caseInsensitivePrefixDetection() {
+    assertEquals("gs://foo/bar", GcsDataflowProjectClient.toGcsLocationUri("GS://foo/bar"));
+    assertEquals("gs://foo/bar", GcsDataflowProjectClient.toGcsLocationUri("gS://foo/bar"));
+    assertEquals("gs://foo/bar", GcsDataflowProjectClient.toGcsLocationUri("Gs://foo/bar"));
+  }
+
+  @Test
   public void testToGcsLocationUriWithNullReturnsNull() {
     assertEquals(null, GcsDataflowProjectClient.toGcsLocationUri(null));
   }
@@ -54,6 +61,19 @@ public class GcsDataflowProjectClientTest {
   public void testToGcsLocationUriWithBucketNameOnlyReturnsWithPrefix() {
     String location = "foo-bar";
     assertEquals("gs://foo-bar", GcsDataflowProjectClient.toGcsLocationUri(location));
+  }
+
+  @Test
+  public void testToGcsBucketName_withoutObject() {
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("my-bucket"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("my-bucket/object"));
+  }
+
+  @Test
+  public void testToGcsBucketName_withObject() {
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("my-bucket/object"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("gs://my-bucket/object"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("GS://my-bucket/object"));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClientTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClientTest.java
@@ -55,5 +55,18 @@ public class GcsDataflowProjectClientTest {
     String location = "foo-bar";
     assertEquals("gs://foo-bar", GcsDataflowProjectClient.toGcsLocationUri(location));
   }
+
+  @Test
+  public void testToGcsBucketName_stripsLeadingForwardSlashes() {
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("my-bucket"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("/my-bucket"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("///my-bucket/"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("///my-bucket/object"));
+
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("gs://my-bucket"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("gs:///my-bucket"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("gs://///my-bucket/"));
+    assertEquals("my-bucket", GcsDataflowProjectClient.toGcsBucketName("gs://///my-bucket/object"));
+  }
 }
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
@@ -90,15 +90,22 @@ public class GcsDataflowProjectClient {
     }
   }
 
-  public static String toGcsBucketName(String stagingLocation) {
-    String gcsLocation;
-    if (stagingLocation.toLowerCase(Locale.US).startsWith(GCS_PREFIX)) {
-      gcsLocation = stagingLocation.substring(GCS_PREFIX.length());
+  /**
+   * Extracts a bucket name from a given GCS URL. For example, {@code "/bucket/object"} returns
+   * {@code "bucket"}.
+   *
+   * @param gcsUrl GCS URL, which may or may not start with case-insensitive {@link #GCS_PREFIX}
+   * @return bucket name, which can be an empty string
+   */
+  public static String toGcsBucketName(String gcsUrl) {
+    String noPrefixUrl;
+    if (gcsUrl.toLowerCase(Locale.US).startsWith(GCS_PREFIX)) {
+      noPrefixUrl = gcsUrl.substring(GCS_PREFIX.length());
     } else {
-      gcsLocation = stagingLocation;
+      noPrefixUrl = gcsUrl;
     }
 
-    List<String> splitted = Splitter.on('/').omitEmptyStrings().splitToList(gcsLocation);
+    List<String> splitted = Splitter.on('/').omitEmptyStrings().splitToList(noPrefixUrl);
     return splitted.isEmpty() ? "" : splitted.get(0);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
@@ -92,7 +92,8 @@ public class GcsDataflowProjectClient {
 
   /**
    * Extracts a bucket name from a given GCS URL. For example, {@code "/bucket/object"} returns
-   * {@code "bucket"}.
+   * {@code "bucket"}. The method assumes that the input is a valid GCS URL. (It just returns
+   * the first segment split by {@code '/'}, ignoring leading {@code '/'}s and empty segments.)
    *
    * @param gcsUrl GCS URL, which may or may not start with case-insensitive {@link #GCS_PREFIX}
    * @return bucket name, which can be an empty string

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
@@ -21,6 +21,7 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Buckets;
 import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.List;
@@ -89,7 +90,14 @@ public class GcsDataflowProjectClient {
   }
 
   public static String toGcsBucketName(String stagingLocation) {
-    String gcsLocation = stripGcsPrefix(stagingLocation);
+    String gcsLocation;
+    if (stagingLocation.startsWith(GCS_PREFIX)) {
+      gcsLocation = stagingLocation.substring(GCS_PREFIX.length());
+    } else {
+      gcsLocation = stagingLocation;
+    }
+
+    gcsLocation = CharMatcher.is('/').trimLeadingFrom(gcsLocation);
 
     String bucketName;
     if (gcsLocation.indexOf('/') < 0) {
@@ -98,14 +106,6 @@ public class GcsDataflowProjectClient {
       bucketName = gcsLocation.substring(0, gcsLocation.indexOf('/'));
     }
     return bucketName;
-  }
-
-  public static String stripGcsPrefix(String gcsPath) {
-    if (gcsPath.startsWith(GCS_PREFIX)) {
-      return gcsPath.substring(GCS_PREFIX.length());
-    } else {
-      return gcsPath;
-    }
   }
 
   public static String toGcsLocationUri(String location) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
@@ -21,10 +21,11 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Buckets;
 import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
-import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -91,26 +92,21 @@ public class GcsDataflowProjectClient {
 
   public static String toGcsBucketName(String stagingLocation) {
     String gcsLocation;
-    if (stagingLocation.startsWith(GCS_PREFIX)) {
+    if (stagingLocation.toLowerCase(Locale.US).startsWith(GCS_PREFIX)) {
       gcsLocation = stagingLocation.substring(GCS_PREFIX.length());
     } else {
       gcsLocation = stagingLocation;
     }
 
-    gcsLocation = CharMatcher.is('/').trimLeadingFrom(gcsLocation);
-
-    String bucketName;
-    if (gcsLocation.indexOf('/') < 0) {
-      bucketName = gcsLocation;
-    } else {
-      bucketName = gcsLocation.substring(0, gcsLocation.indexOf('/'));
-    }
-    return bucketName;
+    List<String> splitted = Splitter.on('/').omitEmptyStrings().splitToList(gcsLocation);
+    return splitted.isEmpty() ? "" : splitted.get(0);
   }
 
   public static String toGcsLocationUri(String location) {
-    if (Strings.isNullOrEmpty(location) || location.startsWith(GCS_PREFIX)) {
+    if (Strings.isNullOrEmpty(location)) {
       return location;
+    } else if (location.toLowerCase(Locale.US).startsWith(GCS_PREFIX)) {
+      return GCS_PREFIX + location.substring(GCS_PREFIX.length());
     }
     return GCS_PREFIX + location;
   }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/project/GcsDataflowProjectClient.java
@@ -88,13 +88,9 @@ public class GcsDataflowProjectClient {
     }
   }
 
-  private static String toGcsBucketName(String stagingLocation) {
-    String gcsLocation;
-    if (stagingLocation.startsWith(GCS_PREFIX)) {
-      gcsLocation = stagingLocation.substring(GCS_PREFIX.length());
-    } else {
-      gcsLocation = stagingLocation;
-    }
+  public static String toGcsBucketName(String stagingLocation) {
+    String gcsLocation = stripGcsPrefix(stagingLocation);
+
     String bucketName;
     if (gcsLocation.indexOf('/') < 0) {
       bucketName = gcsLocation;
@@ -102,6 +98,14 @@ public class GcsDataflowProjectClient {
       bucketName = gcsLocation.substring(0, gcsLocation.indexOf('/'));
     }
     return bucketName;
+  }
+
+  public static String stripGcsPrefix(String gcsPath) {
+    if (gcsPath.startsWith(GCS_PREFIX)) {
+      return gcsPath.substring(GCS_PREFIX.length());
+    } else {
+      return gcsPath;
+    }
   }
 
   public static String toGcsLocationUri(String location) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.dataflow.ui.preferences;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -171,5 +172,14 @@ public class RunOptionsDefaultsComponentTest {
       Thread.sleep(50);
     }
     Assert.assertArrayEquals(buckets, combo.getItems());
+  }
+
+  @Test
+  public void testBucketNameStatus_gscPathWithObjectIsOk() {
+    component.setStagingLocationText("bucket/object");
+    assertTrue(component.bucketNameStatus().isOK());
+
+    component.setStagingLocationText("gs://bucket/object");
+    assertTrue(component.bucketNameStatus().isOK());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -392,6 +392,7 @@ public class RunOptionsDefaultsComponent {
   private static final BucketNameValidator bucketNameValidator = new BucketNameValidator();
 
   private String extractBucketNamePart() {
+    // Don't trim text unless you consistently trim everywhere else (e.g., "getStagingLocation()").
     return GcsDataflowProjectClient.toGcsBucketName(stagingLocationInput.getText());
   }
 


### PR DESCRIPTION
Fixes #2141. Now the staging location will accept GCS paths containing objects, since it will validate only the bucket name part of a path.

Miscs:
- I renamed to _Create_ button that creates a GCS bucket to _Create Bucket_, because otherwise, it can mislead to think it will also create an object. For example, if the input field is `gs://my-bucket/my-object`, it will create the bucket `my-bucket` only. Fortunately, as long as a bucket exists, the Dataflow SDK will create any necessary sub-folder (an object, actually), so there is no need for us to also create an `my-object`.
- `toGcsBucketName()`, which was designed to return only the bucket name part, now removes any trailing forward slashes, as otherwise it will return an empty bucket name.
