### PR TITLE
Refactor BuildPath methods

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
@@ -61,17 +61,16 @@ public class BuildPathTest {
     List<Library> libraries = new ArrayList<>();
     libraries.add(library);
 
-    IClasspathEntry[] result = BuildPath.addNativeLibrary(project, libraries, monitor);
-    Assert.assertEquals(1, result.length);
+    BuildPath.addNativeLibrary(project, libraries, monitor);
     Assert.assertEquals(initialClasspathSize + 1, project.getRawClasspath().length);
   }
   
   @Test
   public void testListNativeLibrary() throws CoreException {
     Library library = new Library("libraryId");
-    IClasspathEntry[] result =
+    IClasspathEntry result =
         BuildPath.listNativeLibrary(project, library, new NullProgressMonitor());
-    Assert.assertEquals(1, result.length);
+    Assert.assertNotNull(result);
     Assert.assertEquals(initialClasspathSize, project.getRawClasspath().length);
   }
 
@@ -80,11 +79,10 @@ public class BuildPathTest {
     Library library = new Library("libraryId");
     List<Library> libraries = new ArrayList<>();
     libraries.add(library);
-    IClasspathEntry[] setup = BuildPath.addNativeLibrary(project, libraries, monitor);
-    Assert.assertEquals(1, setup.length);
+    BuildPath.addNativeLibrary(project, libraries, monitor);
+    Assert.assertEquals(initialClasspathSize + 1, project.getRawClasspath().length);
 
-    IClasspathEntry[] result = BuildPath.addNativeLibrary(project, libraries, monitor);
-    Assert.assertEquals(0, result.length);
+    BuildPath.addNativeLibrary(project, libraries, monitor);
     Assert.assertEquals(initialClasspathSize + 1, project.getRawClasspath().length);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
@@ -16,11 +16,15 @@
 
 package com.google.cloud.tools.eclipse.appengine.libraries.ui;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.appengine.libraries.BuildPath;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
+import com.google.cloud.tools.eclipse.util.MavenUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -33,12 +37,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
-
-import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.libraries.BuildPath;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
-import com.google.cloud.tools.eclipse.util.MavenUtils;
 
 public abstract class CloudLibrariesPage extends WizardPage implements IClasspathContainerPage,
     IClasspathContainerPageExtension, IClasspathContainerPageExtension2 {
@@ -110,8 +108,12 @@ public abstract class CloudLibrariesPage extends WizardPage implements IClasspat
         return new IClasspathEntry[0];
       } else {
         Library masterLibrary = BuildPath.collectLibraryFiles(project, libraries, monitor.newChild(7));
-        IClasspathEntry[] added = BuildPath.listNativeLibrary(project, masterLibrary, monitor.newChild(3));
-        return added;
+        IClasspathEntry masterEntry = BuildPath.listNativeLibrary(project, masterLibrary, monitor.newChild(3));
+        if (masterEntry != null) {
+          return new IClasspathEntry[] {masterEntry};
+        } else {
+          return new IClasspathEntry[0];
+        }
       }
     } catch (CoreException ex) {
       return new IClasspathEntry[0];

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPath.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPath.java
@@ -22,9 +22,9 @@ import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.persistence.LibraryClasspathContainerSerializer;
 import com.google.cloud.tools.eclipse.util.ClasspathUtil;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -75,7 +75,7 @@ public class BuildPath {
   /**
    * Returns the entries added to the classpath.
    */
-  public static IClasspathEntry[] addNativeLibrary(IJavaProject javaProject,
+  public static void addNativeLibrary(IJavaProject javaProject,
       List<Library> libraries, IProgressMonitor monitor) throws CoreException {
     
     SubMonitor subMonitor = SubMonitor.convert(monitor,
@@ -84,7 +84,7 @@ public class BuildPath {
     
     Library masterLibrary = collectLibraryFiles(javaProject, libraries, subMonitor.newChild(8));
     subMonitor.worked(1);
-    List<IClasspathEntry> newEntries = computeEntries(javaProject, masterLibrary, subMonitor.newChild(8));
+    IClasspathEntry masterEntry = computeEntry(javaProject, masterLibrary, subMonitor.newChild(8));
     subMonitor.worked(1);
 
     List<String> libraryIds = new ArrayList<>();
@@ -102,10 +102,10 @@ public class BuildPath {
           StatusUtil.error(BuildPath.class, "Error saving master library list", ex));
     }
 
-    ClasspathUtil.addClasspathEntries(javaProject.getProject(), newEntries, subMonitor);
+    if (masterEntry != null) {
+      ClasspathUtil.addClasspathEntry(javaProject.getProject(), masterEntry, subMonitor);
+    }
     runContainerResolverJob(javaProject);
-
-    return newEntries.toArray(new IClasspathEntry[0]);
   }
 
   /**
@@ -144,17 +144,15 @@ public class BuildPath {
     return masterLibrary;
   }
 
-  private static List<IClasspathEntry> computeEntries(IJavaProject javaProject, Library library,
+  /**
+   * @return a {@link IClasspathEntry} created from {@code library} if {@code javaProject} does not
+   *     already have the entry; otherwise, {@code null}
+   */
+  private static IClasspathEntry computeEntry(IJavaProject javaProject, Library library,
       IProgressMonitor monitor) throws CoreException {
-
     SubMonitor subMonitor = SubMonitor.convert(monitor,
         Messages.getString("computing.entries"), //$NON-NLS-1$
-        12);
-    
-    List<IClasspathEntry> rawClasspath = Lists.newArrayList(javaProject.getRawClasspath());
-    List<IClasspathEntry> newEntries = new ArrayList<>();
-    IClasspathEntry libraryContainer = makeClasspathEntry(library);
-    subMonitor.worked(1);
+        11);
     
     if (CloudLibraries.MASTER_CONTAINER_ID.equals(library.getId())) {
       try {
@@ -167,22 +165,24 @@ public class BuildPath {
     }
     subMonitor.worked(10);
 
-    if (!rawClasspath.contains(libraryContainer)) {
-      newEntries.add(libraryContainer);
-    }
+    IClasspathEntry libraryContainer = makeClasspathEntry(library);
     subMonitor.worked(1);
 
-    return newEntries;
+    IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
+    boolean alreadyExists = Arrays.asList(rawClasspath).contains(libraryContainer);
+    return alreadyExists ? null : libraryContainer;
   }
   
   /**
-   * Returns the entries to be added to the classpath. Does not add them to the classpath.
+   * Returns the entry of {@code library} to be added to the classpath of {@code javaProject}, if
+   * the project does not already have it. (Note that this does not add it to the classpath.)
+   * Returns {@code null} otherwise.
    */
-  public static IClasspathEntry[] listNativeLibrary(IJavaProject javaProject, Library library,
+  public static IClasspathEntry listNativeLibrary(IJavaProject javaProject, Library library,
       IProgressMonitor monitor) throws CoreException {
-    List<IClasspathEntry> newEntries = computeEntries(javaProject, library, monitor);
+    IClasspathEntry libraryEntry = computeEntry(javaProject, library, monitor);
     runContainerResolverJob(javaProject);
-    return newEntries.toArray(new IClasspathEntry[0]);
+    return libraryEntry;
   }
 
   private static IClasspathEntry makeClasspathEntry(Library library) throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPath.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPath.java
@@ -136,7 +136,7 @@ public class BuildPath {
     masterLibrary.setLibraryDependencies(dependentIds);
     subMonitor.worked(1);
     
-    List<LibraryFile> resolved = Library.resolveDuplicates(new ArrayList<LibraryFile>(masterFiles));
+    List<LibraryFile> resolved = Library.resolveDuplicates(new ArrayList<>(masterFiles));
     subMonitor.worked(8);
     masterLibrary.setLibraryFiles(resolved);
     subMonitor.worked(1);
@@ -145,7 +145,7 @@ public class BuildPath {
   }
 
   /**
-   * @return a {@link IClasspathEntry} created from {@code library} if {@code javaProject} does not
+   * @return an {@link IClasspathEntry} created from {@code library} if {@code javaProject} does not
    *     already have the entry; otherwise, {@code null}
    */
   private static IClasspathEntry computeEntry(IJavaProject javaProject, Library library,


### PR DESCRIPTION
Currently, `listNativeLibrary()` and `computeEntres()` return either
  - a singleton list/array of the master container; or
  - an empty list/array.

So, to reduce confusion, I'm making them return just the master container (no list/array) or null.

Also we don't make use of the return value of `addNativeLibrary()` (except tests), so I made it `void`.