### PR TITLE
Handle pipeline options computation as UI-blocking work

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTabTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTabTest.java
@@ -35,6 +35,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -71,6 +72,7 @@ public class PipelineArgumentsTabTest {
       IWorkspaceRoot workspaceRoot = mock(IWorkspaceRoot.class);
       when(workspaceRoot.getProject(anyString())).thenReturn(mock(IProject.class));
 
+      ILaunchConfigurationDialog dialog = mock(ILaunchConfigurationDialog.class);
       ILaunchConfiguration configuration = mock(ILaunchConfiguration.class);
       when(configuration.getAttribute(
           eq(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME), anyString()))
@@ -80,6 +82,7 @@ public class PipelineArgumentsTabTest {
           .thenReturn("DirectPipelineRunner");
 
       PipelineArgumentsTab tab = new PipelineArgumentsTab(workspaceRoot);
+      tab.setLaunchConfigurationDialog(dialog);
       tab.createControl(shellResource.getShell());
       tab.initializeFrom(configuration);  // Should not throw NPE.
 


### PR DESCRIPTION
Execute pipeline computation using the modal context (`IRunnableWithContext` obtained from the `ILaunchConfigurationDialog`): this launches the computation on a background thread, but spins the UI thread (with a progress bar, if it takes longer than some threshold).  The actual pipeline options form updating is handled done with a busy-indicator.

Fixes #2289