### PR TITLE
Ensure run-options validity is propagated

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
@@ -96,8 +96,8 @@ public class RunOptionsDefaultsComponentTest {
     mockStorageApiBucketList(credential2, "bob-bucket");
 
     shell = shellResource.getShell();
-    component = new RunOptionsDefaultsComponent(
-        shell, 3, messageTarget, preferences, null, loginService, apiFactory);
+    component = new RunOptionsDefaultsComponent(shell, 3, messageTarget, preferences, false,
+        loginService, apiFactory);
     selector = CompositeUtil.findControl(shell, AccountSelector.class);
     projectID =
         CompositeUtil.findControlAfterLabel(shell, Text.class, "Cloud Platform &project ID:");
@@ -138,11 +138,44 @@ public class RunOptionsDefaultsComponentTest {
   @Test
   public void testConstructor_testGrid() {
     try {
-      new RunOptionsDefaultsComponent(null, 0, null, null);
+      new RunOptionsDefaultsComponent(null, 0, null, null, false);
       Assert.fail("didn't check grid");
     } catch (IllegalArgumentException ex) {
       Assert.assertNotNull(ex.getMessage());
     }
+  }
+
+  @Test
+  public void testClearIsOk() {
+    component = new RunOptionsDefaultsComponent(shell, 3, messageTarget, preferences, true,
+        loginService, apiFactory);
+    assertTrue(component.isClear());
+    assertTrue(component.isValid());
+  }
+
+  @Test
+  public void testIsClear_empty() {
+    assertTrue(component.isClear());
+  }
+
+  @Test
+  public void testIsClear_nonEmpty() {
+    selector.selectAccount("alice@example.com");
+    assertFalse(component.isClear());
+    component.setCloudProjectText("some-gcp-project-id");
+    assertFalse(component.isClear());
+    component.updateStagingLocations("some-gcp-project-id", 0);
+    assertFalse(component.isClear());
+  }
+
+  @Test
+  public void testClear() {
+    selector.selectAccount("alice@example.com");
+    component.setCloudProjectText("some-gcp-project-id");
+    component.updateStagingLocations("some-gcp-project-id", 0);
+    assertFalse(component.isClear());
+    component.clear();
+    assertTrue(component.isClear());
   }
 
   @Test
@@ -182,6 +215,7 @@ public class RunOptionsDefaultsComponentTest {
     assertFalse(projectID.isEnabled());
     assertFalse(stagingLocations.isEnabled());
     assertFalse(createButton.isEnabled());
+    assertFalse(component.isValid());
   }
 
   @Test
@@ -192,6 +226,7 @@ public class RunOptionsDefaultsComponentTest {
     assertTrue(projectID.isEnabled());
     assertFalse(stagingLocations.isEnabled());
     assertFalse(createButton.isEnabled());
+    assertFalse(component.isValid());
   }
 
   @Test
@@ -203,6 +238,7 @@ public class RunOptionsDefaultsComponentTest {
     assertTrue(projectID.isEnabled());
     assertTrue(stagingLocations.isEnabled());
     assertFalse(createButton.isEnabled());
+    assertFalse(component.isValid());
   }
 
   @Test
@@ -219,12 +255,13 @@ public class RunOptionsDefaultsComponentTest {
         // spin
       }
       Thread.sleep(50);
-    } while (i++ < 200 && !verifyResult.isDone());
+    } while (i++ < 200 && !verifyResult.isDone() && !component.isValid());
     assertTrue(selector.isEnabled());
     assertNotNull(selector.getSelectedCredential());
     assertTrue(projectID.isEnabled());
     assertTrue(stagingLocations.isEnabled());
     assertFalse(createButton.isEnabled());
+    assertTrue(component.isValid());
   }
 
   @Test
@@ -249,6 +286,8 @@ public class RunOptionsDefaultsComponentTest {
     assertTrue(projectID.isEnabled());
     assertTrue(stagingLocations.isEnabled());
     assertTrue(createButton.isEnabled());
+
+    assertFalse(component.isValid()); // since bucket doesn't exist
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -67,8 +67,15 @@ public class DefaultedPipelineOptionsComponent {
     useDefaultsButton.setLayoutData(
         new GridData(SWT.BEGINNING, SWT.CENTER, true, false, numColumns, 1));
 
-    defaultOptions =
-        new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget, preferences);
+    defaultOptions = new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget,
+        preferences, false);
+  }
+
+  /**
+   * Return true if this component is valid.
+   */
+  public boolean isValid() {
+    return useDefaultsButton.getSelection() || defaultOptions.isValid();
   }
 
   public void setUseDefaultValues(boolean useDefaultValues) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -68,14 +68,15 @@ public class DefaultedPipelineOptionsComponent {
         new GridData(SWT.BEGINNING, SWT.CENTER, true, false, numColumns, 1));
 
     defaultOptions = new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget,
-        preferences, false);
+        preferences, false /* clearIsOk */);
   }
 
   /**
    * Return true if this component is valid.
    */
   public boolean isValid() {
-    return useDefaultsButton.getSelection() || defaultOptions.isValid();
+    // when useDefaultsButton is true, defaults are copied into defaultOptions
+    return defaultOptions.isValid();
   }
 
   public void setUseDefaultValues(boolean useDefaultValues) {
@@ -101,6 +102,7 @@ public class DefaultedPipelineOptionsComponent {
         .customValues.put(
             DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY,
             customValues.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    updateDefaultableInputValues();
   }
 
   public void setPreferences(DataflowPreferences preferences) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -248,6 +248,12 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
         setErrorMessage(null);
         setMessage(null);
       }
+
+      @Override
+      public void setValid(boolean valid) {
+        // will call back into isValid()
+        getLaunchConfigurationDialog().updateButtons();
+      }
     };
 
     defaultOptionsComponent =
@@ -448,7 +454,7 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
 
     setErrorMessage(null);
     return validateRequiredProperties(validationFailures)
-        && validateRequiredGroups(validationFailures);
+        && validateRequiredGroups(validationFailures) && defaultOptionsComponent.isValid();
   }
 
   private boolean validateRequiredGroups(MissingRequiredProperties validationFailures) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/DialogPageMessageTarget.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/DialogPageMessageTarget.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.eclipse.dataflow.ui.page;
 
 import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.jface.wizard.WizardPage;
 
 /**
  * A {@link MessageTarget} that sets messages on a {@code DialogPage}.
@@ -41,6 +43,15 @@ public class DialogPageMessageTarget implements MessageTarget {
   @Override
   public void clear() {
     target.setMessage(null);
+  }
+
+  @Override
+  public void setValid(boolean valid) {
+    if(target instanceof WizardPage) {
+      ((WizardPage)target).setPageComplete(valid);
+    } else if (target instanceof PreferencePage) {
+      ((PreferencePage) target).setValid(valid);
+    }
   }
 }
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/MessageTarget.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/MessageTarget.java
@@ -28,4 +28,7 @@ public interface MessageTarget {
 
   /** Clears the message. */
   void clear();
+
+  /** Set the validity. */
+  void setValid(boolean valid);
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
@@ -47,7 +47,7 @@ public class NewDataflowProjectWizardDefaultRunOptionsPage extends WizardPage {
     int numColumns = 3;
     composite.setLayout(new GridLayout(numColumns, false));
     runOptionsDefaultsComponent = new RunOptionsDefaultsComponent(composite, numColumns,
-        new DialogPageMessageTarget(this), prefs, false /* clearIsOk */);
+        new DialogPageMessageTarget(this), prefs, true /* clearIsOk */);
 
     setControl(runOptionsDefaultsComponent.getControl());
   }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
@@ -46,8 +46,8 @@ public class NewDataflowProjectWizardDefaultRunOptionsPage extends WizardPage {
     Composite composite = new Composite(parent, SWT.NULL);
     int numColumns = 3;
     composite.setLayout(new GridLayout(numColumns, false));
-    runOptionsDefaultsComponent = new RunOptionsDefaultsComponent(
-        composite, numColumns, new DialogPageMessageTarget(this), prefs, this);
+    runOptionsDefaultsComponent = new RunOptionsDefaultsComponent(composite, numColumns,
+        new DialogPageMessageTarget(this), prefs, false /* clearIsOk */);
 
     setControl(runOptionsDefaultsComponent.getControl());
   }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/DefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/DefaultRunOptionsPage.java
@@ -54,8 +54,8 @@ public class DefaultRunOptionsPage
     group.setLayout(new GridLayout(numColumns, false));
     group.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
 
-    runOptionsComponent = new RunOptionsDefaultsComponent(
-        group, numColumns, new DialogPageMessageTarget(this), preferences);
+    runOptionsComponent = new RunOptionsDefaultsComponent(group, numColumns,
+        new DialogPageMessageTarget(this), preferences, true /* clearIsOk */);
 
     return composite;
   }
@@ -65,6 +65,13 @@ public class DefaultRunOptionsPage
     updatePreferencesFromInputs();
     preferences.save();
     return super.performOk();
+  }
+
+  @Override
+  protected void performDefaults() {
+    // should project-properties be cleared?
+    runOptionsComponent.clear();
+    super.performDefaults();
   }
 
   /**
@@ -96,5 +103,6 @@ public class DefaultRunOptionsPage
       this.preferences = WritableDataflowPreferences.forProject(this.selectedProject);
     }
   }
+
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -96,6 +96,7 @@ public class RunOptionsDefaultsComponent {
   @VisibleForTesting
   VerifyStagingLocationJob verifyStagingLocationJob;
   private boolean clearIsOk;
+  private boolean enabled = true;
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
       DataflowPreferences preferences, boolean clearIsOk) {
@@ -219,8 +220,10 @@ public class RunOptionsDefaultsComponent {
   }
 
   private void validate() {
+    // if !enabled, still need to validate the contents but no fields should be enabled
     setValid(false);
     messageTarget.clear();
+
     Credential selectedCredential = accountSelector.getSelectedCredential();
     if (selectedCredential == null) {
       projectInput.setEnabled(false);
@@ -230,7 +233,7 @@ public class RunOptionsDefaultsComponent {
       return;
     }
 
-    projectInput.setEnabled(true);
+    projectInput.setEnabled(this.enabled);
     if (Strings.isNullOrEmpty(projectInput.getText())) {
       stagingLocationInput.setEnabled(false);
       createButton.setEnabled(false);
@@ -258,7 +261,7 @@ public class RunOptionsDefaultsComponent {
       }
     }
 
-    stagingLocationInput.setEnabled(true);
+    stagingLocationInput.setEnabled(this.enabled);
 
     final String bucketNamePart = GcsDataflowProjectClient.toGcsBucketName(getStagingLocation());
     if (bucketNamePart.isEmpty()) {
@@ -303,7 +306,7 @@ public class RunOptionsDefaultsComponent {
       } else {
         // user must create this bucket; feels odd that this is flagged as an error
         messageTarget.setError(Messages.getString("could.not.fetch.bucket", bucketNamePart)); //$NON-NLS-1$
-        createButton.setEnabled(true);
+        createButton.setEnabled(this.enabled);
       }
     } catch (InterruptedException | ExecutionException ex) {
       DataflowUiPlugin.logWarning("Unable to verify staging location", ex);
@@ -355,6 +358,7 @@ public class RunOptionsDefaultsComponent {
   }
 
   public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
     accountSelector.setEnabled(enabled);
     projectInput.setEnabled(enabled);
     stagingLocationInput.setEnabled(enabled);


### PR DESCRIPTION
Fixes up the `RunOptionsDefaultComponent` and friends to check and handle validation, particularly situations where an "empty" run-options is ok.

- use the _fetch staging locations_ job result to validate the specified project
- `RunOptionsDefaultComponent` explicitly tracks whether its fields should be enabled or not
- `RunOptionsDefaultComponent` explicitly allows an _empty_ configuration to be considered as valid (e.g., for specifying default values like the project default run-options, or the system default run-options)
- _Preferences > Google Cloud Platform > Google Dataflow_ page enablement is based on validity of values shown; an empty configuration is ok
   - _Restore Defaults_ clears values, which is valid
- the project dataflow property page's enablement is based on validity of values shown; an empty configuration is ok
   - _Restore Defaults_ clears values, which is valid
- the Run/Debug _Pipeline Arguments_ page enablement is tied to the validity of values shown in the run-options
   - when _use defaults_ is selected, the run-options is disabled and the values shown are taken from the project defaults or the system defaults, and validity depends on those defaults
   - empty values is not valid
   - switching between different launch configurations properly loads and validates the values

There is a bug when the Debug/Run that the error messages are cleared when first loading a launch config.  Typically this shouldn't matter, since it shouldn't be possible to save invalid run-options.

Fixes #2282 