### PR TITLE
Add hamcrest.core and .library to category.xml / remove hamcrest.integration from .test.dependencies

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -25,7 +25,8 @@
    <bundle id="org.eclipse.jetty.servlet" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.server" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.util" version="0.0.0"/>
-   <bundle id="org.hamcrest.integration" version="0.0.0"/>
+   <bundle id="org.hamcrest.core" version="1.3.0.v201303031735"/>
+   <bundle id="org.hamcrest.library" version="1.3.0.v201505072020"/>
    <bundle id="org.mortbay.jetty.server" version="6.1.26"/>
    <bundle id="org.mortbay.jetty.util" version="6.1.26"/>
    <bundle id="org.freemarker.freemarker" version="2.3.25.stable-incubating"/>

--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -25,6 +25,7 @@
    <bundle id="org.eclipse.jetty.servlet" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.server" version="0.0.0"/>
    <bundle id="org.eclipse.jetty.util" version="0.0.0"/>
+   <bundle id="org.hamcrest.integration" version="0.0.0"/>
    <bundle id="org.mortbay.jetty.server" version="6.1.26"/>
    <bundle id="org.mortbay.jetty.util" version="6.1.26"/>
    <bundle id="org.freemarker.freemarker" version="2.3.25.stable-incubating"/>

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.hamcrest.core;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
- org.hamcrest.integration;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
  org.hamcrest.library;bundle-version="[1.3.0,1.3.1)";visibility:=reexport
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,


### PR DESCRIPTION
I can check that this does pull in the said bundle, but is this the best?

Another option would be to remove it from the `MANIFEST.MF` in `.test.dependencies`, because no one seems to use it for now. But for completeness, it may be a good idea to leave it there whether it's used or not.

```
Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
 org.hamcrest.core;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
 org.hamcrest.integration;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
 org.hamcrest.library;bundle-version="[1.3.0,1.3.1)";visibility:=reexport
```