### PR TITLE
Back out marking LocalAppEngineConsole as type="javaStackTraceConsole" to avoid CCEs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsole.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/LocalAppEngineConsole.java
@@ -45,10 +45,7 @@ public class LocalAppEngineConsole extends MessageConsole {
   };
 
   private LocalAppEngineConsole(String name, LocalAppEngineServerBehaviour serverBehaviour) {
-    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2140
-    // todo: setting "javaStackTraceConsole" as the console type seems distasteful
-    // but is required to get stack-trace linking to work
-    super(name, "javaStackTraceConsole", AppEngineImages.appEngine(16), true);
+    super(name, AppEngineImages.appEngine(16), true);
     this.unprefixedName = name;
     this.serverBehaviour = serverBehaviour;
   }


### PR DESCRIPTION
From #2147 for #2140 marked our `LocalAppEngineConsole` instances as type of `javaStackTraceConsole`.  But other code assume this console can be cast as a `JavaStackTraceConsole` and the CCE is logged and reported through the Eclipse AERI mechanism.

Fixes #2220