### PR TITLE
Add WAR/JAR file input field validator

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
@@ -56,7 +56,7 @@ public class AppYamlValidatorTest {
   }
 
   @Test
-  public void testContructor_nonAbsoluteBasePath() {
+  public void testConstructor_nonAbsoluteBasePath() {
     try {
       when(appYamlPath.getValue()).thenReturn("app.yaml");
       new AppYamlValidator(new Path("non/absolute/base/path"), appYamlPath);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
@@ -72,7 +72,7 @@ public class AppYamlValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Enter app.yaml path.", result.getMessage());
+    assertEquals("Missing app.yaml path.", result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
@@ -124,8 +124,8 @@ public class AppYamlValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Path is a directory or not a normal file: "
-        + new Path(basePath + "/app.yaml").toOSString(), result.getMessage());
+    assertEquals("Path is a directory: " + new Path(basePath + "/app.yaml").toOSString(),
+        result.getMessage());
   }
 
   @Test
@@ -137,8 +137,8 @@ public class AppYamlValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Path is a directory or not a normal file: "
-        + new Path(basePath + "/app.yaml").toOSString(), result.getMessage());
+    assertEquals("Path is a directory: " + new Path(basePath + "/app.yaml").toOSString(),
+        result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
@@ -67,6 +67,15 @@ public class AppYamlValidatorTest {
   }
 
   @Test
+  public void testValidate_emptyField() {
+    when(appYamlPath.getValue()).thenReturn("");
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("Enter app.yaml path.", result.getMessage());
+  }
+
+  @Test
   public void testValidate_relativePathAndNoAppYaml() {
     when(appYamlPath.getValue()).thenReturn("relative/path/app.yaml");
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidatorTest.java
@@ -124,8 +124,8 @@ public class AppYamlValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Not a file: " + new Path(basePath + "/app.yaml").toOSString(),
-        result.getMessage());
+    assertEquals("Path is a directory or not a normal file: "
+        + new Path(basePath + "/app.yaml").toOSString(), result.getMessage());
   }
 
   @Test
@@ -137,8 +137,8 @@ public class AppYamlValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Not a file: " + new Path(basePath + "/app.yaml").toOSString(),
-        result.getMessage());
+    assertEquals("Path is a directory or not a normal file: "
+        + new Path(basePath + "/app.yaml").toOSString(), result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
@@ -120,8 +120,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Path is a directory or not a normal file: "
-        + new Path(basePath + "/some.war").toOSString(), result.getMessage());
+    assertEquals("Path is a directory: " + new Path(basePath + "/some.war").toOSString(),
+        result.getMessage());
   }
 
   @Test
@@ -133,8 +133,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Path is a directory or not a normal file: "
-        + new Path(basePath + "/some.war").toOSString(), result.getMessage());
+    assertEquals("Path is a directory: " + new Path(basePath + "/some.war").toOSString(),
+        result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeployArtifactValidatorTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Mock private IObservableValue deployArtifactPath;
+
+  private IPath basePath;
+  private DeployArtifactValidator pathValidator;
+
+  @Before
+  public void setUp() throws IOException {
+    basePath = new Path(tempFolder.newFolder().toString());
+    when(deployArtifactPath.getValueType()).thenReturn(String.class);
+    pathValidator = new DeployArtifactValidator(basePath, deployArtifactPath);
+    assertTrue(basePath.isAbsolute());
+  }
+
+  @Test
+  public void testContructor_nonAbsoluteBasePath() {
+    try {
+      when(deployArtifactPath.getValue()).thenReturn("some.jar");
+      new DeployArtifactValidator(new Path("non/absolute/base/path"), deployArtifactPath);
+      fail();
+    } catch (IllegalArgumentException ex) {
+      assertEquals("basePath is not absolute.", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testValidate_emptyField() {
+    when(deployArtifactPath.getValue()).thenReturn("");
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("Enter WAR or JAR path.", result.getMessage());
+  }
+
+  @Test
+  public void testValidate_relativePathAndNoArtifact() {
+    when(deployArtifactPath.getValue()).thenReturn("relative/path/some.jar");
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("WAR or JAR does not exist.", result.getMessage());
+  }
+
+  @Test
+  public void testValidate_absolutePathAndNoArtifact() {
+    String absolutePath = basePath + "/sub/directory/some.jar";
+    when(deployArtifactPath.getValue()).thenReturn(absolutePath);
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("WAR or JAR does not exist.", result.getMessage());
+  }
+
+  @Test
+  public void testValidate_relativePathAndInvalidExtension() {
+    when(deployArtifactPath.getValue()).thenReturn("relative/path/python.py");
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("File extension is not \"war\" or \"jar\".", result.getMessage());
+  }
+
+  @Test
+  public void testValidate_absolutePathInvalidExtension() {
+    String absolutePath = basePath + "/sub/directory/python.py";
+    when(deployArtifactPath.getValue()).thenReturn(absolutePath);
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("File extension is not \"war\" or \"jar\".", result.getMessage());
+  }
+
+  @Test
+  public void testValidate_relativePathNotFile() {
+    basePath.append("some.war").toFile().mkdir();
+    when(deployArtifactPath.getValue()).thenReturn("some.war");
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("Not a file: " + new Path(basePath + "/some.war").toOSString(),
+        result.getMessage());
+  }
+
+  @Test
+  public void testValidate_absolutePathNotFile() {
+    basePath.append("some.war").toFile().mkdir();
+
+    String absolutePath = basePath + "/some.war";
+    when(deployArtifactPath.getValue()).thenReturn(absolutePath);
+
+    IStatus result = pathValidator.validate();
+    assertEquals(IStatus.ERROR, result.getSeverity());
+    assertEquals("Not a file: " + new Path(basePath + "/some.war").toOSString(),
+        result.getMessage());
+  }
+
+  @Test
+  public void testValidate_relativePathWithJar() throws IOException {
+    assertTrue(basePath.append("/some/directory/").toFile().mkdirs());
+    assertTrue(basePath.append("/some/directory/some.jar").toFile().createNewFile());
+
+    when(deployArtifactPath.getValue()).thenReturn("some/directory/some.jar");
+    IStatus result = pathValidator.validate();
+    assertTrue(result.isOK());
+  }
+
+  @Test
+  public void testValidate_absolutePathWithJar() throws IOException {
+    File absolutePath = tempFolder.newFolder("another", "folder");
+    File jar = new File(absolutePath + "/some.jar");
+    assertTrue(jar.createNewFile());
+
+    when(deployArtifactPath.getValue()).thenReturn(jar.toString());
+    IStatus result = pathValidator.validate();
+    assertTrue(result.isOK());
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
@@ -54,7 +54,7 @@ public class DeployArtifactValidatorTest {
   }
 
   @Test
-  public void testContructor_nonAbsoluteBasePath() {
+  public void testConstructor_nonAbsoluteBasePath() {
     try {
       when(deployArtifactPath.getValue()).thenReturn("some.jar");
       new DeployArtifactValidator(new Path("non/absolute/base/path"), deployArtifactPath);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
@@ -79,7 +79,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("WAR or JAR does not exist.", result.getMessage());
+    assertEquals("File does not exist: "
+        + new Path(basePath + "/relative/path/some.jar").toOSString(), result.getMessage());
   }
 
   @Test
@@ -89,7 +90,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("WAR or JAR does not exist.", result.getMessage());
+    assertEquals("File does not exist: " + new Path(absolutePath).toOSString(),
+        result.getMessage());
   }
 
   @Test
@@ -118,8 +120,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Not a file: " + new Path(basePath + "/some.war").toOSString(),
-        result.getMessage());
+    assertEquals("Path is a directory or not a normal file: "
+        + new Path(basePath + "/some.war").toOSString(), result.getMessage());
   }
 
   @Test
@@ -131,8 +133,8 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Not a file: " + new Path(basePath + "/some.war").toOSString(),
-        result.getMessage());
+    assertEquals("Path is a directory or not a normal file: "
+        + new Path(basePath + "/some.war").toOSString(), result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidatorTest.java
@@ -70,7 +70,7 @@ public class DeployArtifactValidatorTest {
 
     IStatus result = pathValidator.validate();
     assertEquals(IStatus.ERROR, result.getSeverity());
-    assertEquals("Enter WAR or JAR path.", result.getMessage());
+    assertEquals("Missing WAR or JAR path.", result.getMessage());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/RelativeFileFieldSetterTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/RelativeFileFieldSetterTest.java
@@ -44,6 +44,7 @@ public class RelativeFileFieldSetterTest {
   @Mock private Text field;
   @Mock private FileDialog dialog;
   @Mock private SelectionEvent event;
+  private final String[] filter = new String[0];
 
   private IPath basePath;
 
@@ -56,7 +57,7 @@ public class RelativeFileFieldSetterTest {
   @Test
   public void testConstructor_nonAbsoluteBasePath() {
     try {
-      new RelativeFileFieldSetter(field, new Path("non/absolute/base/path"), dialog);
+      new RelativeFileFieldSetter(field, new Path("non/absolute/base/path"), filter, dialog);
       fail();
     } catch (IllegalArgumentException ex) {}
   }
@@ -66,7 +67,7 @@ public class RelativeFileFieldSetterTest {
     when(field.getText()).thenReturn("");
     when(dialog.open()).thenReturn(null /* means canceled */);
 
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     verify(field, never()).setText(anyString());
   }
 
@@ -75,7 +76,7 @@ public class RelativeFileFieldSetterTest {
     when(field.getText()).thenReturn("");
     when(dialog.open()).thenReturn(basePath + "/sub/directory/app.yaml");
 
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     verify(field).setText("sub/directory/app.yaml");
   }
 
@@ -84,7 +85,8 @@ public class RelativeFileFieldSetterTest {
     when(field.getText()).thenReturn("");
     when(dialog.open()).thenReturn("/path/outside/base/app.yaml");
 
-    new RelativeFileFieldSetter(field, new Path("/base/path"), dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, new Path("/base/path"), filter, dialog)
+        .widgetSelected(event);
     verify(field).setText("../../path/outside/base/app.yaml");
   }
 
@@ -93,12 +95,12 @@ public class RelativeFileFieldSetterTest {
     when(field.getText()).thenReturn("src/main/appengine/app.yaml");
     when(dialog.open()).thenReturn(null);
 
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     // "basePath" is the first physically existing directory.
     verify(dialog).setFilterPath(basePath.toString());
 
     basePath.append("src").toFile().mkdir();
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     verify(dialog).setFilterPath(basePath + "/src");
   }
 
@@ -107,12 +109,19 @@ public class RelativeFileFieldSetterTest {
     when(field.getText()).thenReturn(basePath + "/deploy/temp/app.yaml");
     when(dialog.open()).thenReturn(null);
 
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     // "basePath" is the first physically existing directory.
     verify(dialog).setFilterPath(basePath.toString());
 
     basePath.append("deploy").toFile().mkdir();
-    new RelativeFileFieldSetter(field, basePath, dialog).widgetSelected(event);
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
     verify(dialog).setFilterPath(basePath + "/deploy");
+  }
+
+  @Test
+  public void testFileDialogFileterExtensionSet() {
+    when(field.getText()).thenReturn("");
+    new RelativeFileFieldSetter(field, basePath, filter, dialog).widgetSelected(event);
+    verify(dialog).setFilterExtensions(filter);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
@@ -70,7 +70,8 @@ public class FlexDeployPreferencesPanel extends AppEngineDeployPreferencesPanel 
 
     Button browse = new Button(secondColumn, SWT.PUSH);
     browse.setText(Messages.getString("deploy.preferences.dialog.browse"));
-    browse.addSelectionListener(new RelativeFileFieldSetter(appYamlField, project.getLocation()));
+    browse.addSelectionListener(
+        new RelativeFileFieldSetter(appYamlField, project.getLocation(), new String[] {"*.yaml"}));
 
     GridLayoutFactory.fillDefaults().numColumns(2).generateLayout(secondColumn);
     GridDataFactory.fillDefaults().applyTo(secondColumn);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/AppYamlValidator.java
@@ -53,6 +53,10 @@ public class AppYamlValidator extends FixedMultiValidator {
 
   @Override
   protected IStatus validate() {
+    if (appYamlPath.getValue().toString().isEmpty()) {
+      return ValidationStatus.error(Messages.getString("error.app.yaml.empty"));
+    }
+
     File appYaml = new File((String) appYamlPath.getValue());
     if (!appYaml.isAbsolute()) {
       appYaml = new File(basePath + "/" + appYaml);
@@ -64,7 +68,7 @@ public class AppYamlValidator extends FixedMultiValidator {
     } else if (!appYaml.exists()) {
       return ValidationStatus.error(Messages.getString("error.app.yaml.non.existing"));
     } else if (!appYaml.isFile()) {
-      return ValidationStatus.error(Messages.getString("error.app.yaml.not.a.file", appYaml));
+      return ValidationStatus.error(Messages.getString("error.not.a.file", appYaml));
     } else {
       return validateRuntime(appYaml);
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.internal;
+
+import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.core.databinding.validation.ValidationStatus;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+public class DeployArtifactValidator extends FixedMultiValidator {
+
+  private final IPath basePath;
+  private final IObservableValue deployArtifactPath;
+
+  public DeployArtifactValidator(IPath basePath, IObservableValue deployArtifactPath) {
+    Preconditions.checkArgument(basePath.isAbsolute(), "basePath is not absolute.");
+    Preconditions.checkArgument(String.class.equals(deployArtifactPath.getValueType()));
+    this.basePath = basePath;
+    this.deployArtifactPath = deployArtifactPath;
+  }
+
+  @Override
+  protected IStatus validate() {
+    String pathValue = deployArtifactPath.getValue().toString();
+    if (pathValue.isEmpty()) {
+      return ValidationStatus.error(Messages.getString("error.deploy.artifact.empty"));
+    } else if (!pathValue.endsWith(".war") && !pathValue.endsWith(".jar")) {
+      return ValidationStatus.error(Messages.getString("error.deploy.artifact.invalid.extension"));
+    }
+
+    File deployArtifact = new File((String) deployArtifactPath.getValue());
+    if (!deployArtifact.isAbsolute()) {
+      deployArtifact = new File(basePath + "/" + deployArtifact);
+    }
+
+    if (!deployArtifact.exists()) {
+      return ValidationStatus.error(Messages.getString("error.deploy.artifact.non.existing"));
+    } else if (!deployArtifact.isFile()) {
+      return ValidationStatus.error(Messages.getString("error.not.a.file", deployArtifact));
+    }
+    return Status.OK_STATUS;
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/DeployArtifactValidator.java
@@ -52,7 +52,8 @@ public class DeployArtifactValidator extends FixedMultiValidator {
     }
 
     if (!deployArtifact.exists()) {
-      return ValidationStatus.error(Messages.getString("error.deploy.artifact.non.existing"));
+      return ValidationStatus.error(
+          Messages.getString("error.deploy.artifact.non.existing", deployArtifact));
     } else if (!deployArtifact.isFile()) {
       return ValidationStatus.error(Messages.getString("error.not.a.file", deployArtifact));
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/RelativeFileFieldSetter.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/internal/RelativeFileFieldSetter.java
@@ -39,15 +39,18 @@ public class RelativeFileFieldSetter extends SelectionAdapter {
   private final Text fileField;
   private final IPath basePath;
   private final FileDialog dialog;
+  private final String[] filterExtensions;
 
-  public RelativeFileFieldSetter(Text directoryField, IPath basePath) {
-    this(directoryField, basePath, new FileDialog(directoryField.getShell()));
+  public RelativeFileFieldSetter(Text directoryField, IPath basePath, String[] filterExtensions) {
+    this(directoryField, basePath, filterExtensions, new FileDialog(directoryField.getShell()));
   }
 
   @VisibleForTesting
-  RelativeFileFieldSetter(Text directoryField, IPath basePath, FileDialog directoryDialog) {
+  RelativeFileFieldSetter(Text directoryField, IPath basePath, String[] filterExtensions,
+      FileDialog directoryDialog) {
     this.fileField = directoryField;
     this.basePath = Preconditions.checkNotNull(basePath);
+    this.filterExtensions = filterExtensions;
     Preconditions.checkArgument(basePath.isAbsolute());
     dialog = directoryDialog;
   }
@@ -62,7 +65,7 @@ public class RelativeFileFieldSetter extends SelectionAdapter {
       filterPath = filterPath.removeLastSegments(1);
     }
     dialog.setFilterPath(filterPath.toString());
-    dialog.setFilterExtensions(new String[]{ "*.yaml" });
+    dialog.setFilterExtensions(filterExtensions);
 
     String result = dialog.open();
     if (result != null) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -23,14 +23,14 @@ deploy.preferences.save.error.message=Error while saving the preferences: {0}
 error.account.missing.signedin=Select an account.
 error.account.missing.signedout=Sign in to Google.
 error.not.a.file=Not a file: {0}
-error.app.yaml.empty: Enter app.yaml path.
+error.app.yaml.empty: Missing app.yaml path.
 error.app.yaml.invalid.name=File name is not app.yaml: {0}
 error.app.yaml.non.existing=app.yaml does not exist.
 error.app.yaml.custom.runtime="runtime: custom" is not yet supported by Cloud Tools for Eclipse.
 error.app.yaml.not.java.runtime="runtime: {0}" in app.yaml is not "java".
 error.app.yaml.malformed=Malformed app.yaml.
 error.app.yaml.cannot.read=Cannot read app.yaml: {0}
-error.deploy.artifact.empty: Enter WAR or JAR path.
+error.deploy.artifact.empty: Missing WAR or JAR path.
 error.deploy.artifact.invalid.extension=File extension is not "war" or "jar".
 error.deploy.artifact.non.existing=WAR or JAR does not exist.
 project=Project:

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -12,7 +12,7 @@ deploy.preferences.dialog.title.withProject=Deployment Parameters for "{0}"
 deploy.preferences.dialog.label.selectAccount=Account:
 deploy.preferences.dialog.label.app.yaml=app.yaml:
 deploy.preferences.dialog.accountSelector.login=<Sign into another account...>
-deploy.preferences.dialog.browse=Browse
+deploy.preferences.dialog.browse=Browse...
 deploy.preferences.dialog.flex.pricing=There is no free quota for the App Engine flexible \
  environment. Visit <a href="https://cloud.google.com/appengine/pricing">GCP Pricing</a> for \
  pricing information.
@@ -22,13 +22,17 @@ deploy.preferences.save.error.title=Could not save preferences
 deploy.preferences.save.error.message=Error while saving the preferences: {0}
 error.account.missing.signedin=Select an account.
 error.account.missing.signedout=Sign in to Google.
+error.not.a.file=Not a file: {0}
+error.app.yaml.empty: Enter app.yaml path.
 error.app.yaml.invalid.name=File name is not app.yaml: {0}
-error.app.yaml.not.a.file=Not a file: {0}
 error.app.yaml.non.existing=app.yaml does not exist.
 error.app.yaml.custom.runtime="runtime: custom" is not yet supported by Cloud Tools for Eclipse.
 error.app.yaml.not.java.runtime="runtime: {0}" in app.yaml is not "java".
 error.app.yaml.malformed=Malformed app.yaml.
 error.app.yaml.cannot.read=Cannot read app.yaml: {0}
+error.deploy.artifact.empty: Enter WAR or JAR path.
+error.deploy.artifact.invalid.extension=File extension is not "war" or "jar".
+error.deploy.artifact.non.existing=WAR or JAR does not exist.
 project=Project:
 settings.advanced=Advanced
 stop.previous.version=Stop previous version

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -22,7 +22,7 @@ deploy.preferences.save.error.title=Could not save preferences
 deploy.preferences.save.error.message=Error while saving the preferences: {0}
 error.account.missing.signedin=Select an account.
 error.account.missing.signedout=Sign in to Google.
-error.not.a.file=Path is a directory or not a normal file: {0}
+error.not.a.file=Path is a directory: {0}
 error.app.yaml.empty: Missing app.yaml path.
 error.app.yaml.invalid.name=File name is not app.yaml: {0}
 error.app.yaml.non.existing=app.yaml does not exist.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -23,14 +23,14 @@ deploy.preferences.save.error.message=Error while saving the preferences: {0}
 error.account.missing.signedin=Select an account.
 error.account.missing.signedout=Sign in to Google.
 error.not.a.file=Path is a directory: {0}
-error.app.yaml.empty: Missing app.yaml path.
+error.app.yaml.empty=Missing app.yaml path.
 error.app.yaml.invalid.name=File name is not app.yaml: {0}
 error.app.yaml.non.existing=app.yaml does not exist.
 error.app.yaml.custom.runtime="runtime: custom" is not yet supported by Cloud Tools for Eclipse.
 error.app.yaml.not.java.runtime="runtime: {0}" in app.yaml is not "java".
 error.app.yaml.malformed=Malformed app.yaml.
 error.app.yaml.cannot.read=Cannot read app.yaml: {0}
-error.deploy.artifact.empty: Missing WAR or JAR path.
+error.deploy.artifact.empty=Missing WAR or JAR path.
 error.deploy.artifact.invalid.extension=File extension is not "war" or "jar".
 error.deploy.artifact.non.existing=File does not exist: {0}
 project=Project:

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/messages.properties
@@ -22,7 +22,7 @@ deploy.preferences.save.error.title=Could not save preferences
 deploy.preferences.save.error.message=Error while saving the preferences: {0}
 error.account.missing.signedin=Select an account.
 error.account.missing.signedout=Sign in to Google.
-error.not.a.file=Not a file: {0}
+error.not.a.file=Path is a directory or not a normal file: {0}
 error.app.yaml.empty: Missing app.yaml path.
 error.app.yaml.invalid.name=File name is not app.yaml: {0}
 error.app.yaml.non.existing=app.yaml does not exist.
@@ -32,7 +32,7 @@ error.app.yaml.malformed=Malformed app.yaml.
 error.app.yaml.cannot.read=Cannot read app.yaml: {0}
 error.deploy.artifact.empty: Missing WAR or JAR path.
 error.deploy.artifact.invalid.extension=File extension is not "war" or "jar".
-error.deploy.artifact.non.existing=WAR or JAR does not exist.
+error.deploy.artifact.non.existing=File does not exist: {0}
 project=Project:
 settings.advanced=Advanced
 stop.previous.version=Stop previous version


### PR DESCRIPTION
To be used in a global flex deploy dialog (non-existing yet).

Misc: I also took this as an opportunity to refactor `RelativeFileFieldSetter`, so that I can reuse it later in the global deploy dialog.