### PR TITLE
Make RunOptionsDefaultsComponent able to be partially filled

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
@@ -20,8 +20,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,7 +49,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Display;
@@ -68,6 +74,8 @@ public class RunOptionsDefaultsComponentTest {
   @Mock private MessageTarget messageTarget;
   @Mock private IGoogleLoginService loginService;
   @Mock private IGoogleApiFactory apiFactory;
+  @Mock
+  private WizardPage page;
 
   private RunOptionsDefaultsComponent component;
   private Shell shell;
@@ -80,24 +88,26 @@ public class RunOptionsDefaultsComponentTest {
 
   @Before
   public void setUp() throws IOException {
-    Account account1 = mock(Account.class);
-    Account account2 = mock(Account.class);
-    Credential credential1 = mock(Credential.class);
-    Credential credential2 = mock(Credential.class);
-
+    Account account1 = mock(Account.class, "alice@example.com");
+    Credential credential1 = mock(Credential.class, "alice@example.com");
     when(account1.getEmail()).thenReturn("alice@example.com");
-    when(account2.getEmail()).thenReturn("bob@example.com");
     when(account1.getOAuth2Credential()).thenReturn(credential1);
+    mockStorageApiBucketList(credential1, "project", "alice-bucket-1", "alice-bucket-2");
+
+    Account account2 = mock(Account.class, "bob@example.com");
+    Credential credential2 = mock(Credential.class, "bob@example.com");
+    when(account2.getEmail()).thenReturn("bob@example.com");
     when(account2.getOAuth2Credential()).thenReturn(credential2);
+    mockStorageApiBucketList(credential2, "project", "bob-bucket");
 
     when(loginService.getAccounts()).thenReturn(Sets.newHashSet(account1, account2));
 
-    mockStorageApiBucketList(credential1, "alice-bucket-1", "alice-bucket-2");
-    mockStorageApiBucketList(credential2, "bob-bucket");
+    doCallRealMethod().when(page).setPageComplete(anyBoolean());
+    doCallRealMethod().when(page).isPageComplete();
 
     shell = shellResource.getShell();
     component = new RunOptionsDefaultsComponent(
-        shell, 3, messageTarget, preferences, null, loginService, apiFactory);
+        shell, 3, messageTarget, preferences, page, false /* partial */, loginService, apiFactory);
     selector = CompositeUtil.findControl(shell, AccountSelector.class);
     projectID =
         CompositeUtil.findControlAfterLabel(shell, Text.class, "Cloud Platform &project ID:");
@@ -105,8 +115,9 @@ public class RunOptionsDefaultsComponentTest {
         CompositeUtil.findControlAfterLabel(shell, Combo.class, "Cloud Storage staging &location:");
     createButton = CompositeUtil.findControl(shell, Button.class);
   }
-
-  private void mockStorageApiBucketList(Credential credential, String... bucketNames)
+  
+  private void mockStorageApiBucketList(Credential credential, String projectId,
+      String... bucketNames)
       throws IOException {
     Storage storageApi = mock(Storage.class);
     Storage.Buckets bucketsApi = mock(Storage.Buckets.class);
@@ -114,10 +125,11 @@ public class RunOptionsDefaultsComponentTest {
     Buckets buckets = new Buckets();
     List<Bucket> bucketList = new ArrayList<>();
 
-    when(apiFactory.newStorageApi(credential)).thenReturn(storageApi);
-    when(storageApi.buckets()).thenReturn(bucketsApi);
-    when(bucketsApi.list(anyString())).thenReturn(listApi);
-    when(listApi.execute()).thenReturn(buckets);
+    doReturn(storageApi).when(apiFactory).newStorageApi(credential);
+    doReturn(bucketsApi).when(storageApi).buckets();
+    doThrow(new IOException("not found")).when(bucketsApi).list(anyString());
+    doReturn(listApi).when(bucketsApi).list(eq(projectId));
+    doReturn(buckets).when(listApi).execute();
 
     Storage.Buckets.Get exceptionGet = mock(Storage.Buckets.Get.class);
     when(bucketsApi.get(anyString())).thenReturn(exceptionGet);
@@ -206,13 +218,11 @@ public class RunOptionsDefaultsComponentTest {
   }
 
   @Test
-  public void testEnablement_existingStagingLocation() throws InterruptedException {
+  public void testEnablement_nonexistingProject() throws InterruptedException {
     selector.selectAccount("alice@example.com");
-    component.setCloudProjectText("project");
-    component.setStagingLocationText("alice-bucket-1");
-    component.startStagingLocationCheck(0); // force right now
-    ListenableFuture<VerifyStagingLocationResult> verifyResult =
-        component.verifyStagingLocationJob.getVerifyResult();
+    component.setCloudProjectText("doesnotexist");
+    ListenableFuture<SortedSet<String>> verifyResult =
+        component.fetchStagingLocationsJob.getStagingLocations();
     int i = 0;
     do {
       while (Display.getCurrent().readAndDispatch()) {
@@ -224,7 +234,33 @@ public class RunOptionsDefaultsComponentTest {
     assertNotNull(selector.getSelectedCredential());
     assertTrue(projectID.isEnabled());
     assertTrue(stagingLocations.isEnabled());
+    assertFalse(page.isPageComplete());
+  }
+
+  @Test
+  public void testEnablement_existingStagingLocation() throws InterruptedException {
+    selector.selectAccount("alice@example.com");
+    component.setCloudProjectText("project");
+    component.updateStagingLocations("project", 0);
+    component.setStagingLocationText("alice-bucket-1");
+    component.startStagingLocationCheck(0); // force right now
+    ListenableFuture<SortedSet<String>> fetchResult =
+        component.fetchStagingLocationsJob.getStagingLocations();
+    ListenableFuture<VerifyStagingLocationResult> verifyResult =
+        component.verifyStagingLocationJob.getVerifyResult();
+    int i = 0;
+    do {
+      while (Display.getCurrent().readAndDispatch()) {
+        // spin
+      }
+      Thread.sleep(50);
+    } while (i++ < 200 && !fetchResult.isDone() && !verifyResult.isDone());
+    assertTrue(selector.isEnabled());
+    assertNotNull(selector.getSelectedCredential());
+    assertTrue(projectID.isEnabled());
+    assertTrue(stagingLocations.isEnabled());
     assertFalse(createButton.isEnabled());
+    assertTrue(page.isPageComplete());
   }
 
   @Test
@@ -249,6 +285,7 @@ public class RunOptionsDefaultsComponentTest {
     assertTrue(projectID.isEnabled());
     assertTrue(stagingLocations.isEnabled());
     assertTrue(createButton.isEnabled());
+    assertFalse(page.isPageComplete());
   }
 
   @Test
@@ -262,8 +299,8 @@ public class RunOptionsDefaultsComponentTest {
   @Test
   public void testAccountSelector_loadBucketCombo() throws InterruptedException {
     selector.selectAccount("alice@example.com");
-    component.setCloudProjectText("some-gcp-project-id");
-    component.updateStagingLocations("some-gcp-project-id", 0);
+    component.setCloudProjectText("project");
+    component.updateStagingLocations("project", 0);
 
     assertStagingLocationCombo("gs://alice-bucket-1", "gs://alice-bucket-2");
 
@@ -293,5 +330,34 @@ public class RunOptionsDefaultsComponentTest {
   public void testBucketNameStatus_gcsUrlPathWithObjectIsOk() {
     component.setStagingLocationText("gs://bucket/object");
     verify(messageTarget, never()).setError(anyString());
+  }
+
+  @Test
+  public void testPartialValidity_allEmpty() {
+    component = new RunOptionsDefaultsComponent(shell, 3, messageTarget, preferences, page,
+        true /* partial */, loginService, apiFactory);
+    assertTrue("should be complete when totally empty", page.isPageComplete());
+  }
+  
+  @Test
+  public void testPartialValidity_account() {
+    testPartialValidity_allEmpty();      
+    component.selectAccount("alice@example.com");
+    assertTrue("should be complete with account", page.isPageComplete());
+  }
+  
+  @Test
+  public void testPartialValidity_account_project() throws InterruptedException {
+    testPartialValidity_account();
+    component.setCloudProjectText("project");
+    int i = 0;
+    do {
+      while (Display.getCurrent().readAndDispatch()) {
+        // spin
+      }
+      Thread.sleep(50);
+    } while (i++ < 200 && !page.isPageComplete());
+
+    assertTrue("should be complete with account and project", page.isPageComplete());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponentTest.java
@@ -107,7 +107,8 @@ public class RunOptionsDefaultsComponentTest {
 
     shell = shellResource.getShell();
     component = new RunOptionsDefaultsComponent(
-        shell, 3, messageTarget, preferences, page, false /* partial */, loginService, apiFactory);
+        shell, 3, messageTarget, preferences, page, false /* allowIncomplete */, loginService,
+        apiFactory);
     selector = CompositeUtil.findControl(shell, AccountSelector.class);
     projectID =
         CompositeUtil.findControlAfterLabel(shell, Text.class, "Cloud Platform &project ID:");
@@ -335,7 +336,7 @@ public class RunOptionsDefaultsComponentTest {
   @Test
   public void testPartialValidity_allEmpty() {
     component = new RunOptionsDefaultsComponent(shell, 3, messageTarget, preferences, page,
-        true /* partial */, loginService, apiFactory);
+        true /* allowIncomplete */, loginService, apiFactory);
     assertTrue("should be complete when totally empty", page.isPageComplete());
   }
   

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
@@ -47,7 +47,8 @@ public class NewDataflowProjectWizardDefaultRunOptionsPage extends WizardPage {
     int numColumns = 3;
     composite.setLayout(new GridLayout(numColumns, false));
     runOptionsDefaultsComponent = new RunOptionsDefaultsComponent(
-        composite, numColumns, new DialogPageMessageTarget(this), prefs, this, true /* partial */);
+        composite, numColumns, new DialogPageMessageTarget(this), prefs, this,
+        true /* allowIncomplete */);
 
     setControl(runOptionsDefaultsComponent.getControl());
   }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
@@ -47,7 +47,7 @@ public class NewDataflowProjectWizardDefaultRunOptionsPage extends WizardPage {
     int numColumns = 3;
     composite.setLayout(new GridLayout(numColumns, false));
     runOptionsDefaultsComponent = new RunOptionsDefaultsComponent(
-        composite, numColumns, new DialogPageMessageTarget(this), prefs, this);
+        composite, numColumns, new DialogPageMessageTarget(this), prefs, this, true /* partial */);
 
     setControl(runOptionsDefaultsComponent.getControl());
   }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -86,6 +86,11 @@ public class RunOptionsDefaultsComponent {
   private final MessageTarget messageTarget;
   private final Composite target;
   
+  /**
+   * If true, then this component is allowed to be partially-complete.
+   */
+  private final boolean partial;
+
   private final AccountSelector accountSelector;
   private final Text projectInput;
   private final Combo stagingLocationInput;
@@ -93,25 +98,27 @@ public class RunOptionsDefaultsComponent {
   private SelectFirstMatchingPrefixListener completionListener;
   private ControlDecoration stagingLocationResults;
 
-  private FetchStagingLocationsJob fetchStagingLocationsJob;
+  @VisibleForTesting
+  FetchStagingLocationsJob fetchStagingLocationsJob;
   @VisibleForTesting
   VerifyStagingLocationJob verifyStagingLocationJob;
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
       DataflowPreferences preferences) {
-    this(target, columns, messageTarget, preferences, null);
+    this(target, columns, messageTarget, preferences, null, false);
   }
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
-      DataflowPreferences preferences, WizardPage page) {
-    this(target, columns, messageTarget, preferences, page,
+      DataflowPreferences preferences, WizardPage page, boolean partial) {
+    this(target, columns, messageTarget, preferences, page, partial,
         PlatformUI.getWorkbench().getService(IGoogleLoginService.class),
         PlatformUI.getWorkbench().getService(IGoogleApiFactory.class));
   }
 
   @VisibleForTesting
   RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
-      DataflowPreferences preferences, WizardPage page, IGoogleLoginService loginService,
+      DataflowPreferences preferences, WizardPage page, boolean partial,
+      IGoogleLoginService loginService,
       IGoogleApiFactory apiFactory) {
     checkArgument(columns >= 3, "DefaultRunOptions must be in a Grid with at least 3 columns"); //$NON-NLS-1$
     this.target = target;
@@ -119,6 +126,7 @@ public class RunOptionsDefaultsComponent {
     this.messageTarget = messageTarget;
     this.displayExecutor = DisplayExecutor.create(target.getDisplay());
     this.apiFactory = apiFactory;
+    this.partial = partial;
 
     Label accountLabel = new Label(target, SWT.NULL);
     accountLabel.setText(Messages.getString("account")); //$NON-NLS-1$
@@ -206,12 +214,16 @@ public class RunOptionsDefaultsComponent {
   }
 
   private void validate() {
+    // we set pageComplete to the value of `partial` if the fields are valid
     setPageComplete(false);
+    messageTarget.clear();
+
     Credential selectedCredential = accountSelector.getSelectedCredential();
     if (selectedCredential == null) {
       projectInput.setEnabled(false);
       stagingLocationInput.setEnabled(false);
       createButton.setEnabled(false);
+      setPageComplete(partial);
       return;
     }
 
@@ -219,27 +231,14 @@ public class RunOptionsDefaultsComponent {
     if (Strings.isNullOrEmpty(projectInput.getText())) {
       stagingLocationInput.setEnabled(false);
       createButton.setEnabled(false);
+      setPageComplete(partial);
       return;
     }
     // FIXME: incorporate project verification here
 
     stagingLocationInput.setEnabled(true);
 
-    final String bucketNamePart = GcsDataflowProjectClient.toGcsBucketName(getStagingLocation());
-    if (bucketNamePart.isEmpty()) {
-      // If the bucket name is empty, we don't have anything to verify; and we don't have any
-      // interesting messaging.
-      createButton.setEnabled(false);
-      return;
-    }
-
-    IStatus status = bucketNameValidator.validate(bucketNamePart);
-    if (!status.isOK()) {
-      messageTarget.setError(status.getMessage());
-      createButton.setEnabled(false);
-      return;
-    }
-    
+    // fetchStagingLocationsJob is a proxy for project checking
     if (fetchStagingLocationsJob != null) {
       Future<SortedSet<String>> stagingLocationsFuture =
           fetchStagingLocationsJob.getStagingLocations();
@@ -255,7 +254,26 @@ public class RunOptionsDefaultsComponent {
         } catch (InterruptedException ex) {
           DataflowUiPlugin.logError(ex, "Interrupted while retrieving staging locations"); //$NON-NLS-1$
         }
+      } else {
+        // in progress
+        return;
       }
+    }
+
+    final String bucketNamePart = GcsDataflowProjectClient.toGcsBucketName(getStagingLocation());
+    if (bucketNamePart.isEmpty()) {
+      // If the bucket name is empty, we don't have anything to verify; and we don't have any
+      // interesting messaging.
+      createButton.setEnabled(false);
+      setPageComplete(partial);
+      return;
+    }
+
+    IStatus status = bucketNameValidator.validate(bucketNamePart);
+    if (!status.isOK()) {
+      messageTarget.setError(status.getMessage());
+      createButton.setEnabled(false);
+      return;
     }
 
     if (verifyStagingLocationJob == null) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -89,7 +89,7 @@ public class RunOptionsDefaultsComponent {
   /**
    * If true, then this component is allowed to be partially-complete.
    */
-  private final boolean partial;
+  private final boolean allowIncomplete;
 
   private final AccountSelector accountSelector;
   private final Text projectInput;
@@ -105,19 +105,19 @@ public class RunOptionsDefaultsComponent {
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
       DataflowPreferences preferences) {
-    this(target, columns, messageTarget, preferences, null, false);
+    this(target, columns, messageTarget, preferences, null, false /* allowIncomplete */);
   }
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
-      DataflowPreferences preferences, WizardPage page, boolean partial) {
-    this(target, columns, messageTarget, preferences, page, partial,
+      DataflowPreferences preferences, WizardPage page, boolean allowIncomplete) {
+    this(target, columns, messageTarget, preferences, page, allowIncomplete,
         PlatformUI.getWorkbench().getService(IGoogleLoginService.class),
         PlatformUI.getWorkbench().getService(IGoogleApiFactory.class));
   }
 
   @VisibleForTesting
   RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
-      DataflowPreferences preferences, WizardPage page, boolean partial,
+      DataflowPreferences preferences, WizardPage page, boolean allowIncomplete,
       IGoogleLoginService loginService,
       IGoogleApiFactory apiFactory) {
     checkArgument(columns >= 3, "DefaultRunOptions must be in a Grid with at least 3 columns"); //$NON-NLS-1$
@@ -126,7 +126,7 @@ public class RunOptionsDefaultsComponent {
     this.messageTarget = messageTarget;
     this.displayExecutor = DisplayExecutor.create(target.getDisplay());
     this.apiFactory = apiFactory;
-    this.partial = partial;
+    this.allowIncomplete = allowIncomplete;
 
     Label accountLabel = new Label(target, SWT.NULL);
     accountLabel.setText(Messages.getString("account")); //$NON-NLS-1$
@@ -214,7 +214,7 @@ public class RunOptionsDefaultsComponent {
   }
 
   private void validate() {
-    // we set pageComplete to the value of `partial` if the fields are valid
+    // we set pageComplete to the value of `allowIncomplete` if the fields are valid
     setPageComplete(false);
     messageTarget.clear();
 
@@ -223,7 +223,7 @@ public class RunOptionsDefaultsComponent {
       projectInput.setEnabled(false);
       stagingLocationInput.setEnabled(false);
       createButton.setEnabled(false);
-      setPageComplete(partial);
+      setPageComplete(allowIncomplete);
       return;
     }
 
@@ -231,7 +231,7 @@ public class RunOptionsDefaultsComponent {
     if (Strings.isNullOrEmpty(projectInput.getText())) {
       stagingLocationInput.setEnabled(false);
       createButton.setEnabled(false);
-      setPageComplete(partial);
+      setPageComplete(allowIncomplete);
       return;
     }
     // FIXME: incorporate project verification here
@@ -265,7 +265,7 @@ public class RunOptionsDefaultsComponent {
       // If the bucket name is empty, we don't have anything to verify; and we don't have any
       // interesting messaging.
       createButton.setEnabled(false);
-      setPageComplete(partial);
+      setPageComplete(allowIncomplete);
       return;
     }
 


### PR DESCRIPTION
- introduce new `partial` argument on `RunOptionsDefaultsComponent` constructors: if `true` then the component should be able to be partially filled, and be complete providing the field values are valid
- rearrange the ordering of checks in `RunOptionsDefaultsComponent#validate()` as the _fetch staging locations for project P_ serves as a proxy for project validity
- adds new tests to verify that partial support is handled; required properly mocking project validation checks; switched to Mockito's _doXXX.when(obj).yyy()_ syntax as some mocks were classes and wouldn't handle mock-overrides properly

With this patch, I can create new dataflow projects without specifying some or all of the run-options defaults.