### PR TITLE
Avoid NPE in DefaultRunOptionsPage#updatePreferencesFromInputs()

### DIFF
--- a/gcloud-eclipse-tools.launch
+++ b/gcloud-eclipse-tools.launch
@@ -7,7 +7,7 @@
 <stringAttribute key="bad_container_name" value="/trunk/gcloud-eclipse-tools-launcher"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
-<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearConfig" value="true"/>
 <booleanAttribute key="clearws" value="true"/>
 <booleanAttribute key="clearwslog" value="false"/>
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/gcloud-eclipse-tools"/>
@@ -24,7 +24,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.7 -XX:MaxPermSize=256m -Xms256m -Xmx1024m -Doauth.client.id=${oauth_id} -Doauth.client.secret=${oauth_secret} -DenableFlexPropertySettingsPage=false"/>
 <stringAttribute key="pde.version" value="3.3"/>
-<stringAttribute key="product" value="org.eclipse.platform.ide"/>
+<stringAttribute key="product" value="org.eclipse.sdk.ide"/>
 <booleanAttribute key="show_selected_only" value="false"/>
 <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
 <booleanAttribute key="tracing" value="false"/>

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/DefaultRunOptionsPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/DefaultRunOptionsPage.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.eclipse.dataflow.core.preferences.DataflowPreferen
 import com.google.cloud.tools.eclipse.dataflow.core.preferences.WritableDataflowPreferences;
 import com.google.cloud.tools.eclipse.dataflow.ui.Messages;
 import com.google.cloud.tools.eclipse.dataflow.ui.page.DialogPageMessageTarget;
-import com.google.cloud.tools.eclipse.projectselector.model.GcpProject;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.preference.PreferencePage;
@@ -73,8 +72,7 @@ public class DefaultRunOptionsPage
    */
   private void updatePreferencesFromInputs() {
     preferences.setDefaultAccountEmail(runOptionsComponent.getAccountEmail());
-    GcpProject project = runOptionsComponent.getProject();
-    preferences.setDefaultProject(project == null ? null : project.getId());
+    preferences.setDefaultProject(runOptionsComponent.getProjectId());
     preferences.setDefaultStagingLocation(runOptionsComponent.getStagingLocation());
   }
 


### PR DESCRIPTION
Default project ID should saved as empty string when there is no project selected.

Fixes #2429