### PR TITLE
Fix NPEs and IAEs when creating new Dataflow launch configuration

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.dataflow.ui.launcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.tools.eclipse.dataflow.core.preferences.DataflowPreferences;
+import com.google.cloud.tools.eclipse.dataflow.ui.page.MessageTarget;
+import com.google.cloud.tools.eclipse.dataflow.ui.preferences.RunOptionsDefaultsComponent;
+import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+/**
+ * DefaultedPipelineOptionsComponent is responsible for saving and restoring custom values when the
+ * user toggles the <em>use defaults</em> button.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultedPipelineOptionsComponentTest {
+  @Rule
+  public ShellTestResource shellCreator = new ShellTestResource();
+  @Mock
+  MessageTarget messageTarget;
+
+  RunOptionsDefaultsComponent defaultOptions;
+  String accountEmail = "";
+  String projectId = "";
+  String stagingLocation = "";
+
+  @Before
+  public void setUp() {
+    // This is easier than subclassing RunOptionsDefaultComponent
+    Answer<String> answerAccountEmail = new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return accountEmail;
+      }
+    };
+    Answer<Void> recordAccountEmail = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        accountEmail = invocation.getArgumentAt(0, String.class);
+        return null;
+      }
+    };
+
+    Answer<String> answerProjectId = new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return projectId;
+      }
+    };
+    Answer<Void> recordProjectId = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        projectId = invocation.getArgumentAt(0, String.class);
+        return null;
+      }
+    };
+    Answer<String> answerStagingLocation = new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) throws Throwable {
+        return stagingLocation;
+      }
+    };
+    Answer<Void> recordStagingLocation = new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        stagingLocation = invocation.getArgumentAt(0, String.class);
+        return null;
+      }
+    };
+
+    defaultOptions = mock(RunOptionsDefaultsComponent.class);
+    doAnswer(answerAccountEmail).when(defaultOptions).getAccountEmail();
+    doAnswer(recordAccountEmail).when(defaultOptions).selectAccount(anyString());
+    doThrow(IllegalStateException.class).when(defaultOptions).getProject();
+    doAnswer(answerProjectId).when(defaultOptions).getProjectId();
+    doAnswer(recordProjectId).when(defaultOptions).setCloudProjectText(anyString());
+    doAnswer(answerStagingLocation).when(defaultOptions).getStagingLocation();
+    doAnswer(recordStagingLocation).when(defaultOptions).setStagingLocationText(anyString());
+  }
+
+  @Test
+  public void testDefaults_nulls() {
+    // no preference values set
+    DataflowPreferences preferences = mock(DataflowPreferences.class);
+
+    DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
+        shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
+
+    assertTrue(component.isUseDefaultOptions());
+    Map<String, String> values = component.getValues();
+    // all empty/null settings should be turned to empty strings
+    assertEquals("", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+  }
+
+  @Test
+  public void testDefaults_values() {
+    DataflowPreferences preferences = mock(DataflowPreferences.class);
+    doReturn("pref-email").when(preferences).getDefaultAccountEmail();
+    doReturn("pref-project").when(preferences).getDefaultProject();
+    doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();
+    doReturn("gs://pref-staging").when(preferences).getDefaultGcpTempLocation();
+
+    DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
+        shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
+
+    assertTrue(component.isUseDefaultOptions());
+    Map<String, String> values = component.getValues();
+    assertEquals("pref-email", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("pref-project", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+  }
+
+  @Test
+  public void testCustomValues_nulls() {
+    DataflowPreferences preferences = mock(DataflowPreferences.class);
+    doReturn("pref-email").when(preferences).getDefaultAccountEmail();
+    doReturn("pref-project").when(preferences).getDefaultProject();
+    doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();
+    doReturn("gs://pref-staging").when(preferences).getDefaultGcpTempLocation();
+
+    DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
+        shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
+    component.setCustomValues(new HashMap<String, String>());
+    component.setUseDefaultValues(false);
+
+    // the empty/null customValues should override the preferences
+    Map<String, String> values = component.getValues();
+    assertEquals("", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+  }
+
+
+  @Test
+  public void testCustomValues_values() {
+    DataflowPreferences preferences = mock(DataflowPreferences.class);
+    DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
+        shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
+
+    // setting useDefaultValues=false should store current values and restore any custom values
+    Map<String, String> customValues = new HashMap<>();
+    customValues.put(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, "newEmail");
+    customValues.put(DataflowPreferences.PROJECT_PROPERTY, "newProject");
+    customValues.put(DataflowPreferences.STAGING_LOCATION_PROPERTY, "newStagingLocation");
+    customValues.put(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY, "newTempLocation");
+
+    component.setCustomValues(customValues);
+    component.setUseDefaultValues(false);
+
+    Map<String, String> values = component.getValues();
+    assertEquals("newEmail", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("newProject", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+  }
+
+  @Test
+  public void testToggleDefaults() {
+    DataflowPreferences preferences = mock(DataflowPreferences.class);
+    doReturn("pref-email").when(preferences).getDefaultAccountEmail();
+    doReturn("pref-project").when(preferences).getDefaultProject();
+    doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();
+    doReturn("gs://pref-staging").when(preferences).getDefaultGcpTempLocation();
+
+    Map<String, String> customValues = new HashMap<>();
+    customValues.put(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, "newEmail");
+    customValues.put(DataflowPreferences.PROJECT_PROPERTY, "newProject");
+    customValues.put(DataflowPreferences.STAGING_LOCATION_PROPERTY, "newStagingLocation");
+    customValues.put(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY, "newTempLocation");
+
+    DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
+        shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
+
+    assertTrue(component.isUseDefaultOptions());
+    component.setCustomValues(customValues);
+    // preferences should be returned, despite customValues being set
+    Map<String, String> values = component.getValues();
+    assertEquals("pref-email", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("pref-project", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+
+    // setting useDefaultValues=false should store current values and restore any custom values
+    component.setUseDefaultValues(false);
+    values = component.getValues();
+    assertEquals("newEmail", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("newProject", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+
+    // setting useDefaultValues=true should restore the preferences values
+    component.setUseDefaultValues(true);
+    values = component.getValues();
+    assertEquals("pref-email", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("pref-project", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("gs://pref-staging", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+
+    // setting useDefaultValues=false should store current values and restore any custom values
+    component.setUseDefaultValues(false);
+    values = component.getValues();
+    assertEquals("newEmail", values.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY));
+    assertEquals("newProject", values.get(DataflowPreferences.PROJECT_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    assertEquals("newStagingLocation", values.get(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
@@ -48,12 +48,12 @@ public class DefaultedPipelineOptionsComponentTest {
   @Rule
   public ShellTestResource shellCreator = new ShellTestResource();
   @Mock
-  MessageTarget messageTarget;
+  private MessageTarget messageTarget;
 
-  RunOptionsDefaultsComponent defaultOptions;
-  String accountEmail = "";
-  String projectId = "";
-  String stagingLocation = "";
+  private RunOptionsDefaultsComponent defaultOptions;
+  private String accountEmail = "";
+  private String projectId = "";
+  private String stagingLocation = "";
 
   @Before
   public void setUp() {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponentTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.tools.eclipse.dataflow.core.preferences.DataflowPreferen
 import com.google.cloud.tools.eclipse.dataflow.ui.page.MessageTarget;
 import com.google.cloud.tools.eclipse.dataflow.ui.preferences.RunOptionsDefaultsComponent;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
+import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -50,10 +51,12 @@ public class DefaultedPipelineOptionsComponentTest {
   @Mock
   private MessageTarget messageTarget;
 
+  @Mock
+  private DataflowPreferences preferences;
   private RunOptionsDefaultsComponent defaultOptions;
-  private String accountEmail = "";
-  private String projectId = "";
-  private String stagingLocation = "";
+  private String accountEmail;
+  private String projectId;
+  private String stagingLocation;
 
   @Before
   public void setUp() {
@@ -61,7 +64,8 @@ public class DefaultedPipelineOptionsComponentTest {
     Answer<String> answerAccountEmail = new Answer<String>() {
       @Override
       public String answer(InvocationOnMock invocation) throws Throwable {
-        return accountEmail;
+        return Strings.nullToEmpty(
+            accountEmail == null ? preferences.getDefaultAccountEmail() : accountEmail);
       }
     };
     Answer<Void> recordAccountEmail = new Answer<Void>() {
@@ -75,7 +79,7 @@ public class DefaultedPipelineOptionsComponentTest {
     Answer<String> answerProjectId = new Answer<String>() {
       @Override
       public String answer(InvocationOnMock invocation) throws Throwable {
-        return projectId;
+        return Strings.nullToEmpty(projectId == null ? preferences.getDefaultProject() : projectId);
       }
     };
     Answer<Void> recordProjectId = new Answer<Void>() {
@@ -88,7 +92,8 @@ public class DefaultedPipelineOptionsComponentTest {
     Answer<String> answerStagingLocation = new Answer<String>() {
       @Override
       public String answer(InvocationOnMock invocation) throws Throwable {
-        return stagingLocation;
+        return Strings.nullToEmpty(
+            stagingLocation == null ? preferences.getDefaultStagingLocation() : stagingLocation);
       }
     };
     Answer<Void> recordStagingLocation = new Answer<Void>() {
@@ -111,9 +116,6 @@ public class DefaultedPipelineOptionsComponentTest {
 
   @Test
   public void testDefaults_nulls() {
-    // no preference values set
-    DataflowPreferences preferences = mock(DataflowPreferences.class);
-
     DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
         shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
 
@@ -128,7 +130,6 @@ public class DefaultedPipelineOptionsComponentTest {
 
   @Test
   public void testDefaults_values() {
-    DataflowPreferences preferences = mock(DataflowPreferences.class);
     doReturn("pref-email").when(preferences).getDefaultAccountEmail();
     doReturn("pref-project").when(preferences).getDefaultProject();
     doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();
@@ -147,7 +148,6 @@ public class DefaultedPipelineOptionsComponentTest {
 
   @Test
   public void testCustomValues_nulls() {
-    DataflowPreferences preferences = mock(DataflowPreferences.class);
     doReturn("pref-email").when(preferences).getDefaultAccountEmail();
     doReturn("pref-project").when(preferences).getDefaultProject();
     doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();
@@ -169,7 +169,6 @@ public class DefaultedPipelineOptionsComponentTest {
 
   @Test
   public void testCustomValues_values() {
-    DataflowPreferences preferences = mock(DataflowPreferences.class);
     DefaultedPipelineOptionsComponent component = new DefaultedPipelineOptionsComponent(
         shellCreator.getShell(), null, messageTarget, preferences, defaultOptions);
 
@@ -192,7 +191,6 @@ public class DefaultedPipelineOptionsComponentTest {
 
   @Test
   public void testToggleDefaults() {
-    DataflowPreferences preferences = mock(DataflowPreferences.class);
     doReturn("pref-email").when(preferences).getDefaultAccountEmail();
     doReturn("pref-project").when(preferences).getDefaultProject();
     doReturn("gs://pref-staging").when(preferences).getDefaultStagingLocation();

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPageTest.java
@@ -16,11 +16,15 @@
 
 package com.google.cloud.tools.eclipse.dataflow.ui.page;
 
+import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class NewDataflowProjectWizardDefaultRunOptionsPageTest {
+  @Rule
+  public ShellTestResource shellCreator = new ShellTestResource();
   
   private NewDataflowProjectWizardDefaultRunOptionsPage page;
   
@@ -43,5 +47,23 @@ public class NewDataflowProjectWizardDefaultRunOptionsPageTest {
   public void testDescription() {
     Assert.assertEquals(
         "Set default options for running a Dataflow Pipeline.", page.getDescription());
+  }
+
+  @Test
+  public void testAccountEmail_none() {
+    page.createControl(shellCreator.getShell());
+    Assert.assertEquals("", page.getAccountEmail());
+  }
+
+  @Test
+  public void testProjectId_none() {
+    page.createControl(shellCreator.getShell());
+    Assert.assertEquals("", page.getProjectId());
+  }
+
+  @Test
+  public void testStagingLocation_none() {
+    page.createControl(shellCreator.getShell());
+    Assert.assertEquals("", page.getStagingLocation());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -55,7 +55,7 @@ public class DefaultedPipelineOptionsComponent {
   }
 
   @VisibleForTesting
-  public DefaultedPipelineOptionsComponent(Composite parent, Object layoutData,
+  DefaultedPipelineOptionsComponent(Composite parent, Object layoutData,
       MessageTarget messageTarget, DataflowPreferences preferences,
       RunOptionsDefaultsComponent defaultOptions) {
     this.preferences = preferences;

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -19,8 +19,6 @@ package com.google.cloud.tools.eclipse.dataflow.ui.launcher;
 import com.google.cloud.tools.eclipse.dataflow.core.preferences.DataflowPreferences;
 import com.google.cloud.tools.eclipse.dataflow.ui.page.MessageTarget;
 import com.google.cloud.tools.eclipse.dataflow.ui.preferences.RunOptionsDefaultsComponent;
-import com.google.cloud.tools.eclipse.projectselector.model.GcpProject;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,9 +110,7 @@ public class DefaultedPipelineOptionsComponent {
   public Map<String, String> getValues() {
     Map<String, String> values = new HashMap<>();
     values.put(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, defaultOptions.getAccountEmail());
-    GcpProject project = defaultOptions.getProject();
-    Preconditions.checkNotNull(project);
-    values.put(DataflowPreferences.PROJECT_PROPERTY, project.getId());
+    values.put(DataflowPreferences.PROJECT_PROPERTY, defaultOptions.getProjectId());
     values.put(DataflowPreferences.STAGING_LOCATION_PROPERTY, defaultOptions.getStagingLocation());
     // TODO: Give this a separate input
     values.put(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY, defaultOptions.getStagingLocation());
@@ -133,7 +129,7 @@ public class DefaultedPipelineOptionsComponent {
     if (isUseDefaultOptions()) {
       customValues.put(
           DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, defaultOptions.getAccountEmail());
-      customValues.put(DataflowPreferences.PROJECT_PROPERTY, defaultOptions.getProject().getId());
+      customValues.put(DataflowPreferences.PROJECT_PROPERTY, defaultOptions.getProjectId());
       customValues.put(
           DataflowPreferences.STAGING_LOCATION_PROPERTY, defaultOptions.getStagingLocation());
       // TODO: Give this a separate input

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.eclipse.dataflow.ui.launcher;
 import com.google.cloud.tools.eclipse.dataflow.core.preferences.DataflowPreferences;
 import com.google.cloud.tools.eclipse.dataflow.ui.page.MessageTarget;
 import com.google.cloud.tools.eclipse.dataflow.ui.preferences.RunOptionsDefaultsComponent;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +51,13 @@ public class DefaultedPipelineOptionsComponent {
 
   public DefaultedPipelineOptionsComponent(Composite parent, Object layoutData,
       MessageTarget messageTarget, DataflowPreferences preferences) {
+    this(parent, layoutData, messageTarget, preferences, null);
+  }
+
+  @VisibleForTesting
+  public DefaultedPipelineOptionsComponent(Composite parent, Object layoutData,
+      MessageTarget messageTarget, DataflowPreferences preferences,
+      RunOptionsDefaultsComponent defaultOptions) {
     this.preferences = preferences;
     customValues = new HashMap<>();
 
@@ -60,6 +68,7 @@ public class DefaultedPipelineOptionsComponent {
 
     useDefaultsButton = new Button(defaultsGroup, SWT.CHECK);
     useDefaultsButton.setText("Use &default Dataflow options");
+    useDefaultsButton.setSelection(true);
 
     useDefaultsButton.addSelectionListener(new SetInputsEnabledOppositeButtonSelectionListener());
     useDefaultsButton.addSelectionListener(new SetInputValuesToDefaultOrCustomSelectionListener());
@@ -67,12 +76,15 @@ public class DefaultedPipelineOptionsComponent {
     useDefaultsButton.setLayoutData(
         new GridData(SWT.BEGINNING, SWT.CENTER, true, false, numColumns, 1));
 
-    defaultOptions =
-        new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget, preferences);
+    this.defaultOptions = defaultOptions == null
+        ? new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget, preferences)
+        : defaultOptions;
+    updateDefaultableInputValues();
   }
 
   public void setUseDefaultValues(boolean useDefaultValues) {
     useDefaultsButton.setSelection(useDefaultValues);
+    updateDefaultableInputValues();
     setWidgetsEnabled(!useDefaultValues);
   }
 
@@ -94,13 +106,16 @@ public class DefaultedPipelineOptionsComponent {
         .customValues.put(
             DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY,
             customValues.get(DataflowPreferences.STAGING_LOCATION_PROPERTY));
+    if (!isUseDefaultOptions()) {
+      loadCustomValues();
+    }
   }
 
   public void setPreferences(DataflowPreferences preferences) {
     this.preferences = preferences;
-    // The default values may have changed, so ensure the input components are set to the
-    // appropriate values.
-    updateDefaultableInputValues();
+    if (isUseDefaultOptions()) {
+      loadPreferences();
+    }
   }
 
   private void setWidgetsEnabled(boolean enabled) {
@@ -127,34 +142,39 @@ public class DefaultedPipelineOptionsComponent {
    */
   private void updateDefaultableInputValues() {
     if (isUseDefaultOptions()) {
-      customValues.put(
-          DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, defaultOptions.getAccountEmail());
-      customValues.put(DataflowPreferences.PROJECT_PROPERTY, defaultOptions.getProjectId());
-      customValues.put(
-          DataflowPreferences.STAGING_LOCATION_PROPERTY, defaultOptions.getStagingLocation());
-      // TODO: Give this a separate input
-      customValues.put(
-          DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY, defaultOptions.getStagingLocation());
-      String defaultAccountEmail = preferences.getDefaultAccountEmail();
-      defaultOptions.selectAccount(Strings.nullToEmpty(defaultAccountEmail));
-      String defaultProject = preferences.getDefaultProject();
-      defaultOptions.setCloudProjectText(Strings.nullToEmpty(defaultProject));
-      String defaultStagingLocation = preferences.getDefaultStagingLocation();
-      defaultOptions.setStagingLocationText(Strings.nullToEmpty(defaultStagingLocation));
+      saveCustomValues();
+      loadPreferences();
     } else {
-      String accountEmail = customValues.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY);
-      if (!Strings.isNullOrEmpty(accountEmail)) {
-        defaultOptions.selectAccount(accountEmail);
-      }
-      String project = customValues.get(DataflowPreferences.PROJECT_PROPERTY);
-      if (!Strings.isNullOrEmpty(project)) {
-        defaultOptions.setCloudProjectText(project);
-      }
-      String stagingLocation = customValues.get(DataflowPreferences.STAGING_LOCATION_PROPERTY);
-      if (!Strings.isNullOrEmpty(stagingLocation)) {
-        defaultOptions.setStagingLocationText(stagingLocation);
-      }
+      loadCustomValues();
     }
+  }
+
+  private void saveCustomValues() {
+    customValues.put(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY, defaultOptions.getAccountEmail());
+    customValues.put(DataflowPreferences.PROJECT_PROPERTY, defaultOptions.getProjectId());
+    customValues.put(DataflowPreferences.STAGING_LOCATION_PROPERTY,
+        defaultOptions.getStagingLocation());
+    // TODO: Give this a separate input
+    customValues.put(DataflowPreferences.GCP_TEMP_LOCATION_PROPERTY,
+        defaultOptions.getStagingLocation());
+  }
+
+  private void loadPreferences() {
+    String defaultAccountEmail = preferences.getDefaultAccountEmail();
+    defaultOptions.selectAccount(Strings.nullToEmpty(defaultAccountEmail));
+    String defaultProject = preferences.getDefaultProject();
+    defaultOptions.setCloudProjectText(Strings.nullToEmpty(defaultProject));
+    String defaultStagingLocation = preferences.getDefaultStagingLocation();
+    defaultOptions.setStagingLocationText(Strings.nullToEmpty(defaultStagingLocation));
+  }
+
+  private void loadCustomValues() {
+    String accountEmail = customValues.get(DataflowPreferences.ACCOUNT_EMAIL_PROPERTY);
+    defaultOptions.selectAccount(Strings.nullToEmpty(accountEmail));
+    String project = customValues.get(DataflowPreferences.PROJECT_PROPERTY);
+    defaultOptions.setCloudProjectText(Strings.nullToEmpty(project));
+    String stagingLocation = customValues.get(DataflowPreferences.STAGING_LOCATION_PROPERTY);
+    defaultOptions.setStagingLocationText(Strings.nullToEmpty(stagingLocation));
   }
 
   public void addAccountSelectionListener(Runnable listener) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/DefaultedPipelineOptionsComponent.java
@@ -79,7 +79,6 @@ public class DefaultedPipelineOptionsComponent {
     this.defaultOptions = defaultOptions == null
         ? new RunOptionsDefaultsComponent(defaultsGroup, numColumns, messageTarget, preferences)
         : defaultOptions;
-    updateDefaultableInputValues();
   }
 
   public void setUseDefaultValues(boolean useDefaultValues) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardDefaultRunOptionsPage.java
@@ -58,7 +58,7 @@ public class NewDataflowProjectWizardDefaultRunOptionsPage extends WizardPage {
   }
 
   public String getProjectId() {
-    return runOptionsDefaultsComponent.getProject().getId();
+    return runOptionsDefaultsComponent.getProjectId();
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -377,16 +377,15 @@ public class RunOptionsDefaultsComponent {
     return target;
   }
 
-  public void selectAccount(String accountEmail) {
-    accountSelector.selectAccount(accountEmail);
-  }
-
-  public void setCloudProjectText(String project) {
-    projectInput.setProject(project);
-  }
-
+  /**
+   * Return the selected account's email, or {@code ""} if no account selected.
+   */
   public String getAccountEmail() {
     return accountSelector.getSelectedEmail();
+  }
+
+  public void selectAccount(String accountEmail) {
+    accountSelector.selectAccount(accountEmail);
   }
 
   /**
@@ -403,13 +402,19 @@ public class RunOptionsDefaultsComponent {
     return projectInput.getProjectId();
   }
 
+  public void setCloudProjectText(String project) {
+    projectInput.setProject(project);
+  }
+
+  /**
+   * Return the selected staging location, or {@code ""} if no staging location specified.
+   */
+  public String getStagingLocation() {
+    return GcsDataflowProjectClient.toGcsLocationUri(stagingLocationInput.getText());
+  }
 
   public void setStagingLocationText(String stagingLocation) {
     stagingLocationInput.setText(stagingLocation);
-  }
-
-  public String getStagingLocation() {
-    return GcsDataflowProjectClient.toGcsLocationUri(stagingLocationInput.getText());
   }
 
   public void addAccountSelectionListener(Runnable listener) {

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -389,9 +389,20 @@ public class RunOptionsDefaultsComponent {
     return accountSelector.getSelectedEmail();
   }
 
+  /**
+   * Return the selected project, or {@code null} if no project selected.
+   */
   public GcpProject getProject() {
     return projectInput.getProject();
   }
+
+  /**
+   * Return the selected project ID, or {@code ""} if no project selected.
+   */
+  public String getProjectId() {
+    return projectInput.getProjectId();
+  }
+
 
   public void setStagingLocationText(String stagingLocation) {
     stagingLocationInput.setText(stagingLocation);
@@ -409,7 +420,9 @@ public class RunOptionsDefaultsComponent {
     projectInput.addSelectionChangedListener(new ISelectionChangedListener() {
       @Override
       public void selectionChanged(SelectionChangedEvent event) {
-        listener.modifyText(new ModifyEvent(new Event()));
+        Event dummy = new Event();
+        dummy.widget = projectInput.getControl();
+        listener.modifyText(new ModifyEvent(dummy));
       }
     });
     stagingLocationInput.addModifyListener(listener);

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/MiniSelectorTest.java
@@ -72,6 +72,8 @@ public class MiniSelectorTest {
     assertNull(selector.getCredential());
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
+    assertNull(selector.getProject());
+    assertEquals("", selector.getProjectId());
   }
 
   @Test
@@ -82,6 +84,9 @@ public class MiniSelectorTest {
     assertEquals(credential, selector.getCredential());
     assertNotNull(selector.getSelection());
     assertTrue(selector.getSelection().isEmpty());
+    assertNull(selector.getProject());
+    assertEquals("", selector.getProjectId());
+
     selector.setProject("foo.id");
     waitUntilResolvedProject(selector); // waits for the project list to be returned
 
@@ -89,6 +94,7 @@ public class MiniSelectorTest {
     assertNotNull(selector.getProject());
     assertEquals("foo", selector.getProject().getName());
     assertEquals("foo.id", selector.getProject().getId());
+    assertEquals("foo.id", selector.getProjectId());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/MiniSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/MiniSelector.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.eclipse.ui.util.DisplayExecutor;
 import com.google.cloud.tools.eclipse.util.jobs.Consumer;
 import com.google.cloud.tools.eclipse.util.jobs.FuturisticJob;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -164,22 +165,24 @@ public class MiniSelector implements ISelectionProvider {
   }
 
   /**
-   * Return the currently selected project ID or {@code null} if none selected.
+   * Return the currently selected project ID or {@code ""} if none selected.
    */
   public String getProjectId() {
     GcpProject selected = getProject();
-    return selected == null ? null : selected.getId();
+    return selected != null ? selected.getId() : "";
   }
 
   /**
    * Set the currently selected project by ID. The selection may not take effect immediately if the
    * project-list is still being fetched.
+   * 
+   * @param projectId may be {@code null} or {@code ""} to deselect
    */
   public void setProject(final String projectId) {
     Preconditions.checkState(comboViewer.getInput() instanceof GcpProject[]);
     // if there's a fetch in progress, then we override the result that should be shown
     toBeSelectedProjectId = projectId;
-    if (projectId == null) {
+    if (Strings.isNullOrEmpty(projectId)) {
       comboViewer.setSelection(StructuredSelection.EMPTY);
     } else {
       for (GcpProject project : (GcpProject[]) comboViewer.getInput()) {


### PR DESCRIPTION
Fixes #2410

Add `getProjectId()` helpers that return an `"" ` if no project is selected.  I don't much like this, but it keeps consistency with the helpers to return selected emails and staging locations.

Create tests for `DefaultedPipelineOptionsComponent` and fixed up class behaviour to be more consistent.