### PR TITLE
Specify conflict with old Dataflow plugin

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.e45.feature/p2.inf
+++ b/features/com.google.cloud.tools.eclipse.suite.e45.feature/p2.inf
@@ -23,3 +23,7 @@
  requires.4.min = 0
  requires.4.max = 0
 
+ requires.5.namespace = org.eclipse.equinox.p2.iu
+ requires.5.name = com.google.cloud.dataflow.eclipse.feature.feature.group
+ requires.5.min = 0
+ requires.5.max = 0


### PR DESCRIPTION
Fixes #2255. I did a manual testing by first installing CT4E and then the old Dataflow plugin. It correctly shows a conflict:

![selection_003](https://user-images.githubusercontent.com/10523105/29300394-26078216-8143-11e7-8d4c-843a7f646738.png)