### PR TITLE
Include plugin.xml in .cte13 bundle

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.cte13/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.cte13/build.properties
@@ -1,6 +1,7 @@
 source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
+               plugin.xml,\
                .
 javacSource=1.7
 javacTarget=1.7


### PR DESCRIPTION
BTW, we should remove `.appengine` from the bundle name.