### PR TITLE
Return empty hierarchy if not Dataflow project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/ClasspathPipelineOptionsHierarchyFactoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/ClasspathPipelineOptionsHierarchyFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.dataflow.core.launcher;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.eclipse.dataflow.core.launcher.options.PipelineOptionsHierarchy;
+import com.google.cloud.tools.eclipse.dataflow.core.launcher.options.PipelineOptionsNamespaces;
+import com.google.cloud.tools.eclipse.dataflow.core.project.MajorVersion;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClasspathPipelineOptionsHierarchyFactoryTest {
+
+  @Mock private IProject project;
+  @Mock private IJavaProject javaProject;
+
+  @Before
+  public void setUp() {
+    IJavaElement javaElement = mock(IJavaElement.class);
+    when(project.getAdapter(IJavaElement.class)).thenReturn(javaElement);
+    when(javaElement.getJavaProject()).thenReturn(javaProject);
+  }
+
+  @Test
+  public void testForProject_projectHasNoPipelineOptionsType()
+      throws PipelineOptionsRetrievalException {
+    PipelineOptionsHierarchy optionsHeierarchy = new ClasspathPipelineOptionsHierarchyFactory()
+        .forProject(project, null, new NullProgressMonitor());
+    assertThat(optionsHeierarchy, instanceOf(EmptyPipelineOptionsHierarchy.class));
+  }
+
+  @Test
+  public void testForProject_pipelineOptionsTypeDoesNotExistInProject()
+      throws PipelineOptionsRetrievalException, JavaModelException {
+    String version = PipelineOptionsNamespaces.rootType(MajorVersion.ONE);
+    when(javaProject.findType(version)).thenReturn(mock(IType.class));
+
+    PipelineOptionsHierarchy optionsHeierarchy = new ClasspathPipelineOptionsHierarchyFactory()
+        .forProject(project, MajorVersion.ONE, new NullProgressMonitor());
+    assertThat(optionsHeierarchy, instanceOf(EmptyPipelineOptionsHierarchy.class));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/options/JavaProjectPipelineOptionsHierarchy.java
@@ -68,11 +68,8 @@ public class JavaProjectPipelineOptionsHierarchy implements PipelineOptionsHiera
       IJavaProject project, MajorVersion version, IProgressMonitor monitor)
       throws JavaModelException {
     IType rootType = project.findType(PipelineOptionsNamespaces.rootType(version));
-    if (rootType == null || !rootType.exists()) {
-      throw new IllegalArgumentException(
-          "Tried to create a TypeHierarchyPipelineOptionsHierarchy for a Java Project "
-              + "where no PipelineOptions type exists");
-    }
+    Preconditions.checkNotNull(rootType, "project has no PipelineOptions type");
+    Preconditions.checkArgument(rootType.exists(), "PipelineOptions does not exist in project");
 
     // Flatten the class hierarchy, recording all the classes present
     ITypeHierarchy hierarchy = rootType.newTypeHierarchy(monitor);


### PR DESCRIPTION
Fixes #2223. Apparently, if a project is not set or is not accessible, we currently return `global()` as below. So, if a project isn't a Dataflow project (no `PipelineOptions` type exists), it is safe to return `global()`.

```java
    if (project != null && project.isAccessible()) {
        ...
        return pipelineOptionsHierarchyFactory.forProject(project, majorVersion, monitor);
        ...
    }
    return pipelineOptionsHierarchyFactory.global(monitor);
```