### PR TITLE
0.x.0 versions aren't released

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFileTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFileTest.java
@@ -34,6 +34,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -201,4 +204,14 @@ public class LibraryFileTest {
     assertFalse(file.getMavenCoordinates().getVersion().isEmpty());
     assertNotEquals("15.0", file.getMavenCoordinates().getVersion());
   }
+  
+  // DefaultArtifactVersion.compareTo isn't well documented so test it here since we depend on this
+  // logic.
+  @Test
+  public void testCompareVersions() {
+    DefaultArtifactVersion newer = new DefaultArtifactVersion("0.25.0-alpha");
+    DefaultArtifactVersion older = new DefaultArtifactVersion("0.8.0");
+    Assert.assertTrue(newer.compareTo(older) > 0);
+  }
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 /**
  * A jar file that is downloaded from the location defined by {@link MavenCoordinates}. It can have
@@ -122,8 +123,11 @@ public class LibraryFile implements Comparable<LibraryFile> {
       ArtifactVersion remoteVersion = ArtifactRetriever.DEFAULT.getLatestArtifactVersion(
           mavenCoordinates.getGroupId(), mavenCoordinates.getArtifactId());
       if (remoteVersion != null) {
-        String updatedVersion = remoteVersion.toString(); 
-        mavenCoordinates = mavenCoordinates.toBuilder().setVersion(updatedVersion).build();
+        DefaultArtifactVersion localVersion = new DefaultArtifactVersion(mavenCoordinates.getVersion());
+        if (remoteVersion.compareTo(localVersion) > 0) {
+          String updatedVersion = remoteVersion.toString(); 
+          mavenCoordinates = mavenCoordinates.toBuilder().setVersion(updatedVersion).build();
+        }
       }
       fixedVersion = true;
     }

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ArtifactRetrieverIntegrationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ArtifactRetrieverIntegrationTest.java
@@ -56,5 +56,16 @@ public class ArtifactRetrieverIntegrationTest {
     Assert.assertEquals(19, guava.getMajorVersion());
     Assert.assertEquals(0, guava.getMinorVersion());
   }
+  
+  @Test
+  public void testGetLatestArtifactVersion() {
+    ArtifactVersion version = ArtifactRetriever.DEFAULT.getLatestArtifactVersion(
+        "com.google.cloud", "google-cloud-pubsub");
+    if (version == null) {
+      // No release version. This is success.
+      return; 
+    }
+    Assert.assertTrue(version.getMajorVersion() > 0);
+  }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/ArtifactRetrieverTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/ArtifactRetrieverTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.eclipse.util;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,4 +55,5 @@ public class ArtifactRetrieverTest {
     Assert.assertEquals("com.google.cloud.dataflow", actual[0]);
     Assert.assertEquals("google-cloud-dataflow-java-sdk-all", actual[1]);
   }
+  
 }

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/ArtifactRetriever.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/ArtifactRetriever.java
@@ -158,7 +158,7 @@ public class ArtifactRetriever {
     try {
       NavigableSet<ArtifactVersion> versions = availableVersions.get(coordinates);
       for (ArtifactVersion version : versions.descendingSet()) {
-        if (Strings.isNullOrEmpty(version.getQualifier())) {
+        if (version.getMajorVersion() > 0 && Strings.isNullOrEmpty(version.getQualifier())) {
           if (range == null || range.containsVersion(version)) {
             return version;
           }


### PR DESCRIPTION
This fixes the 0.8.0 problem but I don't think that it addresses #2481. I suspect that bug comes about in `Pom.addDependencies`. The mistake there is looping through all the library files in the library.

These used to be only the files declared in plugin.xml, but can now include files added transitively later. That one needs a little more thought.
