### PR TITLE
Remove devappserver consoles when corresponding ILaunch is removed

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -86,6 +86,10 @@ import org.eclipse.jdt.launching.IVMConnector;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.SocketUtil;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleManager;
+import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
@@ -431,9 +435,8 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
 
     // configure the console for output
     ConsoleColorProvider colorProvider = new ConsoleColorProvider();
-    LocalAppEngineConsole console =
-        MessageConsoleUtilities.findOrCreateConsole(configuration.getName(),
-            new LocalAppEngineConsole.Factory(serverBehaviour));
+    LocalAppEngineConsole console = MessageConsoleUtilities.findOrCreateConsole(
+        configuration.getName(), new LocalAppEngineConsole.Factory(serverBehaviour));
     console.clearConsole();
     console.activate();
     MessageConsoleStream outputStream = console.newMessageStream();
@@ -442,7 +445,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     errorStream.setColor(colorProvider.getColor(IDebugUIConstants.ID_STANDARD_ERROR_STREAM));
 
     // A launch must have at least one debug target or process, or it becomes a zombie
-    CloudSdkDebugTarget target = new CloudSdkDebugTarget(launch, serverBehaviour);
+    CloudSdkDebugTarget target = new CloudSdkDebugTarget(launch, serverBehaviour, console);
     launch.addDebugTarget(target);
     target.engage();
 
@@ -590,6 +593,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     private ILaunch launch;
     private LocalAppEngineServerBehaviour serverBehaviour;
     private IServer server;
+    private IOConsole console;
 
     // Fire a {@link DebugEvent#TERMINATED} event when the server is stopped
     private IServerListener serverEventsListener = new IServerListener() {
@@ -603,7 +607,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
             return;
 
           case IServer.STATE_STOPPED:
-            disengage();
+            server.removeServerListener(serverEventsListener);
             fireTerminateEvent();
             try {
               logger.fine("Server stopped; terminating launch"); //$NON-NLS-1$
@@ -625,7 +629,6 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
       public void launchesTerminated(ILaunch[] launches) {
         for (ILaunch terminated : launches) {
           if (terminated == launch) {
-            disengage();
             if (server.getServerState() == IServer.STATE_STARTED) {
               logger.fine("Launch terminated; stopping server"); //$NON-NLS-1$
               server.stop(false);
@@ -642,26 +645,37 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
       public void launchesChanged(ILaunch[] launches) {}
 
       @Override
-      public void launchesRemoved(ILaunch[] launches) {}
+      public void launchesRemoved(ILaunch[] launches) {
+        for (ILaunch removed : launches) {
+          if (removed == launch) {
+            getLaunchManager().removeLaunchListener(launchesListener);
+            removeConsole();
+          }
+        }
+      }
     };
 
-    CloudSdkDebugTarget(ILaunch launch, LocalAppEngineServerBehaviour serverBehaviour) {
+    CloudSdkDebugTarget(ILaunch launch, LocalAppEngineServerBehaviour serverBehaviour,
+        IOConsole console) {
       super(null);
       this.launch = launch;
       this.serverBehaviour = serverBehaviour;
       this.server = serverBehaviour.getServer();
+      this.console = console;
     }
+
+    protected void removeConsole() {
+      ConsolePlugin plugin = ConsolePlugin.getDefault();
+      IConsoleManager manager = plugin.getConsoleManager();
+      manager.removeConsoles(new IConsole[] {console});
+      console.destroy();
+    }
+
 
     /** Add required listeners */
     private void engage() {
       getLaunchManager().addLaunchListener(launchesListener);
       server.addServerListener(serverEventsListener);
-    }
-
-    /** Remove any installed listeners */
-    private void disengage() {
-      getLaunchManager().removeLaunchListener(launchesListener);
-      server.removeServerListener(serverEventsListener);
     }
 
     @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsole.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsole.java
@@ -38,7 +38,9 @@ public class LocalAppEngineConsole extends MessageConsole {
   private IServerListener serverStateListener = new IServerListener() {
     @Override
     public void serverChanged(ServerEvent event) {
-      updateName(event.getState());
+      if ((event.getKind() & ServerEvent.SERVER_CHANGE) != 0) {
+        update(event.getState());
+      }
     }
   };
 
@@ -51,18 +53,25 @@ public class LocalAppEngineConsole extends MessageConsole {
     this.serverBehaviour = serverBehaviour;
   }
 
+  protected void update(int serverState) {
+    if (serverState == IServer.STATE_STOPPED) {
+      disengage(); // we should no longer update
+    }
+    updateName(serverState);
+  }
+
   /**
    * Update the shown name with the server stop/stopping state.
    */
-  protected void updateName(int state) {
+  protected void updateName(int serverState) {
     final String computedName;
-    if (state == IServer.STATE_STARTING) {
+    if (serverState == IServer.STATE_STARTING) {
       computedName =
           Messages.getString("SERVER_STARTING_TEMPLATE", unprefixedName);
-    } else if (state == IServer.STATE_STOPPING) {
+    } else if (serverState == IServer.STATE_STOPPING) {
       computedName =
           Messages.getString("SERVER_STOPPING_TEMPLATE", unprefixedName);
-    } else if (state == IServer.STATE_STOPPED) {
+    } else if (serverState == IServer.STATE_STOPPED) {
       computedName =
           Messages.getString("SERVER_STOPPED_TEMPLATE", unprefixedName);
     } else {
@@ -86,13 +95,19 @@ public class LocalAppEngineConsole extends MessageConsole {
   @Override
   protected void init() {
     super.init();
+    updateName(serverBehaviour.getServer().getServerState());
     serverBehaviour.getServer().addServerListener(serverStateListener);
   }
 
   @Override
   protected void dispose() {
-    serverBehaviour.getServer().removeServerListener(serverStateListener);
+    disengage();
     super.dispose();
+  }
+
+  /** Stop reacting to server state changes. */
+  private void disengage() {
+    serverBehaviour.getServer().removeServerListener(serverStateListener);
   }
 
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -149,6 +149,13 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     assertTrue("App Engine console should mark as stopped",
         consoleView.getViewReference().getContentDescription().startsWith("<stopped>"));
     assertFalse("Stop Server button should be disabled", stopServerButton.isEnabled());
+
+    // should also cause console to be discarded
+    launchTree.contextMenu("Remove All Terminated").click();
+    SwtBotTreeUtilities.waitUntilTreeHasNoItems(bot, launchTree);
+    assertThat("App Engine console should be removed",
+        consoleView.getViewReference().getContentDescription(),
+        Matchers.is("No consoles to display at this time."));
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -341,6 +341,26 @@ public class SwtBotTreeUtilities {
   }
 
   /**
+   * Wait until the given tree has not items.
+   * 
+   * @throws TimeoutException if no items appear within the default timeout
+   */
+  public static void waitUntilTreeHasNoItems(SWTWorkbenchBot bot, final SWTBotTree tree) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public String getFailureMessage() {
+        return "Tree items never disappeared";
+      }
+
+      @Override
+      public boolean test() throws Exception {
+        return !tree.hasItems();
+      }
+    });
+  }
+
+
+  /**
    * Wait until the tree item contains the given text with the
    * timeout {@link SWTBotPreferences#TIMEOUT}.
    */


### PR DESCRIPTION
  - Change `CloudSdkDebugTarget` to remove the associated console when the ILaunch is removed (following pattern defined in Java and Eclipse launches).  An ILaunch may only be removed much later after a server has transitioned to a STOPPED state.
  - Cause the consoles to stop updating themselves once the server transitions to a STOPPED state as a new console is allocated on restart.

Fixes #2212 