### PR TITLE
Fix project names in .project files to match corresponding projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/.project
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.google.cloud.tools.eclipse.appengine.libraries.test</name>
+	<name>com.google.cloud.tools.eclipse.appengine.libraries.ui.test</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/.project
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.google.cloud.tools.eclipse.appengine.libraries</name>
+	<name>com.google.cloud.tools.eclipse.appengine.libraries.ui</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
`.libraries.ui` and `.libraries.ui.test` say they're actually called `.libraries` and `.libraries.test`, which conflicts with the actual `.libraries` and `.libraries.test`.