### PR TITLE
Repeatedly wait for problem markers in testValidate_badXml()

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -23,9 +23,11 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.common.base.Stopwatch;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -104,7 +106,13 @@ public class XmlValidatorTest {
     IProject project = dynamicWebProjectCreator.getProject();
     IFile file = project.getFile("src/bad.xml");
     file.create(new ByteArrayInputStream(badXml), true, null);
-    ProjectUtils.waitForProjects(project);  // Wait until Eclipse puts an error marker.
+
+    Stopwatch elapsed = Stopwatch.createStarted();
+    while (elapsed.elapsed(TimeUnit.SECONDS) < 300
+        && file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO).length == 0) {
+      ProjectUtils.waitForProjects(project); // Wait until Eclipse puts an error marker.
+    }
+
 
     IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
     assertEquals(1, markers.length);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -108,10 +108,12 @@ public class XmlValidatorTest {
     file.create(new ByteArrayInputStream(badXml), true, null);
 
     Stopwatch elapsed = Stopwatch.createStarted();
-    while (elapsed.elapsed(TimeUnit.SECONDS) < 300
-        && file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO).length == 0) {
+    IMarker[] markers;
+    do {
       ProjectUtils.waitForProjects(project); // Wait until Eclipse puts an error marker.
-    }
+      markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
+      System.out.printf("%s: %d problem markers found\n", elapsed, markers.length);
+    } while (elapsed.elapsed(TimeUnit.SECONDS) < 300 && markers.length == 0);
 
 
     IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -115,8 +115,7 @@ public class XmlValidatorTest {
       System.out.printf("%s: %d problem markers found\n", elapsed, markers.length);
     } while (elapsed.elapsed(TimeUnit.SECONDS) < 300 && markers.length == 0);
 
-
-    IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
+    markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
     assertEquals(1, markers.length);
 
     String resultMessage = (String) markers[0].getAttribute(IMarker.MESSAGE);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/XmlValidatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.common.base.Stopwatch;
@@ -113,6 +114,9 @@ public class XmlValidatorTest {
       ProjectUtils.waitForProjects(project); // Wait until Eclipse puts an error marker.
       markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
       System.out.printf("%s: %d problem markers found\n", elapsed, markers.length);
+      if (markers.length == 0) {
+        ThreadDumpingWatchdog.report("Expected a problem marker", elapsed);
+      }
     } while (elapsed.elapsed(TimeUnit.SECONDS) < 300 && markers.length == 0);
 
     markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/ThreadDumpingWatchdog.java
@@ -137,7 +137,8 @@ public class ThreadDumpingWatchdog extends TimerTask implements TestRule {
     }
     sb.append("\n|");
     dumpEclipseLocks(sb, "| ");
-
+    sb.append("\n|");
+    dumpEclipseJobs(sb, "| ");
     sb.append("\n|");
     int uselessThreadsCount = 0;
     for (ThreadInfo tinfo : infos) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -328,6 +328,7 @@ public class ProjectUtils {
     // some jobs are not part of a family
     for (Job job : jobManager.find(null)) {
       switch (job.getClass().getName()) {
+        case "org.eclipse.wst.jsdt.web.core.internal.project.ConvertJob":
         case "org.eclipse.m2e.core.ui.internal.wizards.ImportMavenProjectsJob":
         case "org.eclipse.m2e.core.internal.project.registry.ProjectRegistryRefreshJob":
           jobs.add(job);


### PR DESCRIPTION
Towards fixing #2076.

Wait for `ConvertJob`, fixes #2087 