### PR TITLE
Add note about metadata.product version .qualifier

### DIFF
--- a/gcp-repo/metadata.product
+++ b/gcp-repo/metadata.product
@@ -3,6 +3,11 @@
 <!--
   This product exists to (1) bring in any required features, and
   (2) add any additional metadata for the CT4E repository.
+
+  The product version should have a .qualifier *except* for releases.
+  This version is used for creating our CT4E category (see the accompanying
+  .p2.inf).  p2 generates unique qualifiers for categories, so it would be
+  best for our non-release builds to have unique versions too.
 -->
 <product uid="com.google.cloud.tools.eclipse.dist" version="1.3.0.qualifier" useFeatures="true" includeLaunchers="false">
 


### PR DESCRIPTION
p2 and Tycho's p2 publishers normally generate unique versions for categories.  Those categories are used by the p2 UIs (e.g., _Install New Software_).   Should we introduce composite repositories at some point (e.g., to reference latest builds), and we drop this _.qualifier_, then we could have a situation with multiple products and categories with the same ID and versions.  So it's best for us to continue using `.qualifier` in product versions for *non-release* builds.

Since we'll have a single release build, the qualifier-less version will be unique (e.g., `1.3.0`) and all will be well.