### PR TITLE
Add and wire up deploy context menu for Flex JAR Maven projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
@@ -8,9 +8,12 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy.ui
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.test.util,
+Import-Package: com.google.cloud.tools.eclipse.swtbot,
+ com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,
  org.eclipse.jst.common.project.facet.core,
  org.eclipse.jst.j2ee.web.project.facet,
+ org.eclipse.swtbot.eclipse.finder,
+ org.eclipse.swtbot.swt.finder.exceptions,
  org.eclipse.swtbot.swt.finder.widgets

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
                .
 javacSource=1.7
 javacTarget=1.7
+additional.bundles=org.apache.log4j

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/PluginXmlTest.java
@@ -38,9 +38,9 @@ public class PluginXmlTest extends BasePluginXmlTest {
     NodeList enabledWhen = getDocument().getElementsByTagName("enabledWhen");
     Assert.assertEquals(4, enabledWhen.getLength());
     NodeList tests = getDocument().getElementsByTagName("test");
-    Assert.assertEquals(4, tests.getLength());
+    Assert.assertEquals(6, tests.getLength());
     NodeList adapts = getDocument().getElementsByTagName("adapt");
-    Assert.assertEquals(4, adapts.getLength());
+    Assert.assertEquals(5, adapts.getLength());
 
     for (int i = 0; i < enabledWhen.getLength(); i++) {
       Element element = (Element) enabledWhen.item(i);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexJarFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
+import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
+import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.util.MavenUtils;
+import com.google.cloud.tools.eclipse.util.NatureUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class FlexDeployCommandHandlerTest {
+
+  @Rule public TestProjectCreator javaProjectCreator = new TestProjectCreator()
+      .withFacetVersions(JavaFacet.VERSION_1_8);
+
+  @Rule public TestProjectCreator flexJarProjectCreator = new TestProjectCreator()
+      .withFacetVersions(JavaFacet.VERSION_1_8, AppEngineFlexJarFacet.FACET_VERSION);
+
+  @Rule public TestProjectCreator flexWarProjectCreator = new TestProjectCreator()
+      .withFacetVersions(
+          JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31, AppEngineFlexWarFacet.FACET_VERSION);
+
+  @Test
+  public void testDeployContextMenu_hiddenForNonFlexProject() {
+    IProject project = javaProjectCreator.getProject();
+    ProjectUtils.waitForProjects(project);
+    assertFalse(flexDeployMenuVisible(project));
+  }
+
+  @Test
+  public void testDeployContextMenu_visibleForFlexWarProject() {
+    IProject project = flexWarProjectCreator.getProject();
+    ProjectUtils.waitForProjects(project);
+    assertTrue(flexDeployMenuVisible(project));
+  }
+
+  @Test
+  public void testDeployContextMenu_visibleForFlexJarMavenProject() throws CoreException {
+    IProject project = flexJarProjectCreator.getProject();
+    NatureUtils.addNature(project, MavenUtils.MAVEN2_NATURE_ID, null);
+    ProjectUtils.waitForProjects(project);
+    assertTrue(flexDeployMenuVisible(project));
+  }
+
+  @Test
+  public void testDeployContextMenu_hiddenForFlexJarNonMavenProject() {
+    IProject project = flexJarProjectCreator.getProject();
+    ProjectUtils.waitForProjects(project);
+    assertFalse(flexDeployMenuVisible(project));
+  }
+
+  private static boolean flexDeployMenuVisible(IProject project) {
+    SWTBotTreeItem selected = SwtBotProjectActions.selectProject(
+        new SWTWorkbenchBot(), project.getName());
+    try {
+      selected.contextMenu("Deploy to App Engine Flexible...");
+      return true;
+    } catch (WidgetNotFoundException e) {
+      return false;
+    }
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
@@ -80,7 +80,10 @@
         <and>
           <count value="1" />
           <iterate>
-            <reference definitionId="com.google.cloud.tools.eclipse.appengine.onlyInFlexProjects" />
+            <or>
+              <reference definitionId="com.google.cloud.tools.eclipse.appengine.onlyInFlexWarProjects" />
+              <reference definitionId="com.google.cloud.tools.eclipse.appengine.onlyInFlexJarMavenProjects" />
+            </or>
           </iterate>
         </and>
       </enabledWhen>
@@ -88,11 +91,26 @@
   </extension>
 
   <extension point="org.eclipse.core.expressions.definitions">
-    <definition id="com.google.cloud.tools.eclipse.appengine.onlyInFlexProjects">
+    <definition id="com.google.cloud.tools.eclipse.appengine.onlyInFlexWarProjects">
       <adapt type="org.eclipse.core.resources.IProject">
         <test
             property="org.eclipse.wst.common.project.facet.core.projectFacet"
             value="com.google.cloud.tools.eclipse.appengine.facets.flex" />
+      </adapt>
+    </definition>
+  </extension>
+
+  <extension point="org.eclipse.core.expressions.definitions">
+    <definition id="com.google.cloud.tools.eclipse.appengine.onlyInFlexJarMavenProjects">
+      <adapt type="org.eclipse.core.resources.IProject">
+        <and>
+          <test
+              property="org.eclipse.wst.common.project.facet.core.projectFacet"
+              value="com.google.cloud.tools.eclipse.appengine.facets.flex.jar" />
+          <test
+              property="org.eclipse.core.resources.projectNature"
+              value="org.eclipse.m2e.core.maven2Nature" />
+        </and>
       </adapt>
     </definition>
   </extension>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
@@ -129,7 +129,8 @@ public abstract class DeployCommandHandler extends AbstractHandler {
     return severity != IMarker.SEVERITY_ERROR;
   }
 
-  private void launchDeployJob(IProject project, Credential credential) throws IOException {
+  private void launchDeployJob(IProject project, Credential credential)
+      throws IOException, CoreException {
     AnalyticsPingManager.getInstance().sendPing(
         AnalyticsEvents.APP_ENGINE_DEPLOY, AnalyticsEvents.APP_ENGINE_DEPLOY_STANDARD, null);
 
@@ -166,7 +167,7 @@ public abstract class DeployCommandHandler extends AbstractHandler {
     deploy.schedule();
   }
 
-  protected abstract StagingDelegate getStagingDelegate(IProject project);
+  protected abstract StagingDelegate getStagingDelegate(IProject project) throws CoreException;
 
   private static String getConsoleName(String projectId) {
     Date now = new Date();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
@@ -18,16 +18,23 @@ package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexDeployPreferences;
+import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexJarMavenProjectStagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexStagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployCommandHandler;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployPreferencesDialog;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexJarFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
+import com.google.cloud.tools.eclipse.util.MavenUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.wst.common.project.facet.core.IFacetedProject;
+import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 public class FlexDeployCommandHandler extends DeployCommandHandler {
 
@@ -39,14 +46,22 @@ public class FlexDeployCommandHandler extends DeployCommandHandler {
   }
 
   @Override
-  protected StagingDelegate getStagingDelegate(IProject project) {
+  protected StagingDelegate getStagingDelegate(IProject project) throws CoreException {
     String appYamlPath = new FlexDeployPreferences(project).getAppYamlPath();
     IFile appYaml = project.getFile(appYamlPath);
     if (!appYaml.exists()) {
       throw new IllegalStateException("Invalid app.yaml path from project preferences.");
     }
     IPath appEngineDirectory = appYaml.getParent().getLocation();
-    return new FlexStagingDelegate(appEngineDirectory);
+
+    IFacetedProject facetedProject = ProjectFacetsManager.create(project);
+    if (AppEngineFlexWarFacet.hasFacet(facetedProject)) {
+      return new FlexStagingDelegate(appEngineDirectory);
+    }
+    if (AppEngineFlexJarFacet.hasFacet(facetedProject) && MavenUtils.hasMavenNature(project)) {
+      return new FlexJarMavenProjectStagingDelegate(appEngineDirectory);
+    }
+    throw new IllegalStateException("BUG: command enabled for non-flex or non-Maven-flex projects");
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
@@ -57,8 +57,8 @@ public class FlexDeployCommandHandler extends DeployCommandHandler {
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     if (AppEngineFlexWarFacet.hasFacet(facetedProject)) {
       return new FlexStagingDelegate(appEngineDirectory);
-    }
-    if (AppEngineFlexJarFacet.hasFacet(facetedProject) && MavenUtils.hasMavenNature(project)) {
+    } else if (AppEngineFlexJarFacet.hasFacet(facetedProject)
+        && MavenUtils.hasMavenNature(project)) {
       return new FlexJarMavenProjectStagingDelegate(appEngineDirectory);
     }
     throw new IllegalStateException("BUG: command enabled for non-flex or non-Maven-flex projects");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
@@ -57,11 +57,15 @@ public class FlexDeployCommandHandler extends DeployCommandHandler {
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     if (AppEngineFlexWarFacet.hasFacet(facetedProject)) {
       return new FlexStagingDelegate(appEngineDirectory);
-    } else if (AppEngineFlexJarFacet.hasFacet(facetedProject)
-        && MavenUtils.hasMavenNature(project)) {
-      return new FlexJarMavenProjectStagingDelegate(appEngineDirectory);
+    } else if (AppEngineFlexJarFacet.hasFacet(facetedProject)) {
+      if (MavenUtils.hasMavenNature(project)) {
+        return new FlexJarMavenProjectStagingDelegate(appEngineDirectory);
+      } else {
+        throw new IllegalStateException("BUG: command enabled for non-Maven flex projects");
+      }
+    } else {
+      throw new IllegalStateException("BUG: command enabled for non-flex projects");
     }
-    throw new IllegalStateException("BUG: command enabled for non-flex or non-Maven-flex projects");
   }
 
 }


### PR DESCRIPTION
Fixes #2105.

_Merging to the feature branch `gae-flex-jar-feature`_. After the merge, the feature branch becomes complete and can be merged to `master` to enable deploying Maven JAR projects.

- The (existing) flex deploy context menu is enabled if it has the flex JAR facet and has the Maven nature (in addition to current enabled state for the flex WAR project).
- The command handler determines if a project is a WAR or JAR Maven project and uses an appropriate deploy artifact stager.

Again, this will complete the (initial) implementation of deploying a flex JAR Maven project.