### PR TITLE
Fix SnakeYaml bundle version

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -37,5 +37,5 @@
    <bundle id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
    <bundle id="ch.qos.logback.slf4j" version="0.0.0"/>
    <bundle id="org.slf4j.log4j" version="0.0.0"/>
-   <bundle id="org.yaml.snakeyaml" version="1.17"/>
+   <bundle id="org.yaml.snakeyaml" version="1.17.0"/>
 </site>

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -78,7 +78,7 @@
          id="org.yaml.snakeyaml"
          download-size="0"
          install-size="0"
-         version="1.17"
+         version="1.17.0"
          unpack="false"/>
 
 </feature>


### PR DESCRIPTION
Eclipse correctly shows a warning that it can't find the version:

![selection_002](https://user-images.githubusercontent.com/10523105/31199802-8bc254e0-a926-11e7-8055-de00cecd5192.png)

The Maven coordinate version is "1.17", but the bundle version is "1.17.0". The bundle's `MANIFEST.MF` says it:
```
Bundle-Description: YAML 1.1 parser and emitter for Java
...
Bundle-Name: SnakeYAML
...
Bundle-SymbolicName: org.yaml.snakeyaml
Bundle-Version: 1.17.0
Created-By: Apache Maven Bundle Plugin
```