### PR TITLE
Remove unnecessary Bundle-ClassPath in MANIFEST.MF

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.util/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.util/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Google Inc.
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Export-Package: com.google.cloud.tools.eclipse.util,
  com.google.cloud.tools.eclipse.util.io,
  com.google.cloud.tools.eclipse.util.service,
@@ -26,7 +27,5 @@ Import-Package: com.google.common.annotations;version="[20.0.0,21.0.0)",
  org.eclipse.ui.statushandlers,
  org.eclipse.wst.common.project.facet.core,
  org.osgi.framework
-Bundle-ClassPath: .,
- templates/appengine/
 Require-Bundle: org.eclipse.m2e.maven.runtime,
  org.eclipse.m2e.core;bundle-version="1.6.2"

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
@@ -88,8 +88,7 @@ public class Templates {
 
   private static Configuration createConfiguration() {
     Configuration configuration = new Configuration(Configuration.VERSION_2_3_25);
-    configuration.setClassForTemplateLoading(
-        Templates.class, "/templates/appengine");
+    configuration.setClassForTemplateLoading(Templates.class, "/templates/appengine");
     configuration.setDefaultEncoding(StandardCharsets.UTF_8.name());
     configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
     configuration.setLogTemplateExceptions(false);


### PR DESCRIPTION
`template/appengine/` is where the freemarker template files (`.ftl`) and one `favicon.ico` reside. I don't think it needs to be in a classpath, as we always provide `template/appengine/` as a base package path:
```java
    Configuration configuration = new Configuration(Configuration.VERSION_2_3_25);
    configuration.setClassForTemplateLoading(Templates.class, "/templates/appengine");
```
```java
        InputStream inputStream = Templates.class
            .getResourceAsStream("/templates/appengine/" + sourceName);
```

FYI, the Javadoc of `setClassForTemplateLoading()` is [here](http://freemarker.org/docs/api/freemarker/template/Configuration.html#setClassForTemplateLoading-java.lang.Class-java.lang.String-).