### PR TITLE
Fix integration tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
@@ -65,6 +65,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
     updateOldContainers();
 
+    ProjectUtils.waitForProjects(project);
     ProjectUtils.failIfBuildErrors("Imported App Engine standard Java 7 project has errors",
         project);
 
@@ -93,6 +94,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
     updateOldContainers();
 
+    ProjectUtils.waitForProjects(project);
     ProjectUtils.failIfBuildErrors("Imported App Engine standard Java 8 project has errors",
         project);
 


### PR DESCRIPTION
#2509 fixed the integration tests with legacy library containers by migrating the containers, but [we still need the wait for the migration to complete]( https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/2509/files#r145276541).