### PR TITLE
Fix height issue of App Engine wizard error pages

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/MissingComponentPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/MissingComponentPage.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 
 /**
@@ -50,13 +49,8 @@ public class MissingComponentPage extends WizardPage {
   @Override
   public void createControl(Composite parent) {
     Composite container = new Composite(parent, SWT.NONE);
-    GridLayoutFactory.swtDefaults().numColumns(1).applyTo(container);
-
-    GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
-    gridData.widthHint = parent.getSize().x;
 
     StyledText styledText = new StyledText(container, SWT.MULTI | SWT.READ_ONLY | SWT.WRAP);
-    styledText.setLayoutData(gridData);
     styledText.setText(message);
     styledText.setBackground(container.getBackground());
     styledText.setCaret(null /* hide caret */);
@@ -74,6 +68,7 @@ public class MissingComponentPage extends WizardPage {
     setControl(container);
     setPageComplete(false);
     Dialog.applyDialogFont(container);
+    GridLayoutFactory.swtDefaults().generateLayout(container);
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/messages.properties
@@ -7,7 +7,7 @@ fix.cloud.sdk.location=Cannot create an App Engine Eclipse project \
  and set the location in the Google Cloud Platform preferences.
 fix.cloud.sdk.version=Cannot create an App Engine Eclipse project \
  because the Cloud SDK is too old. \
- Update it by running `gcloud components update` at the command line.
+ Update it by running ''gcloud components update'' at the command line.
 cloud.sdk.missing=Cloud SDK missing
 cloud.sdk.not.installed=Could not find the Google Cloud SDK
 cloud.sdk.out.of.date=Cloud SDK too old


### PR DESCRIPTION
Fixes #2349. `generateLayout()` fills in a reasonable layout data for child controls that don't have a data.