### PR TITLE
Avoid NPEs when dealing with deleted projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
@@ -30,3 +30,5 @@ cloudsdk.not.configured=Could not run project because the Cloud SDK was not foun
 cloudsdk.out.of.date=Could not run project because the installed Cloud SDK is too old. \
  Run `gcloud components update` and try again.
  
+ deleted.project=Deleted project: {0}
+ 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerDelegate.java
@@ -106,6 +106,9 @@ public class LocalAppEngineServerDelegate extends ServerDelegate implements IURL
   IStatus checkProjectFacets(IModule[] toBeAdded) {
     if (toBeAdded != null) {
       for (IModule module : toBeAdded) {
+        if (!module.exists()) {
+          return StatusUtil.error(this, Messages.getString("deleted.project", module.getName())); //$NON-NLS-1$
+        }
         if (module.getProject() != null) {
           IStatus supportedFacets = FacetUtil.verifyFacets(module.getProject(), getServer());
           if (supportedFacets != null && !supportedFacets.isOK()) {
@@ -131,23 +134,33 @@ public class LocalAppEngineServerDelegate extends ServerDelegate implements IURL
     // verify that we do not have conflicting modules by service id
     Map<String, IModule> currentServiceIds = new HashMap<>();
     for (IModule module : current) {
-      String moduleServiceId = getServiceId(module);
-      if (currentServiceIds.containsKey(moduleServiceId)) {
-        // should never happen: we have a conflict within the already-defined modules
-        return StatusUtil.error(this, Messages.getString("SERVICE_CONFLICTS", //$NON-NLS-1$
-            module.getName(), currentServiceIds.get(moduleServiceId).getName(), moduleServiceId));
+      // ignore deleted modules / closed projects
+      if (module.exists()) {
+        String moduleServiceId = getServiceId(module);
+        if (currentServiceIds.containsKey(moduleServiceId)) {
+          // should never happen: we have a conflict within the already-defined modules
+          return StatusUtil.error(this, Messages.getString("SERVICE_CONFLICTS", //$NON-NLS-1$
+              module.getName(), currentServiceIds.get(moduleServiceId).getName(), moduleServiceId));
+        }
+        currentServiceIds.put(moduleServiceId, module);
       }
-      currentServiceIds.put(moduleServiceId, module);
     }
     if (toBeRemoved != null) {
       for (IModule module : toBeRemoved) {
-        String moduleServiceId = getServiceId(module);
-        // could verify that: serviceIds.containsKey(moduleServiceId)
-        currentServiceIds.remove(moduleServiceId);
+        // always ok to remove deleted modules / closed projects
+        if (module.exists()) {
+          String moduleServiceId = getServiceId(module);
+          // could verify that: serviceIds.containsKey(moduleServiceId)
+          currentServiceIds.remove(moduleServiceId);
+        }
       }
     }
     if (toBeAdded != null) {
       for (IModule module : toBeAdded) {
+        if (!module.exists()) {
+          return StatusUtil.error(this, Messages.getString("deleted.project", //$NON-NLS-1$
+              module.getName()));
+        }
         if (currentServiceIds.containsValue(module)) {
           // skip modules that are already present
           continue;


### PR DESCRIPTION
Deleted / closed projects may still be referenced in server definitions, and selecting the modules may trigger calls into our server delegate to see if they can be removed.  This patch adds some guards to `LocalAppEngineServerDelegate` to check for whether the given module exists.

Fixes #2344 