### PR TITLE
Fix flakey MiniProjectSelector tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/META-INF/MANIFEST.MF
@@ -9,4 +9,6 @@ Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.projectselector
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
 Import-Package: com.google.api.client.googleapis.testing.json;version="[1.22.0,1.23.0)",
- com.google.cloud.tools.eclipse.test.util.ui
+ com.google.cloud.tools.eclipse.test.util.ui,
+ org.eclipse.swtbot.swt.finder,
+ org.eclipse.swtbot.swt.finder.waits

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.projectselector;
 
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,10 +39,16 @@ import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,6 +61,13 @@ public class MiniSelectorTest {
   public IGoogleApiFactory apiFactory;
   @Rule
   public ShellTestResource shellResource = new ShellTestResource();
+  
+  private SWTBot bot;
+
+  @Before
+  public void setUp() {
+    bot = new SWTBot(shellResource.getShell());
+  }
 
   @Test
   public void testNoCredential() {
@@ -72,7 +86,7 @@ public class MiniSelectorTest {
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
     selector.setProject("foo.id");
-    spinEvents(); // setProject() waits for the project list to be returned
+    waitUntilResolvedProject(selector); // waits for the project list to be returned
 
     assertFalse(selector.getSelection().isEmpty());
     assertNotNull(selector.getProject());
@@ -89,30 +103,47 @@ public class MiniSelectorTest {
 
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
-    final boolean[] calledAndCorrect = new boolean[] {false};
+    final AtomicInteger selectionEventSeen = new AtomicInteger(0);
+    final AtomicReference<ISelection> lastSelection = new AtomicReference<>();
     selector.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override
       public void selectionChanged(SelectionChangedEvent event) {
-        assertThat(event.getSelection(), instanceOf(IStructuredSelection.class));
-        IStructuredSelection selection = (IStructuredSelection) event.getSelection();
-        assertEquals(1, selection.size());
-        assertThat(selection.getFirstElement(), instanceOf(GcpProject.class));
-        GcpProject gcpProject = (GcpProject) selection.getFirstElement();
-        calledAndCorrect[0] =
-            "foo".equals(gcpProject.getName()) && "foo.id".equals(gcpProject.getId());
+        selectionEventSeen.incrementAndGet();
+        lastSelection.set(event.getSelection());
       }
     });
-    assertFalse(calledAndCorrect[0]);
 
     selector.setProject("foo.id");
-    spinEvents(); // setProject() waits for the project list to be returned
+    waitUntilResolvedProject(selector); // waits for the project list to be returned
 
-    assertTrue(calledAndCorrect[0]);
+    assertThat(selectionEventSeen.get(), greaterThan(0));
+    assertThat(lastSelection.get(), instanceOf(IStructuredSelection.class));
+    IStructuredSelection selection = (IStructuredSelection) lastSelection.get();
+    assertEquals(1, selection.size());
+    assertThat(selection.getFirstElement(), instanceOf(GcpProject.class));
+    GcpProject gcpProject = (GcpProject) selection.getFirstElement();
+    assertEquals("foo", gcpProject.getName());
+    assertEquals("foo.id", gcpProject.getId());
   }
 
-  private void spinEvents() {
-    while (Display.getCurrent().readAndDispatch());
+  private void waitUntilResolvedProject(final MiniSelector selector) {
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public boolean test() throws Exception {
+        if (Display.getCurrent() != null) {
+          // seems surprising that this is required?
+          while (Display.getCurrent().readAndDispatch());
+        }
+        return selector.getProject() != null;
+      }
+
+      @Override
+      public String getFailureMessage() {
+        return "MiniSelector project was never resolved";
+      }
+    });
   }
+
 
   private void mockProjectsList(Credential credential,
       GcpProject... gcpProjects) {

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
@@ -125,7 +125,7 @@ public class MiniSelectorTest {
       @Override
       public boolean test() throws Exception {
         if (Display.getCurrent() != null) {
-          // seems surprising that this is required?
+          // seems surprising that waitUtil() doesn't spin the event loop
           while (Display.getCurrent().readAndDispatch());
         }
         return selector.getProject() != null;

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.eclipse.projectselector;
 
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +38,6 @@ import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -103,12 +101,10 @@ public class MiniSelectorTest {
 
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
-    final AtomicInteger selectionEventSeen = new AtomicInteger(0);
     final AtomicReference<ISelection> lastSelection = new AtomicReference<>();
     selector.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override
       public void selectionChanged(SelectionChangedEvent event) {
-        selectionEventSeen.incrementAndGet();
         lastSelection.set(event.getSelection());
       }
     });
@@ -116,7 +112,6 @@ public class MiniSelectorTest {
     selector.setProject("foo.id");
     waitUntilResolvedProject(selector); // waits for the project list to be returned
 
-    assertThat(selectionEventSeen.get(), greaterThan(0));
     assertThat(lastSelection.get(), instanceOf(IStructuredSelection.class));
     IStructuredSelection selection = (IStructuredSelection) lastSelection.get();
     assertEquals(1, selection.size());

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
@@ -38,7 +38,6 @@ import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -101,19 +100,19 @@ public class MiniSelectorTest {
 
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
-    final AtomicReference<ISelection> lastSelection = new AtomicReference<>();
+    final ISelection[] lastSelection = new ISelection[1];
     selector.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override
       public void selectionChanged(SelectionChangedEvent event) {
-        lastSelection.set(event.getSelection());
+        lastSelection[0] = event.getSelection();
       }
     });
 
     selector.setProject("foo.id");
     waitUntilResolvedProject(selector); // waits for the project list to be returned
 
-    assertThat(lastSelection.get(), instanceOf(IStructuredSelection.class));
-    IStructuredSelection selection = (IStructuredSelection) lastSelection.get();
+    assertThat(lastSelection[0], instanceOf(IStructuredSelection.class));
+    IStructuredSelection selection = (IStructuredSelection) lastSelection[0];
     assertEquals(1, selection.size());
     assertThat(selection.getFirstElement(), instanceOf(GcpProject.class));
     GcpProject gcpProject = (GcpProject) selection.getFirstElement();


### PR DESCRIPTION
Spin the display event loop until a project has been selected.  The selection-change event could be called multiple times.