### PR TITLE
Ensure JSP and JSTL are added to new standard and flex projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -228,7 +228,7 @@ public class CloudLibrariesInPluginXmlTest {
     assertNotNull(jspApiLibrary.getLibraryDependencies());
     assertTrue(jspApiLibrary.getLibraryDependencies().isEmpty());
 
-    assertThat(jspApiLibrary.getLibraryFiles().size(), is(2));
+    assertThat(jspApiLibrary.getLibraryFiles().size(), is(1));
     LibraryFile jspApi = jspApiLibrary.getLibraryFiles().get(0);
     assertThat(jspApi.getJavadocUri(), is(new URI(
         "http://docs.oracle.com/cd/E17802_01/products/products/jsp/2.1/docs/jsp-2_1-pfd2/")));
@@ -244,22 +244,5 @@ public class CloudLibrariesInPluginXmlTest {
     assertNull(mavenCoordinates.getClassifier());
 
     assertTrue(jspApi.getFilters().isEmpty());
-
-    LibraryFile jstlApi = jspApiLibrary.getLibraryFiles().get(1);
-    assertThat(jstlApi.getJavadocUri(), 
-        is(new URI("https://tomcat.apache.org/taglibs/standard/apidocs/")));
-    assertNull(jstlApi.getSourceUri());
-
-    assertNotNull(jstlApi.getMavenCoordinates());
-    MavenCoordinates jstlCoordinates = jstlApi.getMavenCoordinates();
-    assertThat(jstlCoordinates.getRepository(), is("central"));
-    assertThat(jstlCoordinates.getGroupId(), is("javax.servlet"));
-    assertThat(jstlCoordinates.getArtifactId(), is("jstl"));
-    assertThat(jstlCoordinates.getVersion(), is("1.2"));
-    assertThat(jstlCoordinates.getType(), is("jar"));
-    assertNull(jstlCoordinates.getClassifier());
-
-    assertTrue(jstlApi.getFilters().isEmpty());
   }
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -94,12 +94,6 @@
               artifactId="jsp-api"
               version="2.1" />
       </libraryFile>
-      <libraryFile javadocUri="https://tomcat.apache.org/taglibs/standard/apidocs/">
-        <mavenCoordinates
-              groupId="javax.servlet"
-              artifactId="jstl"
-              version="1.2" />
-      </libraryFile>
     </library>
 
   </extension>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
@@ -134,7 +134,7 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
     creator.execute(monitor);
 
-    assertTrue(project.getFile("lib/fake-jstl-1.2.jar").exists());
+    assertTrue(project.getFile("src/main/webapp/WEB-INF/lib/fake-jstl-1.2.jar").exists());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
@@ -74,6 +74,14 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
     File servletApi31Jar = tempFolder.newFile("fake-servlet-api-3.1.jar");
     when(servletApi31.getFile()).thenReturn(servletApi31Jar);
 
+    final Artifact jspApi231 = mock(Artifact.class);
+    File jspApi231Jar = tempFolder.newFile("fake-jsp-api-2.3.1.jar");
+    when(jspApi231.getFile()).thenReturn(jspApi231Jar);
+
+    final Artifact jstl12 = mock(Artifact.class);
+    File jstl12Jar = tempFolder.newFile("fake-jstl-1.2.jar");
+    when(jstl12.getFile()).thenReturn(jstl12Jar);
+
     when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
         .thenAnswer(new Answer<Artifact>() {
           @Override
@@ -85,6 +93,14 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
                 && "javax.servlet-api".equals(coordinates.getArtifactId())
                 && "3.1.0".equals(coordinates.getVersion())) {
               return servletApi31;
+            } else if ("javax.servlet.jsp".equals(coordinates.getGroupId())
+                && "javax.servlet.jsp-api".equals(coordinates.getArtifactId())
+                && "2.3.1".equals(coordinates.getVersion())) {
+              return jspApi231;
+            } else if ("jstl".equals(coordinates.getGroupId())
+                && "jstl".equals(coordinates.getArtifactId())
+                && "1.2".equals(coordinates.getVersion())) {
+              return jstl12;
             } else {
               return someArtifact;
             }
@@ -103,6 +119,22 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
     creator.execute(monitor);
 
     assertTrue(project.getFile("lib/fake-servlet-api-3.1.jar").exists());
+  }
+
+  @Test
+  public void testJspApi231Added() throws InvocationTargetException, CoreException {
+    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    creator.execute(monitor);
+
+    assertTrue(project.getFile("lib/fake-jsp-api-2.3.1.jar").exists());
+  }
+
+  @Test
+  public void testJstl12Added() throws InvocationTargetException, CoreException {
+    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    creator.execute(monitor);
+
+    assertTrue(project.getFile("lib/fake-jstl-1.2.jar").exists());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
@@ -18,20 +18,29 @@ package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
+import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProjectTest;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -42,13 +51,58 @@ import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpProjectTest {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Mock
+  private ILibraryRepositoryService repositoryService;
+
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+    mockRepositoryService();
+  }
+
+  private void mockRepositoryService() throws IOException, CoreException {
+    final Artifact someArtifact = mock(Artifact.class);
+    when(someArtifact.getFile()).thenReturn(tempFolder.newFile());
+
+    final Artifact jstl12 = mock(Artifact.class);
+    File jstl12Jar = tempFolder.newFile("fake-jstl-1.2.jar");
+    when(jstl12.getFile()).thenReturn(jstl12Jar);
+
+    when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
+        .thenAnswer(new Answer<Artifact>() {
+          @Override
+          public Artifact answer(InvocationOnMock invocation) throws Throwable {
+            LibraryFile libraryFile = invocation.getArgumentAt(0, LibraryFile.class);
+            MavenCoordinates coordinates = libraryFile.getMavenCoordinates();
+            if ("jstl".equals(coordinates.getGroupId())
+                && "jstl".equals(coordinates.getArtifactId())
+                && "1.2".equals(coordinates.getVersion())) {
+              return jstl12;
+            } else {
+              return someArtifact;
+            }
+          }
+        });
+  }
 
   @Override
   protected CreateAppEngineWtpProject newCreateAppEngineWtpProject() {
-    return new CreateAppEngineStandardWtpProject(config, mock(IAdaptable.class));
+    return new CreateAppEngineStandardWtpProject(config, mock(IAdaptable.class), repositoryService);
   }
 
   @Test
@@ -80,6 +134,14 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
     assertAppEngineApiSdkOnClasspath();
   }
 
+  @Test
+  public void testJstlAdded() throws InvocationTargetException, CoreException {
+    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    creator.execute(monitor);
+
+    assertTrue(project.getFile("src/main/webapp/WEB-INF/lib/fake-jstl-1.2.jar").exists());
+  }
+
   private void assertAppEngineApiSdkOnClasspath() throws CoreException {
     IJavaProject javaProject = JavaCore.create(project);
     Matcher<IClasspathEntry> masterLibraryEntryMatcher =
@@ -105,7 +167,8 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
   @Test
   public void testNullConfig() {
     try {
-      new CreateAppEngineStandardWtpProject(null, mock(IAdaptable.class));
+      new CreateAppEngineStandardWtpProject(null, mock(IAdaptable.class),
+          mock(ILibraryRepositoryService.class));
       Assert.fail("allowed null config");
     } catch (NullPointerException ex) {
       // success

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
@@ -26,11 +26,11 @@ import com.google.cloud.tools.eclipse.appengine.newproject.CodeTemplates;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
 import com.google.cloud.tools.eclipse.util.ClasspathUtil;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,19 +66,26 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
   private static final List<MavenCoordinates> PROJECT_DEPENDENCIES;
 
   static {
-    MavenCoordinates.Builder servletApi = new MavenCoordinates.Builder()
+    // FIXME: servlet-api and jsp-api should be provided by the servlet container and not included
+    MavenCoordinates servletApi = new MavenCoordinates.Builder()
         .setGroupId("javax.servlet") //$NON-NLS-1$
         .setArtifactId("javax.servlet-api") //$NON-NLS-1$
-        .setVersion("3.1.0"); //$NON-NLS-1$
-    PROJECT_DEPENDENCIES = Collections.singletonList(servletApi.build());
+        .setVersion("3.1.0") //$NON-NLS-1$
+        .build();
+    MavenCoordinates jsp = new MavenCoordinates.Builder().setGroupId("javax.servlet.jsp") //$NON-NLS-1$
+        .setArtifactId("javax.servlet.jsp-api") //$NON-NLS-1$
+        .setVersion("2.3.1") //$NON-NLS-1$
+        .build();
+    MavenCoordinates jstl = new MavenCoordinates.Builder().setGroupId("jstl") //$NON-NLS-1$
+        .setArtifactId("jstl") //$NON-NLS-1$
+        .setVersion("1.2") //$NON-NLS-1$
+        .build();
+    PROJECT_DEPENDENCIES = ImmutableList.of(servletApi, jsp, jstl);
   }
-
-  private ILibraryRepositoryService repositoryService;
 
   CreateAppEngineFlexWtpProject(AppEngineProjectConfig config, IAdaptable uiInfoAdapter,
       ILibraryRepositoryService repositoryService) {
-    super(config, uiInfoAdapter);
-    this.repositoryService = repositoryService;
+    super(config, uiInfoAdapter, repositoryService);
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.newproject.flex;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
+import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
@@ -28,13 +28,9 @@ import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
 import com.google.cloud.tools.eclipse.util.ClasspathUtil;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -63,10 +59,11 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
   private static final Logger logger =
       Logger.getLogger(CreateAppEngineFlexWtpProject.class.getName());
 
+  private static final List<MavenCoordinates> SERVLET_DEPENDENCIES;
   private static final List<MavenCoordinates> PROJECT_DEPENDENCIES;
 
   static {
-    // FIXME: servlet-api and jsp-api should be provided by the servlet container and not included
+    // servlet-api and jsp-api are marked as not being included
     MavenCoordinates servletApi = new MavenCoordinates.Builder()
         .setGroupId("javax.servlet") //$NON-NLS-1$
         .setArtifactId("javax.servlet-api") //$NON-NLS-1$
@@ -76,11 +73,14 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
         .setArtifactId("javax.servlet.jsp-api") //$NON-NLS-1$
         .setVersion("2.3.1") //$NON-NLS-1$
         .build();
+    SERVLET_DEPENDENCIES = ImmutableList.of(servletApi, jsp);
+
     MavenCoordinates jstl = new MavenCoordinates.Builder().setGroupId("jstl") //$NON-NLS-1$
         .setArtifactId("jstl") //$NON-NLS-1$
         .setVersion("1.2") //$NON-NLS-1$
         .build();
-    PROJECT_DEPENDENCIES = ImmutableList.of(servletApi, jsp, jstl);
+    PROJECT_DEPENDENCIES = ImmutableList.of(jstl);
+
   }
 
   CreateAppEngineFlexWtpProject(AppEngineProjectConfig config, IAdaptable uiInfoAdapter,
@@ -141,30 +141,15 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
     }
 
     // Download the dependencies from maven
-    int ticks = 50 / PROJECT_DEPENDENCIES.size();
-    for (MavenCoordinates dependency : PROJECT_DEPENDENCIES) {
-      LibraryFile libraryFile = new LibraryFile(dependency);
-      File artifactFile = null;
-      try {
-        Artifact artifact = repositoryService.resolveArtifact(
-            libraryFile, subMonitor.newChild(ticks));
-        artifactFile = artifact.getFile();
-        IFile destFile = libFolder.getFile(artifactFile.getName());
-        destFile.create(Files.newInputStream(artifactFile.toPath()), true, subMonitor.newChild(30));
-      } catch (CoreException ex) {
-        logger.log(Level.WARNING, "Error downloading " + //$NON-NLS-1$
-            libraryFile.getMavenCoordinates().toString() + " from maven", ex); //$NON-NLS-1$
-      } catch (IOException ex) {
-        logger.log(Level.WARNING, "Error copying over " + artifactFile.toString() + " to " + //$NON-NLS-1$ //$NON-NLS-2$
-            libFolder.getFullPath().toPortableString(), ex);
-      }
+    subMonitor.setWorkRemaining(SERVLET_DEPENDENCIES.size() + 10);
+    for (MavenCoordinates dependency : SERVLET_DEPENDENCIES) {
+      installArtifact(dependency, libFolder, subMonitor.newChild(1));
     }
 
-    addDependenciesToClasspath(project, libFolder.getLocation().toString(),
-        subMonitor.newChild(10));
+    addDependenciesToClasspath(project, libFolder, subMonitor.newChild(10));
   }
 
-  private void addDependenciesToClasspath(IProject project, String libraryPath,
+  private void addDependenciesToClasspath(IProject project, IFolder folder,
       IProgressMonitor monitor)  throws CoreException {
     List<IClasspathEntry> newEntries = new ArrayList<>();
 
@@ -172,7 +157,7 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
         new IClasspathAttribute[] {UpdateClasspathAttributeUtil.createNonDependencyAttribute()};
 
     // Add all the jars under lib folder to the classpath
-    File libFolder = new File(libraryPath);
+    File libFolder = folder.getLocation().toFile();
     for (File file : libFolder.listFiles()) {
       IPath path = Path.fromOSString(file.toPath().toString());
       newEntries.add(JavaCore.newLibraryEntry(path, null, null, new IAccessRule[0],
@@ -181,5 +166,25 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
 
     ClasspathUtil.addClasspathEntries(project, newEntries, monitor);
   }
+
+  @Override
+  protected void addAdditionalDependencies(IProject newProject, IProgressMonitor monitor)
+      throws CoreException {
+    SubMonitor progress = SubMonitor.convert(monitor, 20);
+    super.addAdditionalDependencies(newProject, progress.newChild(10));
+
+    // locate WEB-INF/lib
+    IFolder webInfFolder = WebProjectUtil.getWebInfDirectory(newProject);
+    IFolder libFolder = webInfFolder.getFolder("lib"); //$NON-NLS-1$
+    if (!libFolder.exists()) {
+      libFolder.create(true, true, progress.newChild(5));
+    }
+
+    progress.setWorkRemaining(PROJECT_DEPENDENCIES.size());
+    for (MavenCoordinates dependency : PROJECT_DEPENDENCIES) {
+      installArtifact(dependency, libFolder, progress.newChild(10));
+    }
+  }
+
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.ILibraryClasspathContainerResolverService;
+import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectWizard;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
@@ -37,6 +38,9 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
 
   @Inject
   private ILibraryClasspathContainerResolverService resolverService;
+
+  @Inject
+  private ILibraryRepositoryService repositoryService;
 
   public AppEngineStandardProjectWizard() {
     setWindowTitle(Messages.getString("new.app.engine.standard.project"));
@@ -76,7 +80,7 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
   @Override
   public CreateAppEngineWtpProject getAppEngineProjectCreationOperation(
       AppEngineProjectConfig config, IAdaptable uiInfoAdapter) {
-    return new CreateAppEngineStandardWtpProject(config, uiInfoAdapter);
+    return new CreateAppEngineStandardWtpProject(config, uiInfoAdapter, repositoryService);
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProject.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
@@ -26,13 +25,8 @@ import com.google.cloud.tools.eclipse.appengine.newproject.CodeTemplates;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
 import com.google.common.collect.ImmutableList;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -103,25 +97,9 @@ public class CreateAppEngineStandardWtpProject extends CreateAppEngineWtpProject
     }
 
     // Download the dependencies from maven
-    progress.setWorkRemaining(10 * PROJECT_DEPENDENCIES.size());
+    progress.setWorkRemaining(PROJECT_DEPENDENCIES.size());
     for (MavenCoordinates dependency : PROJECT_DEPENDENCIES) {
-      LibraryFile libraryFile = new LibraryFile(dependency);
-      File artifactFile = null;
-      try {
-        Artifact artifact =
-            repositoryService.resolveArtifact(libraryFile, progress.newChild(5));
-        artifactFile = artifact.getFile();
-        IFile destFile = libFolder.getFile(artifactFile.getName());
-        destFile.create(Files.newInputStream(artifactFile.toPath()), true, progress.newChild(5));
-      } catch (CoreException ex) {
-        logger.log(Level.WARNING, "Error downloading " + //$NON-NLS-1$
-            libraryFile.getMavenCoordinates().toString() + " from maven", ex); //$NON-NLS-1$
-      } catch (IOException ex) {
-        logger.log(Level.WARNING, "Error copying over " + artifactFile.toString() + " to " + //$NON-NLS-1$ //$NON-NLS-2$
-            libFolder.getFullPath().toPortableString(), ex);
-      }
+      installArtifact(dependency, libFolder, progress.newChild(1));
     }
-
   }
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/plugin.xml
@@ -111,12 +111,6 @@
               artifactId="javax.servlet.jsp-api"
               version="2.3.0" />
       </libraryFile>
-      <libraryFile>
-        <mavenCoordinates
-              groupId="javax.servlet"
-              artifactId="jstl"
-              version="1.2" />
-      </libraryFile>
     </library>
   </extension>
   <extension

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.flex.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.flex.ftl
@@ -32,6 +32,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>javax.servlet.jsp-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jstl</groupId>
       <artifactId>jstl</artifactId>
       <version>1.2</version>

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
@@ -40,6 +40,7 @@
     </dependency>
 <#else>
     <dependency>
+      <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
       <scope>provided</scope>

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/pom.xml.standard.ftl
@@ -25,17 +25,32 @@
 
   <dependencies>
     <!-- Compile/runtime dependencies -->
+<#if servletVersion == "2.5">
     <dependency>
       <groupId>javax.servlet</groupId>
-<#if servletVersion == "2.5">
       <artifactId>servlet-api</artifactId>
       <version>2.5</version>
-<#else>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-</#if>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>jsp-api</artifactId>
+      <version>2.1</version>
+      <scope>provided</scope>
+    </dependency>
+<#else>
+    <dependency>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>javax.servlet.jsp-api</artifactId>
+      <version>2.3.1</version>
+      <scope>provided</scope>
+    </dependency>
+</#if>
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>


### PR DESCRIPTION
An alternative implementation for #2455 and #2456:
  - AES native (Java 7 + 8): downloads and installs `jstl:jstl:1.2` into the `src/main/webapp/WEB-INF/lib`; removes `jstl` from the servlet container (where it didn't belong)
  - AES maven (Java 7 + 8): sets up the `pom.xml` to `jstl:jstl:1.2` plus with appropriate `jsp-api` references
  - AEF native: downloads and installs `jstl:jstl:1.2` into `lib/` as was happening previously with `servlet-api` and `jsp-api`
     - this doesn't feel quite right, but we're not creating a proper WTP server runtime for flex
  - AEF maven: adds `jstl:jstl:1.2` to the `pom.xml`