### PR TITLE
Move SDK into runtime

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -43,7 +43,7 @@ public class CloudLibrariesInPluginXmlTest {
 
   @Test
   public void testLibrarySize() {
-    assertThat(CloudLibraries.getLibraries("appengine").size(), is(3));
+    assertThat(CloudLibraries.getLibraries("appengine").size(), is(2));
     // There may be different number of servlet libraries depending on whether the
     // .appengine.java.standard.java8 bundle is present
     List<Library> servletLibraries = CloudLibraries.getLibraries("servlet");
@@ -60,7 +60,7 @@ public class CloudLibrariesInPluginXmlTest {
                is(Library.CONTAINER_PATH_PREFIX + "/" + APP_ENGINE_API_LIBRARY_ID));
     assertThat(appEngineLibrary.getId(), is(APP_ENGINE_API_LIBRARY_ID));
     assertThat(appEngineLibrary.getName(), is("App Engine API"));
-    assertThat(appEngineLibrary.getGroup(), is("appengine"));
+    assertThat(appEngineLibrary.getGroup(), is("appengine-api"));
     assertFalse(appEngineLibrary.getToolTip().isEmpty());
     assertThat(appEngineLibrary.getSiteUri(),
         is(new URI("https://cloud.google.com/appengine/docs/java/")));
@@ -71,7 +71,7 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(libraryFile.getJavadocUri(),
         is(new URI("https://cloud.google.com/appengine/docs/java/javadoc/")));
     assertNull(libraryFile.getSourceUri());
-    assertTrue("App Engine API not exported", libraryFile.isExport());
+    assertFalse("App Engine API exported", libraryFile.isExport());
 
     assertNotNull(libraryFile.getMavenCoordinates());
     MavenCoordinates mavenCoordinates = libraryFile.getMavenCoordinates();
@@ -106,9 +106,6 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(endpointsLibrary.getSiteUri(), is(new URI(
         "https://cloud.google.com/endpoints/docs/frameworks/java/about-cloud-endpoints-frameworks")));
     assertTrue(endpointsLibrary.isExport());
-    assertNotNull(endpointsLibrary.getLibraryDependencies());
-    assertThat(endpointsLibrary.getLibraryDependencies().size(), is(1));
-    assertThat(endpointsLibrary.getLibraryDependencies().get(0), is("appengine-api"));
     assertTrue(endpointsLibrary.getToolTip().contains("v2"));
 
     assertThat(endpointsLibrary.getLibraryFiles().size(), is(1));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
@@ -31,7 +31,7 @@ public class CloudLibrariesTest {
       Assert.assertFalse(tooltip.isEmpty());
       Assert.assertFalse(tooltip, tooltip.startsWith("!"));
     }
-    Assert.assertEquals(3, libraries.size());
+    Assert.assertEquals(2, libraries.size());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/AppEngineLibrariesSelectorGroupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/AppEngineLibrariesSelectorGroupTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.eclipse.appengine.libraries.ui;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +45,6 @@ public class AppEngineLibrariesSelectorGroupTest {
 
   private Shell shell;
   private LibrarySelectorGroup librariesSelector;
-  private SWTBotCheckBox appengineButton;
   private SWTBotCheckBox endpointsButton;
   private SWTBotCheckBox objectifyButton;
 
@@ -56,7 +54,6 @@ public class AppEngineLibrariesSelectorGroupTest {
     shell.setLayout(new FillLayout());
     librariesSelector = new LibrarySelectorGroup(shell, CloudLibraries.APP_ENGINE_GROUP);
     shell.open();
-    appengineButton = getButton("appengine-api");
     endpointsButton = getButton("appengine-endpoints");
     objectifyButton = getButton("objectify");
   }
@@ -66,8 +63,7 @@ public class AppEngineLibrariesSelectorGroupTest {
     Control groupAsControl = shell.getChildren()[0];
     assertThat(groupAsControl, instanceOf(Group.class));
     Control[] buttonsAsControls = ((Group) groupAsControl).getChildren();
-    String[] expectedLibraryOrder =
-        new String[] {"appengine-api", "appengine-endpoints", "objectify"};
+    String[] expectedLibraryOrder = new String[] {"appengine-endpoints", "objectify"};
     for (int i = 0; i < buttonsAsControls.length; i++) {
       Control control = buttonsAsControls[i];
       assertThat(control, instanceOf(Button.class));
@@ -81,7 +77,6 @@ public class AppEngineLibrariesSelectorGroupTest {
 
   @Test
   public void testToolTips() {
-    assertTrue(appengineButton.getToolTipText().length() > 0);
     assertTrue(endpointsButton.getToolTipText().length() > 0);
     assertTrue(objectifyButton.getToolTipText().length() > 0);
   }
@@ -92,22 +87,12 @@ public class AppEngineLibrariesSelectorGroupTest {
   }
 
   @Test
-  public void testSelectAppEngineApi() {
-    appengineButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(1));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-  }
-
-  @Test
   public void testSelectEndpointsSelectsAppEngineApiAsWell() {
     endpointsButton.click();
     List<Library> selectedLibraries = getSelectedLibrariesSorted();
     assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("appengine-endpoints"));
+    assertThat(selectedLibraries.size(), is(1));
+    assertThat(selectedLibraries.get(0).getId(), is("appengine-endpoints"));
   }
 
   @Test
@@ -115,9 +100,8 @@ public class AppEngineLibrariesSelectorGroupTest {
     objectifyButton.click();
     List<Library> selectedLibraries = getSelectedLibrariesSorted();
     assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("objectify"));
+    assertThat(selectedLibraries.size(), is(1));
+    assertThat(selectedLibraries.get(0).getId(), is("objectify"));
   }
 
   @Test
@@ -126,94 +110,9 @@ public class AppEngineLibrariesSelectorGroupTest {
     endpointsButton.click();
     List<Library> selectedLibraries = getSelectedLibrariesSorted();
     assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(3));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("appengine-endpoints"));
-    assertThat(selectedLibraries.get(2).getId(), is("objectify"));
-  }
-
-  @Test
-  public void testSelectObjectifyAndEndpointsThenUnselectObjectifyShouldKeepAppEngineApiSelected() {
-    objectifyButton.click();
-    endpointsButton.click();
-    objectifyButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
     assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("appengine-endpoints"));
-  }
-
-  @Test
-  public void testSelectObjectifyAndEndpointsThenUnselectEndpointsShouldKeepAppEngineApiSelected() {
-    endpointsButton.click();
-    objectifyButton.click();
-    endpointsButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
+    assertThat(selectedLibraries.get(0).getId(), is("appengine-endpoints"));
     assertThat(selectedLibraries.get(1).getId(), is("objectify"));
-  }
-
-  @Test
-  public void testSelectObjectifyAndEndpointsThenUnselectBothShouldMakeAppEngineApiUnSelected() {
-    objectifyButton.click();
-    endpointsButton.click();
-    objectifyButton.click();
-    endpointsButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertTrue(selectedLibraries.isEmpty());
-  }
-
-  @Test
-  public void testSelectAppEngineApiThenEndpointsThenUnselectEndpointsShouldKeepAppEngineSelected() {
-    appengineButton.click();
-    endpointsButton.click();
-    endpointsButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(1));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-  }
-
-  @Test
-  public void testSelectAppEngineApiThenObjectifyThenUnselectObjectifyShouldKeepAppEngineSelected() {
-    appengineButton.click();
-    objectifyButton.click();
-    objectifyButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(1));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-  }
-
-  // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/954
-  @Test
-  public void testSelectAndUnselectAppEngineApiThenSelectEndpointsShouldKeepAppEngineSelected() {
-    appengineButton.click();
-    appengineButton.click();
-    endpointsButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("appengine-endpoints"));
-  }
-
-  // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1254
-  @Test
-  public void testSelectAppEngineApiThenSelectObjectifyShouldDisableAppEngine() {
-    appengineButton.click();
-    objectifyButton.click();
-    List<Library> selectedLibraries = getSelectedLibrariesSorted();
-    assertNotNull(selectedLibraries);
-    assertThat(selectedLibraries.size(), is(2));
-    assertThat(selectedLibraries.get(0).getId(), is("appengine-api"));
-    assertThat(selectedLibraries.get(1).getId(), is("objectify"));
-    assertFalse(appengineButton.isEnabled());
-    assertTrue(objectifyButton.isEnabled());
   }
 
   private SWTBotCheckBox getButton(String libraryId) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -9,7 +9,7 @@
              
     <library 
           id="appengine-api"
-          group="appengine"
+          group="appengine-api"
           name="App Engine API"
           tooltip="%appengine.api.tooltip"
           siteUri="https://cloud.google.com/appengine/docs/java/" >
@@ -32,7 +32,6 @@
           tooltip="%endpoints.tooltip"
           dependencies="include"
           siteUri="https://cloud.google.com/endpoints/docs/frameworks/java/about-cloud-endpoints-frameworks" >
-      <libraryDependency id="appengine-api" />
       <libraryFile export="true" 
             javadocUri="https://cloud.google.com/endpoints/docs/frameworks/java/javadoc/">
         <mavenCoordinates
@@ -48,7 +47,6 @@
           name="Objectify"
           tooltip="%objectify.tooltip"
           siteUri="https://github.com/objectify/objectify/wiki" >
-      <libraryDependency id="appengine-api" />
       <libraryFile
           export="true"
           javadocUri="https://www.javadoc.io/doc/com.googlecode.objectify/objectify/5.1.21">

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -14,7 +14,7 @@
           tooltip="%appengine.api.tooltip"
           siteUri="https://cloud.google.com/appengine/docs/java/" >
       <libraryFile javadocUri="https://cloud.google.com/appengine/docs/java/javadoc/"
-          export="true">
+          export="false">
         <mavenCoordinates
               artifactId="appengine-api-1.0-sdk"
               groupId="com.google.appengine" 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
@@ -241,8 +241,16 @@ public class LibraryClasspathContainerResolverService
 
     Artifact artifact = repositoryService.resolveArtifact(libraryFile, new NullProgressMonitor());
     IPath libraryPath = new Path(artifact.getFile().getAbsolutePath());
-    IPath sourceAttachmentPath = repositoryService.resolveSourceArtifact(libraryFile,
-        artifact.getVersion(), new NullProgressMonitor());
+    
+    // Not all artifacts have sources; need to work if no source arrtifact is available
+    // e.g. appengine-api-sdk doesn't
+    IPath sourceAttachmentPath = null;
+    try {
+      sourceAttachmentPath = repositoryService.resolveSourceArtifact(libraryFile,
+          artifact.getVersion(), new NullProgressMonitor());
+    } catch (CoreException ex) {
+      // continue without source
+    }
     
     IClasspathEntry newLibraryEntry =
         JavaCore.newLibraryEntry(libraryPath,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
@@ -242,7 +242,7 @@ public class LibraryClasspathContainerResolverService
     Artifact artifact = repositoryService.resolveArtifact(libraryFile, new NullProgressMonitor());
     IPath libraryPath = new Path(artifact.getFile().getAbsolutePath());
     
-    // Not all artifacts have sources; need to work if no source arrtifact is available
+    // Not all artifacts have sources; need to work if no source artifact is available
     // e.g. appengine-api-sdk doesn't
     IPath sourceAttachmentPath = null;
     try {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProvider.java
@@ -96,7 +96,10 @@ public class ServletClasspathProvider extends RuntimeClasspathProviderDelegate {
       IClasspathEntry[] apiEntries =
           resolverService.resolveLibraryAttachSourcesSync(servletApiId);
       IClasspathEntry[] jspApiEntries = resolverService.resolveLibraryAttachSourcesSync(jspApiId);
-      return ObjectArrays.concat(apiEntries, jspApiEntries, IClasspathEntry.class);
+      IClasspathEntry[] appEngineSdkEntries = resolverService.resolveLibraryAttachSourcesSync("appengine-api");
+      IClasspathEntry[] result = ObjectArrays.concat(apiEntries, jspApiEntries, IClasspathEntry.class);
+      result = ObjectArrays.concat(result, appEngineSdkEntries, IClasspathEntry.class);
+      return result;
     } catch (CoreException ex) {
       logger.log(Level.WARNING, "Failed to initialize libraries", ex);
     }

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
@@ -37,6 +37,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.57</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jstl</groupId>
       <artifactId>jstl</artifactId>
       <version>1.2</version>


### PR DESCRIPTION
@briandealwis @chanseokoh This will be necessary since the Maven graph doesn't include the SDK as a dependency (nor should it). This is probably how we should have fixed #2350 in the first place.