### PR TITLE
Add App Engine flex JAR facet

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexStagingDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexStagingDelegateTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class FlexStagingDelegateTest {
 
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator().withFacetVersions(
-      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineFlexFacet.FACET_VERSION);
+      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineFlexWarFacet.FACET_VERSION);
 
   private IProject project;
   private IPath safeWorkDirectory;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.BasePluginXmlTest;
 import org.junit.Assert;
@@ -51,7 +51,7 @@ public class PluginXmlTest extends BasePluginXmlTest {
     Element standardAdapt = (Element) adapts.item(0);
     verifyAdapt(standardAdapt, AppEngineStandardFacet.ID);
     Element flexAdapt = (Element) adapts.item(1);
-    verifyAdapt(flexAdapt, AppEngineFlexFacet.ID);
+    verifyAdapt(flexAdapt, AppEngineFlexWarFacet.ID);
   }
 
   private void verifyAdapt(Element adapt, String attributeValue) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/DeployPropertyPageForFlexProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/DeployPropertyPageForFlexProjectTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployPropertyPageTest;
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
@@ -29,7 +29,7 @@ public class DeployPropertyPageForFlexProjectTest
 
   @Rule
   public TestProjectCreator flexProjectCreator = new TestProjectCreator().withFacetVersions(
-      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineFlexFacet.FACET_VERSION);
+      JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineFlexWarFacet.FACET_VERSION);
 
   @Override
   protected IProject getProject() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanelTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.AppYamlValidator;
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.projectselector.ProjectRepository;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
@@ -55,7 +55,7 @@ public class FlexDeployPreferencesPanelTest {
 
   @Rule public ShellTestResource shellResource = new ShellTestResource();
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator().withFacetVersions(
-      JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31, AppEngineFlexFacet.FACET_VERSION);
+      JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31, AppEngineFlexWarFacet.FACET_VERSION);
 
   private IProject project;
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployPropertyPage.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.deploy.ui;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible.FlexDeployPreferencesPanel;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.standard.StandardDeployPreferencesPanel;
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
@@ -159,8 +159,8 @@ public class DeployPropertyPage extends PropertyPage {
       createStandardPanelIfNeeded();
       showPanel(standardPreferencesPanel);
     } else if (facetedProject != null
-        && ProjectFacetsManager.isProjectFacetDefined(AppEngineFlexFacet.ID)
-        && AppEngineFlexFacet.hasFacet(facetedProject)) {
+        && ProjectFacetsManager.isProjectFacetDefined(AppEngineFlexWarFacet.ID)
+        && AppEngineFlexWarFacet.hasFacet(facetedProject)) {
       createFlexPanelIfNeeded();
       showPanel(flexPreferencesPanel);
     } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetPresetsTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFacetPresetsTest.java
@@ -43,13 +43,23 @@ public class AppEngineFacetPresetsTest {
   }
 
   @Test
-  public void appEngineFlexiblePresetExists() {
+  public void appEngineFlexibleWarPresetExists() {
     IPreset preset = ProjectFacetsManager
         .getPreset("com.google.cloud.tools.eclipse.appengine.flexible.war.preset");
     assertNotNull(preset);
     assertEquals("App Engine flexible environment with Java 8, Servlet 3.1", preset.getLabel());
     assertThat(preset.getProjectFacets(), hasItem(JavaFacet.VERSION_1_8));
     assertThat(preset.getProjectFacets(), hasItem(WebFacetUtils.WEB_31));
-    assertThat(preset.getProjectFacets(), hasItem(AppEngineFlexFacet.FACET_VERSION));
+    assertThat(preset.getProjectFacets(), hasItem(AppEngineFlexWarFacet.FACET_VERSION));
+  }
+
+  @Test
+  public void appEngineFlexibleJarPresetExists() {
+    IPreset preset = ProjectFacetsManager
+        .getPreset("com.google.cloud.tools.eclipse.appengine.flexible.jar.preset");
+    assertNotNull(preset);
+    assertEquals("App Engine flexible environment with Java 8, runnable JAR", preset.getLabel());
+    assertThat(preset.getProjectFacets(), hasItem(JavaFacet.VERSION_1_8));
+    assertThat(preset.getProjectFacets(), hasItem(AppEngineFlexJarFacet.FACET_VERSION));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexJarFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexJarFacetTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.facets;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.eclipse.wst.common.project.facet.core.IConstraint;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppEngineFlexJarFacetTest {
+  @Mock private IFacetedProject facetedProject;
+
+  @Test
+  public void testFlexFacetExists() {
+    Assert.assertEquals("com.google.cloud.tools.eclipse.appengine.facets.flex.jar",
+        AppEngineFlexJarFacet.ID);
+    Assert.assertEquals("1", AppEngineFlexJarFacet.VERSION);
+    Assert.assertTrue(ProjectFacetsManager.isProjectFacetDefined(AppEngineFlexJarFacet.ID));
+    Assert.assertEquals(AppEngineFlexJarFacet.ID, AppEngineFlexJarFacet.FACET.getId());
+    Assert.assertEquals(AppEngineFlexJarFacet.VERSION,
+        AppEngineFlexJarFacet.FACET_VERSION.getVersionString());
+  }
+
+  @Test
+  public void testHasAppEngineFacet_withFacet() {
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexJarFacet.ID);
+    when(facetedProject.hasProjectFacet(projectFacet)).thenReturn(true);
+
+    Assert.assertTrue(AppEngineFlexJarFacet.hasFacet(facetedProject));
+  }
+
+  @Test
+  public void testHasAppEngineFacet_withoutFacet() {
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexJarFacet.ID);
+    when(facetedProject.hasProjectFacet(projectFacet)).thenReturn(false);
+
+    Assert.assertFalse(AppEngineFlexJarFacet.hasFacet(facetedProject));
+  }
+
+  @Test
+  public void testFacetLabel() {
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexJarFacet.ID);
+    Assert.assertEquals("App Engine Java Flexible Environment (JAR)", projectFacet.getLabel());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava7() {
+    IConstraint constraint = AppEngineFlexJarFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_okWithJava8() {
+    IConstraint constraint = AppEngineFlexJarFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8));
+    Assert.assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithNoJava() {
+    IConstraint constraint = AppEngineFlexJarFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Collections.<IProjectFacetVersion>emptyList());
+    Assert.assertFalse(result.isOK());
+  }
+
+  @Test
+  public void testInstallConstraints_notOkWithServlet() {
+    IConstraint constraint = AppEngineFlexJarFacet.FACET_VERSION.getConstraint();
+    IStatus result = constraint.check(Arrays.asList(WebFacetUtils.WEB_31));
+    Assert.assertFalse(result.isOK());
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacetTest.java
@@ -33,102 +33,102 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AppEngineFlexFacetTest {
+public class AppEngineFlexWarFacetTest {
   @Mock private IFacetedProject facetedProject;
 
   @Test
   public void testFlexFacetExists() {
     Assert.assertEquals("com.google.cloud.tools.eclipse.appengine.facets.flex",
-        AppEngineFlexFacet.ID);
-    Assert.assertEquals("1", AppEngineFlexFacet.VERSION);
+        AppEngineFlexWarFacet.ID);
+    Assert.assertEquals("1", AppEngineFlexWarFacet.VERSION);
     Assert.assertTrue(
-        ProjectFacetsManager.isProjectFacetDefined(AppEngineFlexFacet.ID));
-    Assert.assertEquals(AppEngineFlexFacet.ID, AppEngineFlexFacet.FACET.getId());
-    Assert.assertEquals(AppEngineFlexFacet.VERSION,
-        AppEngineFlexFacet.FACET_VERSION.getVersionString());
+        ProjectFacetsManager.isProjectFacetDefined(AppEngineFlexWarFacet.ID));
+    Assert.assertEquals(AppEngineFlexWarFacet.ID, AppEngineFlexWarFacet.FACET.getId());
+    Assert.assertEquals(AppEngineFlexWarFacet.VERSION,
+        AppEngineFlexWarFacet.FACET_VERSION.getVersionString());
   }
 
   @Test
   public void testHasAppEngineFacet_withFacet() {
-    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
     when(facetedProject.hasProjectFacet(projectFacet)).thenReturn(true);
 
-    Assert.assertTrue(AppEngineFlexFacet.hasFacet(facetedProject));
+    Assert.assertTrue(AppEngineFlexWarFacet.hasFacet(facetedProject));
   }
 
   @Test
   public void testHasAppEngineFacet_withoutFacet() {
-    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
     when(facetedProject.hasProjectFacet(projectFacet)).thenReturn(false);
 
-    Assert.assertFalse(AppEngineFlexFacet.hasFacet(facetedProject));
+    Assert.assertFalse(AppEngineFlexWarFacet.hasFacet(facetedProject));
   }
 
   @Test
   public void testFacetLabel() {
-    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
+    IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
     Assert.assertEquals("App Engine Java Flexible Environment", projectFacet.getLabel());
   }
 
   @Test
   public void testInstallConstraints_okWithJava7Servlet25() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava7Servlet30() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_30));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava7Servlet31() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_31));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava8Servlet25() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_25));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava8Servlet30() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_30));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_okWithJava8Servlet31() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31));
     Assert.assertTrue(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_notOkWithNoJava() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(WebFacetUtils.WEB_31));
     Assert.assertFalse(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_notOkWithNoServlet() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8));
     Assert.assertFalse(result.isOK());
   }
 
   @Test
   public void testInstallConstraints_notOkWithServlet24() {
-    IConstraint constraint = AppEngineFlexFacet.FACET_VERSION.getConstraint();
+    IConstraint constraint = AppEngineFlexWarFacet.FACET_VERSION.getConstraint();
     IStatus result = constraint.check(Arrays.asList(JavaFacet.VERSION_1_8, WebFacetUtils.WEB_24));
     Assert.assertFalse(result.isOK());
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacetTest.java
@@ -67,7 +67,7 @@ public class AppEngineFlexWarFacetTest {
   @Test
   public void testFacetLabel() {
     IProjectFacet projectFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
-    Assert.assertEquals("App Engine Java Flexible Environment", projectFacet.getLabel());
+    Assert.assertEquals("App Engine Java Flexible Environment (WAR)", projectFacet.getLabel());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegateTest.java
@@ -40,13 +40,13 @@ public class FlexFacetInstallDelegateTest {
     IProject project = projectCreator.getProject();
 
     IProgressMonitor monitor = new NullProgressMonitor();
-    IProjectFacet appEngineFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
+    IProjectFacet appEngineFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
     IProjectFacetVersion appEngineFacetVersion =
-        appEngineFacet.getVersion(AppEngineFlexFacet.VERSION);
+        appEngineFacet.getVersion(AppEngineFlexWarFacet.VERSION);
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     facetedProject.installProjectFacet(appEngineFacetVersion, null /* config */, monitor);
 
-    Assert.assertTrue(AppEngineFlexFacet.hasFacet(facetedProject));
+    Assert.assertTrue(AppEngineFlexWarFacet.hasFacet(facetedProject));
     Assert.assertTrue(project.getFile("src/main/appengine/app.yaml").exists());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
@@ -2,8 +2,10 @@ google = Google
 Bundle-Vendor = Google Inc.
 Bundle-Name = Cloud Tools for Eclipse Facets
 
-flexFacetName = App Engine Java Flexible Environment
-flexFacetDescription = Supply App Engine flexible environment functionality
+flexWarFacetName = App Engine Java Flexible Environment (WAR)
+flexWarFacetDescription = Supply App Engine flexible environment functionality for WAR application
+flexJarFacetName = App Engine Java Flexible Environment (JAR)
+flexJarFacetDescription = Supply App Engine flexible environment functionality for JAR application
 
 standardFacetName = App Engine Java Standard Environment
 standardFacetDescription = Supply App Engine standard environment functionality
@@ -14,3 +16,4 @@ convertToAppEngineStandardCommandName = Convert to App Engine Standard Project
 
 appengine.standard.jre7.preset = App Engine standard environment with Java 7, Servlet 2.5
 appengine.flexible.war.preset = App Engine flexible environment with Java 8, Servlet 3.1
+appengine.flexible.war.preset = App Engine flexible environment with Java 8, runnable JAR

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.properties
@@ -16,4 +16,4 @@ convertToAppEngineStandardCommandName = Convert to App Engine Standard Project
 
 appengine.standard.jre7.preset = App Engine standard environment with Java 7, Servlet 2.5
 appengine.flexible.war.preset = App Engine flexible environment with Java 8, Servlet 3.1
-appengine.flexible.war.preset = App Engine flexible environment with Java 8, runnable JAR
+appengine.flexible.jar.preset = App Engine flexible environment with Java 8, runnable JAR

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -137,16 +137,17 @@
   </extension>
   <!-- end App Engine standard facet -->
 
-  <!-- begin App Engine flex facet -->
+  <!-- begin App Engine flex WAR facet -->
   <extension point="org.eclipse.wst.common.project.facet.core.facets">
     <project-facet id="com.google.cloud.tools.eclipse.appengine.facets.flex">
-      <label>%flexFacetName</label>
-      <description>%flexFacetDescription</description>
+      <label>%flexWarFacetName</label>
+      <description>%flexWarFacetDescription</description>
     </project-facet>
     <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.flex" version="1">
       <constraint>
         <and>
           <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.standard"/>
+          <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.flex.jar"/>
           <requires facet="jst.web"
                     version="2.5,3.0,3.1">
           </requires>
@@ -180,19 +181,71 @@
 
   <extension point="org.eclipse.wst.common.project.facet.core.facets">
     <action
-      id="com.google.cloud.tools.eclipse.appengine.facets.flex.install.action"
-      facet="com.google.cloud.tools.eclipse.appengine.facets.flex"
-      type="INSTALL">
+        id="com.google.cloud.tools.eclipse.appengine.facets.flex.install.action"
+        facet="com.google.cloud.tools.eclipse.appengine.facets.flex"
+        type="INSTALL">
       <delegate class="com.google.cloud.tools.eclipse.appengine.facets.FlexFacetInstallDelegate"/>
     </action>
     <action
-      id="com.google.cloud.tools.eclipse.appengine.facets.flex.uninstall.action"
-      facet="com.google.cloud.tools.eclipse.appengine.facets.flex"
-      type="UNINSTALL">
+        id="com.google.cloud.tools.eclipse.appengine.facets.flex.uninstall.action"
+        facet="com.google.cloud.tools.eclipse.appengine.facets.flex"
+        type="UNINSTALL">
       <delegate class="com.google.cloud.tools.eclipse.appengine.facets.FlexFacetUninstallDelegate"/>
     </action>
   </extension>
-  <!-- end App Engine flex facet -->
+  <!-- end App Engine flex WAR facet -->
+
+  <!-- begin App Engine flex JAR facet -->
+  <extension point="org.eclipse.wst.common.project.facet.core.facets">
+    <project-facet id="com.google.cloud.tools.eclipse.appengine.facets.flex.jar">
+      <label>%flexJarFacetName</label>
+      <description>%flexJarFacetDescription</description>
+    </project-facet>
+    <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.flex.jar" version="1">
+      <constraint>
+        <and>
+          <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.standard"/>
+          <conflicts facet="com.google.cloud.tools.eclipse.appengine.facets.flex"/>
+          <conflicts facet="jst.web"/>
+          <requires facet="java"
+                    version="1.7,1.8">
+          </requires>
+        </and>
+      </constraint>
+    </project-facet-version>
+  </extension>
+
+  <extension
+        point="org.eclipse.wst.common.project.facet.core.presets">
+     <static-preset
+           id="com.google.cloud.tools.eclipse.appengine.flexible.jar.preset">
+        <label>%appengine.flexible.jar.preset</label>
+        <facet
+              id="com.google.cloud.tools.eclipse.appengine.facets.flex.jar"
+              version="1">
+        </facet>
+        <facet
+              id="java"
+              version="1.8">
+        </facet>
+     </static-preset>
+  </extension>
+
+  <extension point="org.eclipse.wst.common.project.facet.core.facets">
+    <action
+        id="com.google.cloud.tools.eclipse.appengine.facets.flex.jar.install.action"
+        facet="com.google.cloud.tools.eclipse.appengine.facets.flex.jar"
+        type="INSTALL">
+      <delegate class="com.google.cloud.tools.eclipse.appengine.facets.FlexFacetInstallDelegate"/>
+    </action>
+    <action
+        id="com.google.cloud.tools.eclipse.appengine.facets.flex.jar.uninstall.action"
+        facet="com.google.cloud.tools.eclipse.appengine.facets.flex.jar"
+        type="UNINSTALL">
+      <delegate class="com.google.cloud.tools.eclipse.appengine.facets.FlexFacetUninstallDelegate"/>
+    </action>
+  </extension>
+  <!-- end App Engine flex JAR facet -->
 
   <extension point="org.eclipse.core.contenttype.contentTypes">
     <content-type id="yaml"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexJarFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexJarFacet.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.facets;
+
+import com.google.common.base.Preconditions;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.IProjectFacet;
+import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
+
+public class AppEngineFlexJarFacet {
+  public static final String ID = "com.google.cloud.tools.eclipse.appengine.facets.flex.jar";
+  public static final String VERSION = "1";
+
+  public static final IProjectFacet FACET = ProjectFacetsManager.getProjectFacet(ID);
+  public static final IProjectFacetVersion FACET_VERSION = FACET.getVersion(VERSION);
+
+  /**
+   * Returns true if project has the App Engine Flex JAR facet and false otherwise.
+   *
+   * @param project should not be null
+   * @return true if project has the App Engine Flex JAR facet and false otherwise
+   */
+  public static boolean hasFacet(IFacetedProject project) {
+    Preconditions.checkNotNull(project);
+    return project.hasProjectFacet(FACET);
+  }
+
+  /**
+   * Installs the App Engine Flexible JAR facet if {@code facetedProject} does not have it already.
+   *
+   * @param facetedProject the faceted project receiving the App Engine facet
+   * @param installDependentFacets true if the facets required by the App Engine facet should be
+   *        installed, false otherwise
+   * @param monitor the progress monitor
+   * @throws CoreException if anything goes wrong during install
+   */
+  public static void installAppEngineFacet(IFacetedProject facetedProject,
+      boolean installDependentFacets, IProgressMonitor monitor) throws CoreException {
+    if (facetedProject.hasProjectFacet(FACET)) {
+      return;
+    }
+
+    FacetUtil facetUtil = new FacetUtil(facetedProject);
+    if (installDependentFacets) {
+      facetUtil.addJavaFacetToBatch(JavaFacet.VERSION_1_8);
+    }
+
+    facetUtil.addFacetToBatch(FACET_VERSION, null /* config */);
+    facetUtil.install(monitor);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineFlexWarFacet.java
@@ -25,7 +25,7 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacet;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
-public class AppEngineFlexFacet {
+public class AppEngineFlexWarFacet {
   public static final String ID = "com.google.cloud.tools.eclipse.appengine.facets.flex";
   public static final String VERSION = "1";
 
@@ -33,10 +33,10 @@ public class AppEngineFlexFacet {
   public static final IProjectFacetVersion FACET_VERSION = FACET.getVersion(VERSION);
 
   /**
-   * Returns true if project has the App Engine Flex facet and false otherwise.
+   * Returns true if project has the App Engine Flex WAR facet and false otherwise.
    *
    * @param project should not be null
-   * @return true if project has the App Engine Flex facet and false otherwise
+   * @return true if project has the App Engine Flex WAR facet and false otherwise
    */
   public static boolean hasFacet(IFacetedProject project) {
     Preconditions.checkNotNull(project);
@@ -44,7 +44,7 @@ public class AppEngineFlexFacet {
   }
 
   /**
-   * Installs the App Engine Flexible facet if {@code facetedProject} does not have it already.
+   * Installs the App Engine Flexible WAR facet if {@code facetedProject} does not have it already.
    *
    * @param facetedProject the faceted project receiving the App Engine facet
    * @param installDependentFacets true if the facets required by the App Engine facet should be

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
@@ -31,7 +31,8 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
 /**
- * Applies to both the WAR facet and the JAR facet.
+ * Creates {@code src/main/appengine/app.yaml} if not present. Applies to both the WAR facet and
+ * the JAR facet.
  */
 public class FlexFacetInstallDelegate extends AppEngineFacetInstallDelegate {
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetInstallDelegate.java
@@ -30,6 +30,9 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
+/**
+ * Applies to both the WAR facet and the JAR facet.
+ */
 public class FlexFacetInstallDelegate extends AppEngineFacetInstallDelegate {
   @Override
   public void execute(IProject project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetUninstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetUninstallDelegate.java
@@ -23,7 +23,7 @@ import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
 /**
- * Applies to both the WAR facet and the JAR facet.
+ * Applies to both the WAR facet and the JAR facet. Does nothing for now.
  */
 public class FlexFacetUninstallDelegate implements IDelegate {
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetUninstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FlexFacetUninstallDelegate.java
@@ -22,12 +22,15 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 
+/**
+ * Applies to both the WAR facet and the JAR facet.
+ */
 public class FlexFacetUninstallDelegate implements IDelegate {
 
   @Override
   public void execute(IProject project, IProjectFacetVersion facetVersion, Object config, IProgressMonitor monitor)
       throws CoreException {
-    
+
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.flex;
 
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
@@ -116,9 +116,9 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
     facetUtil.addJavaFacetToBatch(JavaFacet.VERSION_1_8);
     facetUtil.addWebFacetToBatch(WebFacetUtils.WEB_31);
 
-    IProjectFacet appEngineFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexFacet.ID);
+    IProjectFacet appEngineFacet = ProjectFacetsManager.getProjectFacet(AppEngineFlexWarFacet.ID);
     IProjectFacetVersion appEngineFacetVersion =
-        appEngineFacet.getVersion(AppEngineFlexFacet.VERSION);
+        appEngineFacet.getVersion(AppEngineFlexWarFacet.VERSION);
     facetUtil.addFacetToBatch(appEngineFacetVersion, null /* config */);
     facetUtil.install(subMonitor.newChild(50));
   }


### PR DESCRIPTION
Fixes #2104.

_I decided to fork a feature branch while developing flex JAR support. This PR is to be merged to the branch `gae-flex-jar-feature`. I will regularly sync the branch with `master`, which I think will be a trivial task most of the time._

This PR introduces a new App Engine flex JAR facet. Consequently, the current flex facet will be renamed to a WAR facet.

@patflynn and @etanshaul said a few times that there will be a benefit when not having separate facets for the particular use-case where a Spring Boot user changes the packaging option in `pom.xml` from `jar` to `war` (which doesn't do any change to source but makes Spring Boot magically produce a WAR artifact from a plain old Java application). However, as of now, our current facet (WAR) in CT4E is directly coupled with WTP, which forces the WAR source structure (e.g.., having `WEB-INF/web.xml`, WAR file assembly by WTP, etc), so it is not possible to reuse to the current WAR facet, unless we overturn the current CT4E flex codebase.

![selection_004](https://user-images.githubusercontent.com/10523105/30215909-669cb73e-947f-11e7-846c-4dde6d1ac651.png)

![selection_006](https://user-images.githubusercontent.com/10523105/30215910-684c56b6-947f-11e7-904e-b46a978d6354.png)

![selection_007](https://user-images.githubusercontent.com/10523105/30215915-6b7e53b6-947f-11e7-94fb-f876fab32831.png)
