### PR TITLE
Clean folder before uploading release binaries

### DIFF
--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -223,14 +223,19 @@ echo "# into 'gs://cloud-tools-for-eclipse/<VERSION>/'."
 echo "#"
 echo -n "Enter version: "
 read VERSION
+
+DESTINATION=gs://cloud-tools-for-eclipse/$VERSION
+echo
+echo "THIS WILL DELETE ALL FILES IN '$DESTINATION' IF THEY EXIST!"
 ask_proceed
 
 set -x
+gsutil -m rm $DESTINATION/** && \
 gsutil cp $LOCAL_REPO/artifacts.jar $LOCAL_REPO/content.jar \
     $SIGNED_DIR/index.html \
-    gs://cloud-tools-for-eclipse/$VERSION/ && \
+    $DESTINATION && \
 gsutil -m cp -R $LOCAL_REPO/features $LOCAL_REPO/plugins \
-    gs://cloud-tools-for-eclipse/$VERSION/
+    $DESTINATION
 set +x
 
 ###############################################################################


### PR DESCRIPTION
I noticed that some of our previous CT4E releases had duplicate bundles (with different timestamps), because we uploaded to the same destination (version directory) as we do multiple cuts during QA. Fortunately, bundles with old timestamps didn't seem to cause any trouble until now. Anyway, it's safe to clean the destination before uploading new binaries.

I've tested this a few times manually.