### PR TITLE
Add maven nature to com.google.cloud.tools.eclipse.swtbot

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.swtbot/.project
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/.project
@@ -21,14 +21,14 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
I had wondered why I'd see maven errors to do with not being able to resolve `com.google.cloud.tools.eclipse.swtbot`