### PR TITLE
Restore the inclusion of schema bundles for .test.dependencies

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -7,7 +7,11 @@ Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.hamcrest.core;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
- org.hamcrest.library;bundle-version="[1.3.0,1.3.1)";visibility:=reexport
+ org.hamcrest.library;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
+ org.eclipse.jst.standard.schemas;bundle-version="[1.2,2.0)",
+ org.eclipse.wst.standard.schemas;bundle-version="[1.0,2.0)",
+ org.eclipse.xsd;bundle-version="[2.11,3.0)",
+ org.eclipse.wst.xsd.core;bundle-version="[1.1,2.0)"
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,
    org.mockito.verification,


### PR DESCRIPTION
Restores the inclusion of the schema bundles from #2092.

Fixes #1196 (again)