### PR TITLE
Add and enable global WAR/JAR deploy menu

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandlerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexExistingArtifactDeployPreferences;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.io.ByteArrayInputStream;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osgi.service.prefs.BackingStoreException;
+
+public class FlexExistingArtifactDeployCommandHandlerTest {
+
+  @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
+
+  private static final FlexExistingArtifactDeployCommandHandler handler =
+      new FlexExistingArtifactDeployCommandHandler();
+
+  private static final FlexExistingArtifactDeployPreferences preferences =
+      new FlexExistingArtifactDeployPreferences();
+
+  @Before
+  public void setUp() throws BackingStoreException {
+    IPath workspace = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+    IPath appYaml = projectCreator.getProject().getFile("app.yaml").getLocation();
+    IPath jar = projectCreator.getProject().getFile("my-app.jar").getLocation();
+
+    IPath relativeAppYaml = appYaml.makeRelativeTo(workspace);
+    IPath relativeJar = jar.makeRelativeTo(workspace);
+
+    preferences.setAppYamlPath(relativeAppYaml.toString());
+    preferences.setDeployArtifactPath(relativeJar.toString());
+    preferences.save();
+  }
+
+  @After
+  public void tearDown() throws BackingStoreException {
+    preferences.resetToDefaults();
+    preferences.save();
+  }
+
+  @Test
+  public void testGetStagingDelegate_exceptionIfAppYamlDoesNotExist() {
+    try {
+      handler.getStagingDelegate(projectCreator.getProject());
+      fail();
+    } catch (CoreException e) {
+      assertThat(e.getMessage(), endsWith("app.yaml does not exist."));
+    }
+  }
+
+  @Test
+  public void testGetStagingDelegate_exceptionIfDeployArtifactDoesNotExist() {
+    try {
+      createFileInProject("app.yaml");
+
+      handler.getStagingDelegate(projectCreator.getProject());
+      fail();
+    } catch (CoreException e) {
+      assertThat(e.getMessage(), endsWith("my-app.jar does not exist."));
+    }
+  }
+
+  @Test
+  public void testGetStagingDelegate_noException() throws CoreException {
+    createFileInProject("app.yaml");
+    createFileInProject("my-app.jar");
+    handler.getStagingDelegate(projectCreator.getProject());
+  }
+
+  private IPath createFileInProject(String filename) throws CoreException {
+    IFile file = projectCreator.getProject().getFile(filename);
+    file.create(new ByteArrayInputStream(new byte[0]), true, null);
+    return file.getLocation();
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandlerTest.java
@@ -83,7 +83,7 @@ public class FlexExistingArtifactDeployCommandHandlerTest {
   }
 
   @Test
-  public void testGetStagingDelegate_absoluateAppYamlPathDoesNotExist()
+  public void testGetStagingDelegate_absoluteAppYamlPathDoesNotExist()
       throws BackingStoreException {
     try {
       setUpDeployPreferences(false /* asRelativePath */);
@@ -95,7 +95,7 @@ public class FlexExistingArtifactDeployCommandHandlerTest {
   }
 
   @Test
-  public void testGetStagingDelegate_absoluateJarPathDoesNotExist() throws BackingStoreException {
+  public void testGetStagingDelegate_absoluteJarPathDoesNotExist() throws BackingStoreException {
     try {
       setUpDeployPreferences(false /* asRelativePath */);
       createFileInProject("app.yaml");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.properties
@@ -8,3 +8,7 @@ deployStandardMenuLabel=Deploy to App Engine Standard...
 deployFlexCommandDescription=Uploads the project to Google App Engine flexible environment.
 deployFlexCommandName=Deploy to App Engine Flexible
 deployFlexMenuLabel=Deploy to App Engine Flexible...
+
+deployFlexExistingWarJarCommandDescription=Uploads existing WAR/JAR to Google App Engine \
+ flexible environment.
+deployFlexExistingWarJarCommandName=Deploy Existing WAR/JAR to App Engine Flexible

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/plugin.xml
@@ -57,6 +57,11 @@
         id="com.google.cloud.tools.eclipse.appengine.flex.deploy"
         name="%deployFlexCommandName">
     </command>
+    <command
+        description="%deployFlexExistingWarJarCommandDescription"
+        id="com.google.cloud.tools.eclipse.appengine.flex.deploy.existing.war.jar"
+        name="%deployFlexExistingWarJarCommandName">
+    </command>
   </extension>
 
   <extension point="org.eclipse.ui.menus">
@@ -87,6 +92,10 @@
           </iterate>
         </and>
       </enabledWhen>
+    </handler>
+    <handler
+        class="com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible.FlexExistingArtifactDeployCommandHandler"
+        commandId="com.google.cloud.tools.eclipse.appengine.flex.deploy.existing.war.jar">
     </handler>
   </extension>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/DeployCommandHandler.java
@@ -74,14 +74,7 @@ public abstract class DeployCommandHandler extends AbstractHandler {
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {
     try {
-      IProject project = ProjectFromSelectionHelper.getFirstProject(event);
-      if (project == null) {
-        throw new NullPointerException("Deploy menu enabled for non-project resources");
-      }
-      IFacetedProject facetedProject = ProjectFacetsManager.create(project);
-      if (facetedProject == null) {
-        throw new NullPointerException("Deploy menu enabled for non-faceted projects");
-      }
+      IProject project = getSelectedProject(event);
 
       if (PlatformUI.isWorkbenchRunning()) {
         if (!PlatformUI.getWorkbench().saveAllEditors(true)) {
@@ -91,7 +84,7 @@ public abstract class DeployCommandHandler extends AbstractHandler {
           Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
         }
       }
-      if (!checkProjectErrors(project)) {
+      if (project != null && !checkProjectErrors(project)) {
         MessageDialog.openInformation(HandlerUtil.getActiveShell(event),
                                       Messages.getString("build.error.dialog.title"),
                                       Messages.getString("build.error.dialog.message"));
@@ -116,12 +109,30 @@ public abstract class DeployCommandHandler extends AbstractHandler {
     }
   }
 
+  protected IProject getSelectedProject(ExecutionEvent event)
+      throws ExecutionException, CoreException {
+    IProject project = ProjectFromSelectionHelper.getFirstProject(event);
+    if (project == null) {
+      throw new NullPointerException("Deploy menu enabled for non-project resources");
+    }
+    IFacetedProject facetedProject = ProjectFacetsManager.create(project);
+    if (facetedProject == null) {
+      throw new NullPointerException("Deploy menu enabled for non-faceted projects");
+    }
+    return project;
+  }
+
   private IWorkspace getWorkspace(ExecutionEvent event) {
     return ServiceUtils.getService(event, IWorkspace.class);
   }
 
   protected abstract DeployPreferencesDialog newDeployPreferencesDialog(Shell shell,
       IProject project, IGoogleLoginService loginService, IGoogleApiFactory googleApiFactory);
+
+  // It should better be named "getDeployPreferencesSnapshot" or something implying that. The
+  // snapshot then should be propagated as a single source of truth for the entire duration of
+  // the deploy job: https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2416
+  protected abstract DeployPreferences getDeployPreferences(IProject project);
 
   private static boolean checkProjectErrors(IProject project) throws CoreException {
     int severity = project.findMaxProblemSeverity(
@@ -135,7 +146,7 @@ public abstract class DeployCommandHandler extends AbstractHandler {
         AnalyticsEvents.APP_ENGINE_DEPLOY, AnalyticsEvents.APP_ENGINE_DEPLOY_STANDARD, null);
 
     IPath workDirectory = createWorkDirectory();
-    DeployPreferences deployPreferences = new DeployPreferences(project);
+    DeployPreferences deployPreferences = getDeployPreferences(project);
 
     DeployConsole messageConsole =
         MessageConsoleUtilities.createConsole(getConsoleName(deployPreferences.getProjectId()),

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployCommandHandler.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
 
+import com.google.cloud.tools.eclipse.appengine.deploy.DeployPreferences;
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexDeployPreferences;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexMavenPackagedProjectStagingDelegate;
@@ -72,4 +73,8 @@ public class FlexDeployCommandHandler extends DeployCommandHandler {
     }
   }
 
+  @Override
+  protected DeployPreferences getDeployPreferences(IProject project) {
+    return new FlexDeployPreferences(project);
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
+
+import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
+import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexExistingArtifactDeployPreferences;
+import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexExistingDeployArtifactStagingDelegate;
+import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployCommandHandler;
+import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployPreferencesDialog;
+import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
+import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
+import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
+import com.google.cloud.tools.eclipse.util.status.StatusUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.swt.widgets.Shell;
+
+public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandler {
+
+  @Override
+  protected DeployPreferencesDialog newDeployPreferencesDialog(Shell shell, IProject project,
+      IGoogleLoginService loginService, IGoogleApiFactory googleApiFactory) {
+    String title = Messages.getString("deploy.preferences.dialog.title.flexible");
+    return new FlexExistingArtifactDeployPreferencesDialog(shell, title, loginService,
+        googleApiFactory);
+  }
+
+  @Override
+  protected StagingDelegate getStagingDelegate(IProject project) throws CoreException {
+    String appYamlPath = new FlexExistingArtifactDeployPreferences().getAppYamlPath();
+    IFile appYaml = resolveFileAgainstWorkspace(appYamlPath);
+    IPath appEngineDirectory = appYaml.getParent().getLocation();
+
+    String deployArtifactPath = new FlexExistingArtifactDeployPreferences().getDeployArtifactPath();
+    IFile deployArtifact = resolveFileAgainstWorkspace(deployArtifactPath);
+
+    return new FlexExistingDeployArtifactStagingDelegate(deployArtifact, appEngineDirectory);
+  }
+
+  private IFile resolveFileAgainstWorkspace(String path) throws CoreException {
+    IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(path));
+    if (!file.exists()) {
+      throw new CoreException(StatusUtil.error(this, file + " does not exist."));
+    }
+    return file;
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
@@ -57,14 +57,13 @@ public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandl
     return new FlexExistingDeployArtifactStagingDelegate(deployArtifact, appEngineDirectory);
   }
 
-  private IPath resolveFileAgainstWorkspace(String pathString) throws CoreException {
-    IPath path = new Path(pathString);
-    if (path.isAbsolute()) {
-      return path;
+  private IPath resolveFileAgainstWorkspace(String path) throws CoreException {
+    IPath fullPath = new Path(path);
+    if (!fullPath.isAbsolute()) {
+      IPath workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+      fullPath = workspaceRoot.append(path);
     }
 
-    IPath workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation();
-    IPath fullPath = workspaceRoot.append(pathString);
     if (!fullPath.toFile().exists()) {
       throw new CoreException(StatusUtil.error(this, fullPath + " does not exist."));
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy.ui.flexible;
 
+import com.google.cloud.tools.eclipse.appengine.deploy.DeployPreferences;
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexExistingArtifactDeployPreferences;
 import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexExistingDeployArtifactStagingDelegate;
@@ -25,6 +26,8 @@ import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
 import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -63,4 +66,14 @@ public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandl
     return file;
   }
 
+  @Override
+  protected DeployPreferences getDeployPreferences(IProject project) {
+    return new FlexExistingArtifactDeployPreferences();
+  }
+
+  @Override
+  protected IProject getSelectedProject(ExecutionEvent event)
+      throws ExecutionException, CoreException {
+    return null;
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
@@ -28,12 +28,10 @@ import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.widgets.Shell;
 
 public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandler {
@@ -49,21 +47,22 @@ public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandl
   @Override
   protected StagingDelegate getStagingDelegate(IProject project) throws CoreException {
     String appYamlPath = new FlexExistingArtifactDeployPreferences().getAppYamlPath();
-    IFile appYaml = resolveFileAgainstWorkspace(appYamlPath);
-    IPath appEngineDirectory = appYaml.getParent().getLocation();
+    IPath appYaml = resolveFileAgainstWorkspace(appYamlPath);
+    IPath appEngineDirectory = appYaml.removeLastSegments(1);
 
     String deployArtifactPath = new FlexExistingArtifactDeployPreferences().getDeployArtifactPath();
-    IFile deployArtifact = resolveFileAgainstWorkspace(deployArtifactPath);
+    IPath deployArtifact = resolveFileAgainstWorkspace(deployArtifactPath);
 
     return new FlexExistingDeployArtifactStagingDelegate(deployArtifact, appEngineDirectory);
   }
 
-  private IFile resolveFileAgainstWorkspace(String path) throws CoreException {
-    IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(path));
-    if (!file.exists()) {
-      throw new CoreException(StatusUtil.error(this, file + " does not exist."));
+  private IPath resolveFileAgainstWorkspace(String path) throws CoreException {
+    IPath workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+    IPath fullPath = workspaceRoot.append(path);
+    if (!fullPath.toFile().exists()) {
+      throw new CoreException(StatusUtil.error(this, fullPath + " does not exist."));
     }
-    return file;
+    return fullPath;
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployCommandHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.swt.widgets.Shell;
 
 public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandler {
@@ -56,9 +57,14 @@ public class FlexExistingArtifactDeployCommandHandler extends DeployCommandHandl
     return new FlexExistingDeployArtifactStagingDelegate(deployArtifact, appEngineDirectory);
   }
 
-  private IPath resolveFileAgainstWorkspace(String path) throws CoreException {
+  private IPath resolveFileAgainstWorkspace(String pathString) throws CoreException {
+    IPath path = new Path(pathString);
+    if (path.isAbsolute()) {
+      return path;
+    }
+
     IPath workspaceRoot = ResourcesPlugin.getWorkspace().getRoot().getLocation();
-    IPath fullPath = workspaceRoot.append(path);
+    IPath fullPath = workspaceRoot.append(pathString);
     if (!fullPath.toFile().exists()) {
       throw new CoreException(StatusUtil.error(this, fullPath + " does not exist."));
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexExistingArtifactDeployPreferencesPanel.java
@@ -40,7 +40,7 @@ public class FlexExistingArtifactDeployPreferencesPanel extends FlexDeployPrefer
     Text deployArtifactField = createBrowseFileRow(
         Messages.getString("deploy.preferences.dialog.label.deploy.artifact"),
         Messages.getString("tooltip.deploy.artifact"),
-        getWorkingDirectory(), new String[] {"*.war", "*.jar"});
+        getWorkingDirectory(), new String[] {"*.war;*.jar"});
     setupPossiblyUnvalidatedTextFieldDataBinding(deployArtifactField, "deployArtifactPath",
         new DeployArtifactValidator(getWorkingDirectory(), deployArtifactField));
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/standard/StandardDeployCommandHandler.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.deploy.ui.standard;
 
+import com.google.cloud.tools.eclipse.appengine.deploy.DeployPreferences;
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardStagingDelegate;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.DeployCommandHandler;
@@ -61,5 +62,10 @@ public class StandardDeployCommandHandler extends DeployCommandHandler {
       // Give up.
     }
     return null;
+  }
+
+  @Override
+  protected DeployPreferences getDeployPreferences(IProject project) {
+    return new DeployPreferences(project);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexExistingDeployArtifactStagingDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexExistingDeployArtifactStagingDelegate.java
@@ -43,6 +43,7 @@ public class FlexExistingDeployArtifactStagingDelegate extends FlexStagingDelega
   public FlexExistingDeployArtifactStagingDelegate(IPath deployArtifact, IPath appEngineDirectory) {
     super(appEngineDirectory);
     Preconditions.checkNotNull(deployArtifact);
+    Preconditions.checkArgument(!deployArtifact.isEmpty());
     Preconditions.checkArgument(deployArtifact.isAbsolute());
     Preconditions.checkArgument(appEngineDirectory.isAbsolute());
     this.deployArtifact = deployArtifact;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexExistingDeployArtifactStagingDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/flex/FlexExistingDeployArtifactStagingDelegate.java
@@ -18,7 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.deploy.flex;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.StagingDelegate;
 import com.google.common.base.Preconditions;
-import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -36,21 +37,34 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
  */
 public class FlexExistingDeployArtifactStagingDelegate extends FlexStagingDelegate {
 
-  private final IFile deployArtifact;
+  private final IPath deployArtifact;
+  private final ISchedulingRule schedulingRule;
 
-  public FlexExistingDeployArtifactStagingDelegate(IFile deployArtifact, IPath appEngineDirectory) {
+  public FlexExistingDeployArtifactStagingDelegate(IPath deployArtifact, IPath appEngineDirectory) {
     super(appEngineDirectory);
-    this.deployArtifact = Preconditions.checkNotNull(deployArtifact);
+    Preconditions.checkNotNull(deployArtifact);
+    Preconditions.checkArgument(deployArtifact.isAbsolute());
+    Preconditions.checkArgument(appEngineDirectory.isAbsolute());
+    this.deployArtifact = deployArtifact;
+
+    // Compute SchedulingRule; will be the artifact itself, if inside the workspace.
+    IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+    if (workspaceRoot.getLocation().isPrefixOf(deployArtifact)) {
+      IPath relativeToWorkspace = deployArtifact.makeRelativeTo(workspaceRoot.getLocation());
+      schedulingRule = workspaceRoot.getFile(relativeToWorkspace);
+    } else {
+      schedulingRule = null;  // Outside the workspace; we can't lock it.
+    }
   }
 
   @Override
   protected IPath getDeployArtifact(IPath safeWorkDirectory, IProgressMonitor monitor)
       throws CoreException {
-    return deployArtifact.getLocation();
+    return deployArtifact;
   }
 
   @Override
   public ISchedulingRule getSchedulingRule() {
-    return deployArtifact;
+    return schedulingRule;
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
@@ -14,3 +14,5 @@ launch.gae.run = Run on App Engine
 launch.gae.debug = Debug on App Engine
 
 appEngineFlexAbbreviation=Flex
+
+deployFlexExistingWarJarMenuLabel=Deploy Existing WAR/JAR to App Engine Flexible...

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
@@ -106,6 +106,11 @@
               commandId="com.google.cloud.tools.eclipse.appengine.flex.deploy"
               style="push">
         </command>
+        <command
+              commandId="com.google.cloud.tools.eclipse.appengine.flex.deploy.existing.war.jar"
+              label="%deployFlexExistingWarJarMenuLabel"
+              style="push">
+        </command>
         <separator
               name="additions"
               visible="true">


### PR DESCRIPTION
The menu is always enabled.

![selection_007](https://user-images.githubusercontent.com/10523105/31025685-79e9b420-a511-11e7-83d4-ec72f77073e3.png)

Can't say I'm 100% satisfied with the current code structure, but I decided to go for reasonably minimal code change, as otherwise refactoring starts to propagate to too many files.

Did some actual testing:
- Absolute JAR path and relative app.yaml path, outside the workspace:
![selection_005](https://user-images.githubusercontent.com/10523105/31025756-d19c2108-a511-11e7-84b2-f6b5bd13b06a.png)

- Relative JAR path and absolute app.yaml, inside the workspace:
![selection_008](https://user-images.githubusercontent.com/10523105/31025801-f9165dca-a511-11e7-82e9-77298ddece78.png)

I also tested if the existing standard, flex WAR, and flex JAR (Maven projects) deployments work well.