### PR TITLE
.deploy.test needs to include org.eclipse.jdt to detect VMs on macOS

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/pom.xml
@@ -29,6 +29,11 @@
                 <id>org.eclipse.jst.web_ui.feature</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.jdt</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
             </extraRequirements>
           </dependency-resolution>
         </configuration>


### PR DESCRIPTION
Fixes #2497
