### PR TITLE
Cause build commands to appear in Kokoro log

### DIFF
--- a/kokoro/windows/continuous.bat
+++ b/kokoro/windows/continuous.bat
@@ -1,3 +1,4 @@
+@echo on
 cd github/google-cloud-eclipse
 
 set CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true


### PR DESCRIPTION
It's useful to see the commands actually executed.