### PR TITLE
Equals methods

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFileTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFileTest.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -131,5 +133,25 @@ public class LibraryFileTest {
     LibraryFile libraryFile = new LibraryFile(mavenCoordinates);
     libraryFile.setExport(false);
     assertFalse(libraryFile.isExport());
+  }
+  
+
+  @Test
+  public void testEquals() throws URISyntaxException {
+    MavenCoordinates mavenCoordinatesAb = new MavenCoordinates("a", "b");
+    MavenCoordinates mavenCoordinatesXy = new MavenCoordinates("x", "y");
+    LibraryFile libraryFile1 = new LibraryFile(mavenCoordinatesAb);
+    LibraryFile libraryFile2 = new LibraryFile(mavenCoordinatesXy);
+    LibraryFile libraryFile3 = new LibraryFile(mavenCoordinatesAb);
+    libraryFile3.setJavadocUri(new URI("http://www.example.com"));
+    
+    assertEquals(libraryFile1, libraryFile1);
+    assertEquals(libraryFile1, libraryFile3);
+    assertEquals(libraryFile1.hashCode(), libraryFile3.hashCode());
+    assertNotEquals(libraryFile1, libraryFile2);
+    assertNotEquals(libraryFile1.hashCode(), libraryFile2.hashCode());
+    assertNotEquals(libraryFile1, null);
+    assertNotEquals(libraryFile1, "a:b");
+    assertEquals(libraryFile1, libraryFile3);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinatesTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -161,4 +163,22 @@ public class MavenCoordinatesTest {
         .build();
     assertThat(mavenCoordinates.getClassifier(), is(""));
   }
+  
+  @Test
+  public void testEquals() {
+    MavenCoordinates mavenCoordinates1 =
+        new MavenCoordinates.Builder().setGroupId("g").setArtifactId("a").setClassifier("").build();
+    MavenCoordinates mavenCoordinates2 = mavenCoordinates1.toBuilder().build();
+    MavenCoordinates mavenCoordinates3 = mavenCoordinates1.toBuilder().setVersion("1.9.3").build();
+    MavenCoordinates mavenCoordinates4 = mavenCoordinates1.toBuilder().setArtifactId("b").build();
+
+    assertEquals(mavenCoordinates1, mavenCoordinates2);
+    assertEquals(mavenCoordinates1, mavenCoordinates3);
+    assertEquals(mavenCoordinates1.hashCode(), mavenCoordinates3.hashCode());
+    assertNotEquals(mavenCoordinates1, mavenCoordinates4);
+    assertNotEquals(mavenCoordinates1.hashCode(), mavenCoordinates4.hashCode());
+    assertNotEquals(mavenCoordinates1, null);
+    assertNotEquals(mavenCoordinates1, "g:a:1.9.3");
+  }
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelpTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelpTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.repository;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import org.eclipse.core.runtime.IPath;
@@ -36,9 +35,6 @@ public class MavenHelpTest {
         .setVersion("1.0.0")
         .build();
     
-    when(artifact.getGroupId()).thenReturn("groupId");
-    when(artifact.getArtifactId()).thenReturn("artifactId");
-    when(artifact.getVersion()).thenReturn("1.0.0");
     IPath folder = MavenHelper.bundleStateBasedMavenFolder(artifact);
     assertTrue(folder.toString().endsWith(EXPECTED_DOWNLOAD_FOLDER));
   }
@@ -52,7 +48,6 @@ public class MavenHelpTest {
         .setVersion("LATEST")
         .build();
         
-        when(artifact.getVersion()).thenReturn("LATEST");
     MavenHelper.bundleStateBasedMavenFolder(artifact);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelpTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelpTest.java
@@ -22,20 +22,20 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import org.eclipse.core.runtime.IPath;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public class MavenHelpTest {
 
   private static final String EXPECTED_DOWNLOAD_FOLDER =
       ".metadata/.plugins/com.google.cloud.tools.eclipse.appengine.libraries/downloads/groupId/artifactId/1.0.0";
 
-  @Mock private MavenCoordinates artifact;
-
   @Test
   public void testBundleStateBasedMavenFolder_withSpecificVersion() {
+    MavenCoordinates artifact = new MavenCoordinates.Builder()
+        .setGroupId("groupId")
+        .setArtifactId("artifactId")
+        .setVersion("1.0.0")
+        .build();
+    
     when(artifact.getGroupId()).thenReturn("groupId");
     when(artifact.getArtifactId()).thenReturn("artifactId");
     when(artifact.getVersion()).thenReturn("1.0.0");
@@ -45,7 +45,14 @@ public class MavenHelpTest {
   
   @Test(expected = IllegalArgumentException.class)
   public void testBundleStateBasedMavenFolder_withLatestVersion() {
-    when(artifact.getVersion()).thenReturn("LATEST");
+    
+    MavenCoordinates artifact = new MavenCoordinates.Builder()
+        .setGroupId("groupId")
+        .setArtifactId("artifactId")
+        .setVersion("LATEST")
+        .build();
+        
+        when(artifact.getVersion()).thenReturn("LATEST");
     MavenHelper.bundleStateBasedMavenFolder(artifact);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
@@ -78,4 +78,23 @@ public class LibraryFile {
   void setExport(boolean export) {
     this.export = export;
   }
+  
+  /**
+   * Two LibraryFile objects are equal if and only if their Maven coordinates are equal.
+   * 
+   * @see MavenCoordinates#equals(Object)
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof LibraryFile)) {
+      return false;
+    }
+    LibraryFile other = (LibraryFile) o;
+    return other.mavenCoordinates.equals(mavenCoordinates);
+  }
+  
+  @Override
+  public int hashCode() {
+    return 37 * mavenCoordinates.hashCode() + 43;
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinates.java
@@ -20,7 +20,8 @@ import com.google.common.base.Preconditions;
 import java.text.MessageFormat;
 
 /**
- * Describes a Maven artifact.
+ * Describes a Maven artifact. MavenCoordinates objects are considered to be equal
+ * if and only if the group ID and artifact IDs are the same.
  */
 public final class MavenCoordinates {
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/MavenCoordinates.java
@@ -22,7 +22,7 @@ import java.text.MessageFormat;
 /**
  * Describes a Maven artifact.
  */
-public class MavenCoordinates {
+public final class MavenCoordinates {
 
   public static final String LATEST_VERSION = "LATEST";
   public static final String JAR_TYPE = "jar";
@@ -91,6 +91,26 @@ public class MavenCoordinates {
    */
   public String getArtifactId() {
     return artifactId;
+  }
+  
+  @Override 
+  public int hashCode() {
+    return (groupId + ":" + artifactId).hashCode();
+  }
+  
+  /**
+   * Two Maven coordinates are equal if and only if they have the same
+   * group ID and artifact ID. Type, classifier, version, and repo
+   * are deliberately not considered. 
+   */
+  @Override 
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof MavenCoordinates)) {
+      return false;
+    }
+    MavenCoordinates other = (MavenCoordinates) o;
+    return other.artifactId.equals(artifactId) 
+        && other.groupId.equals(groupId);
   }
 
   @Override


### PR DESCRIPTION
@briandealwis Looks like we're going to need this to avoid duping transitive dependencies. 

These methods quite deliberately do not consider all fields of their classes. 