### PR TITLE
Refactor Maven coordinates UI

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUiTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUiTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.eclipse.test.util.ui.CompositeUtil;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.junit.Before;
@@ -44,7 +45,7 @@ public class MavenCoordinatesUiTest {
   @Before
   public void setUp() {
     shell = shellResource.getShell();
-    ui = new MavenCoordinatesUi(shell);
+    ui = new MavenCoordinatesUi(shell, SWT.NONE);
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUiTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUiTest.java
@@ -17,18 +17,14 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.maven;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
 
 import com.google.cloud.tools.eclipse.test.util.ui.CompositeUtil;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.DialogPage;
-import org.eclipse.jface.dialogs.IMessageProvider;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,17 +48,6 @@ public class MavenCoordinatesUiTest {
   }
 
   @Test
-  public void testUi() {
-    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
-    assertEquals("Create as Maven project", asMavenProject.getText());
-
-    assertFalse(asMavenProject.getSelection());
-    assertFalse(getGroupIdField().getEnabled());
-    assertFalse(getArtifactIdField().getEnabled());
-    assertFalse(getVersionField().getEnabled());
-  }
-
-  @Test
   public void testDefaultFieldValues() {
     assertTrue(getGroupIdField().getText().isEmpty());
     assertTrue(getArtifactIdField().getText().isEmpty());
@@ -70,78 +55,50 @@ public class MavenCoordinatesUiTest {
   }
 
   @Test
-  public void testDynamicEnabling() {
-    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
-
-    new SWTBotCheckBox(asMavenProject).click();
-    assertTrue(getGroupIdField().getEnabled());
-    assertTrue(getArtifactIdField().getEnabled());
-    assertTrue(getVersionField().getEnabled());
-
-    new SWTBotCheckBox(asMavenProject).click();
-    assertFalse(getGroupIdField().getEnabled());
-    assertFalse(getArtifactIdField().getEnabled());
-    assertFalse(getVersionField().getEnabled());
-  }
-
-  @Test
   public void testValidateMavenSettings_emptyGroupId() {
-    enableUi();
-
-    assertFalse(ui.setValidationMessage(dialogPage));
-    verify(dialogPage).setMessage("Provide Maven Group ID.", IMessageProvider.INFORMATION);
+    IStatus status = ui.validateMavenSettings();
+    assertEquals(status.getSeverity(), IStatus.INFO);
+    assertEquals("Provide Maven Group ID.", status.getMessage());
   }
 
   @Test
   public void testValidateMavenSettings_emptyArtifactId() {
-    enableUi();
     getGroupIdField().setText("com.example");
 
-    assertFalse(ui.setValidationMessage(dialogPage));
-    verify(dialogPage).setMessage("Provide Maven Artifact ID.", IMessageProvider.INFORMATION);
+    IStatus status = ui.validateMavenSettings();
+    assertEquals(status.getSeverity(), IStatus.INFO);
+    assertEquals("Provide Maven Artifact ID.", status.getMessage());
   }
 
   @Test
   public void testValidateMavenSettings_emptyVersion() {
-    enableUi();
     getGroupIdField().setText("com.example");
     getArtifactIdField().setText("some-artifact-id");
     getVersionField().setText("");
 
-    assertFalse(ui.setValidationMessage(dialogPage));
-    verify(dialogPage).setMessage("Provide Maven artifact version.", IMessageProvider.INFORMATION);
+    IStatus status = ui.validateMavenSettings();
+    assertEquals(status.getSeverity(), IStatus.INFO);
+    assertEquals("Provide Maven artifact version.", status.getMessage());
   }
 
   @Test
   public void testValidateMavenSettings_illegalGroupId() {
-    enableUi();
-
     getArtifactIdField().setText("some-artifact-id");
 
     getGroupIdField().setText("<:#= Illegal ID =#:>");
-    assertFalse(ui.setValidationMessage(dialogPage));
-    verify(dialogPage).setErrorMessage("Illegal Maven Group ID: <:#= Illegal ID =#:>");
+    IStatus status = ui.validateMavenSettings();
+    assertEquals(status.getSeverity(), IStatus.ERROR);
+    assertEquals("Illegal Maven Group ID: <:#= Illegal ID =#:>", status.getMessage());
   }
 
   @Test
   public void testValidateMavenSettings_illegalArtifactId() {
-    enableUi();
     getGroupIdField().setText("com.example");
 
     getArtifactIdField().setText("<:#= Illegal ID =#:>");
-    assertFalse(ui.setValidationMessage(dialogPage));
-    verify(dialogPage).setErrorMessage("Illegal Maven Artifact ID: <:#= Illegal ID =#:>");
-  }
-
-  @Test
-  public void testValidateMavenSettings_noValidationIfUiDisabled() {
-    getGroupIdField().setText("<:#= Illegal ID =#:>");
-    assertTrue(ui.setValidationMessage(dialogPage));
-  }
-
-  private void enableUi() {
-    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
-    new SWTBotCheckBox(asMavenProject).click();
+    IStatus status = ui.validateMavenSettings();
+    assertEquals(status.getSeverity(), IStatus.ERROR);
+    assertEquals("Illegal Maven Artifact ID: <:#= Illegal ID =#:>", status.getMessage());
   }
 
   private Text getGroupIdField() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUiTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUiTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.newproject.maven;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.tools.eclipse.test.util.ui.CompositeUtil;
+import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
+import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MavenCoordinatesWizardUiTest {
+
+  @Rule public ShellTestResource shellResource = new ShellTestResource();
+  @Mock private DialogPage dialogPage;
+
+  private Shell shell;
+  private MavenCoordinatesWizardUi ui;
+
+  @Before
+  public void setUp() {
+    shell = shellResource.getShell();
+    ui = new MavenCoordinatesWizardUi(shell);
+  }
+
+  @Test
+  public void testUi() {
+    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
+    assertEquals("Create as Maven project", asMavenProject.getText());
+
+    assertFalse(asMavenProject.getSelection());
+    assertFalse(getGroupIdField().getEnabled());
+    assertFalse(getArtifactIdField().getEnabled());
+    assertFalse(getVersionField().getEnabled());
+  }
+
+  @Test
+  public void testDefaultFieldValues() {
+    assertTrue(getGroupIdField().getText().isEmpty());
+    assertTrue(getArtifactIdField().getText().isEmpty());
+    assertEquals("0.1.0-SNAPSHOT", getVersionField().getText());
+  }
+
+  @Test
+  public void testDynamicEnabling() {
+    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
+
+    new SWTBotCheckBox(asMavenProject).click();
+    assertTrue(getGroupIdField().getEnabled());
+    assertTrue(getArtifactIdField().getEnabled());
+    assertTrue(getVersionField().getEnabled());
+
+    new SWTBotCheckBox(asMavenProject).click();
+    assertFalse(getGroupIdField().getEnabled());
+    assertFalse(getArtifactIdField().getEnabled());
+    assertFalse(getVersionField().getEnabled());
+  }
+
+  @Test
+  public void testValidateMavenSettings_okWhenDisabled() {
+    assertFalse(ui.uiEnabled());
+    assertTrue(ui.validateMavenSettings().isOK());
+  }
+
+  @Test
+  public void testSetValidationMessage_okWhenDisabled() {
+    assertFalse(ui.uiEnabled());
+    assertTrue(ui.setValidationMessage(dialogPage));
+  }
+
+  @Test
+  public void testSetValidationMessage_emptyGroupId() {
+    enableUi();
+
+    assertFalse(ui.setValidationMessage(dialogPage));
+    verify(dialogPage).setMessage("Provide Maven Group ID.", IMessageProvider.INFORMATION);
+  }
+
+  @Test
+  public void testSetValidationMessage_emptyArtifactId() {
+    enableUi();
+    getGroupIdField().setText("com.example");
+
+    assertFalse(ui.setValidationMessage(dialogPage));
+    verify(dialogPage).setMessage("Provide Maven Artifact ID.", IMessageProvider.INFORMATION);
+  }
+
+  @Test
+  public void testSetValidationMessage_emptyVersion() {
+    enableUi();
+    getGroupIdField().setText("com.example");
+    getArtifactIdField().setText("some-artifact-id");
+    getVersionField().setText("");
+
+    assertFalse(ui.setValidationMessage(dialogPage));
+    verify(dialogPage).setMessage("Provide Maven artifact version.", IMessageProvider.INFORMATION);
+  }
+
+  @Test
+  public void testSetValidationMessage_illegalGroupId() {
+    enableUi();
+
+    getArtifactIdField().setText("some-artifact-id");
+
+    getGroupIdField().setText("<:#= Illegal ID =#:>");
+    assertFalse(ui.setValidationMessage(dialogPage));
+    verify(dialogPage).setErrorMessage("Illegal Maven Group ID: <:#= Illegal ID =#:>");
+  }
+
+  @Test
+  public void testSetValidationMessage_illegalArtifactId() {
+    enableUi();
+    getGroupIdField().setText("com.example");
+
+    getArtifactIdField().setText("<:#= Illegal ID =#:>");
+    assertFalse(ui.setValidationMessage(dialogPage));
+    verify(dialogPage).setErrorMessage("Illegal Maven Artifact ID: <:#= Illegal ID =#:>");
+  }
+
+  @Test
+  public void testValidateMavenSettings_noValidationIfUiDisabled() {
+    getGroupIdField().setText("<:#= Illegal ID =#:>");
+    assertTrue(ui.setValidationMessage(dialogPage));
+  }
+
+  private void enableUi() {
+    Button asMavenProject = CompositeUtil.findControl(shell, Button.class);
+    new SWTBotCheckBox(asMavenProject).click();
+  }
+
+  private Text getGroupIdField() {
+    return CompositeUtil.findControlAfterLabel(shell, Text.class, "Group ID:");
+  }
+
+  private Text getArtifactIdField() {
+    return CompositeUtil.findControlAfterLabel(shell, Text.class, "Artifact ID:");
+  }
+
+  private Text getVersionField() {
+    return CompositeUtil.findControlAfterLabel(shell, Text.class, "Version:");
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUiTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUiTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.eclipse.test.util.ui.CompositeUtil;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import org.eclipse.jface.dialogs.DialogPage;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
@@ -48,7 +49,7 @@ public class MavenCoordinatesWizardUiTest {
   @Before
   public void setUp() {
     shell = shellResource.getShell();
-    ui = new MavenCoordinatesWizardUi(shell);
+    ui = new MavenCoordinatesWizardUi(shell, SWT.NONE);
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.eclipse.appengine.newproject;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.libraries.ui.LibrarySelectorGroup;
-import com.google.cloud.tools.eclipse.appengine.newproject.maven.MavenCoordinatesUi;
+import com.google.cloud.tools.eclipse.appengine.newproject.maven.MavenCoordinatesWizardUi;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.cloud.tools.eclipse.util.JavaPackageValidator;
 import com.google.cloud.tools.eclipse.util.MavenCoordinatesValidator;
@@ -52,7 +52,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
   private LibrarySelectorGroup appEngineLibrariesSelectorGroup;
   private Text javaPackageField;
   private Text serviceNameField;
-  private MavenCoordinatesUi mavenCoordinatesUi;
+  private MavenCoordinatesWizardUi mavenCoordinatesUi;
   private final boolean showLibrariesSelectorGroup;
 
   /** True if we should auto-generate the javaPackageField from the provided groupId */
@@ -79,7 +79,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
 
     createCustomFields(container);
 
-    mavenCoordinatesUi = new MavenCoordinatesUi(container);
+    mavenCoordinatesUi = new MavenCoordinatesWizardUi(container);
     mavenCoordinatesUi.addChangeListener(new Listener() {
       @Override
       public void handleEvent(Event event) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineWizardPage.java
@@ -79,7 +79,7 @@ public abstract class AppEngineWizardPage extends WizardNewProjectCreationPage {
 
     createCustomFields(container);
 
-    mavenCoordinatesUi = new MavenCoordinatesWizardUi(container);
+    mavenCoordinatesUi = new MavenCoordinatesWizardUi(container, SWT.NONE);
     mavenCoordinatesUi.addChangeListener(new Listener() {
       @Override
       public void handleEvent(Event event) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUi.java
@@ -21,16 +21,10 @@ import com.google.cloud.tools.eclipse.util.MavenCoordinatesValidator;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jface.dialogs.DialogPage;
-import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
@@ -39,50 +33,30 @@ public class MavenCoordinatesUi {
 
   private static final String DEFAULT_VERSION = "0.1.0-SNAPSHOT"; //$NON-NLS-1$
 
-  private Button asMavenProjectButton;
-  private Group coordinatesGroup;
-  private Text groupIdField;
-  private Text artifactIdField;
-  private Text versionField;
-  private Label groupIdLabel;
-  private Label artifactIdLabel;
-  private Label versionLabel;
+  private final Text groupIdField;
+  private final Text artifactIdField;
+  private final Text versionField;
+  private final Label groupIdLabel;
+  private final Label artifactIdLabel;
+  private final Label versionLabel;
 
   public MavenCoordinatesUi(Composite container) {
-    asMavenProjectButton = new Button(container, SWT.CHECK);
-    asMavenProjectButton.setText(Messages.getString("CREATE_AS_MAVEN_PROJECT")); //$NON-NLS-1$
-    asMavenProjectButton.addSelectionListener(new SelectionAdapter() {
-      @Override
-      public void widgetSelected(SelectionEvent event) {
-        updateEnablement();
-      }
-    });
-
-    coordinatesGroup = new Group(container, SWT.NONE);
-    coordinatesGroup.setText(Messages.getString("MAVEN_PROJECT_COORDINATES")); //$NON-NLS-1$
-
-    groupIdLabel = new Label(coordinatesGroup, SWT.LEAD);
+    groupIdLabel = new Label(container, SWT.LEAD);
     groupIdLabel.setText(Messages.getString("GROUP_ID")); //$NON-NLS-1$
-    groupIdField = new Text(coordinatesGroup, SWT.BORDER);
+    groupIdField = new Text(container, SWT.BORDER);
     groupIdField.setToolTipText(Messages.getString("GROUP_ID_TOOLTIP")); //$NON-NLS-1$
 
-    artifactIdLabel = new Label(coordinatesGroup, SWT.LEAD);
+    artifactIdLabel = new Label(container, SWT.LEAD);
     artifactIdLabel.setText(Messages.getString("ARTIFACT_ID")); //$NON-NLS-1$
-    artifactIdField = new Text(coordinatesGroup, SWT.BORDER);
+    artifactIdField = new Text(container, SWT.BORDER);
     artifactIdField.setToolTipText(Messages.getString("ARTIFACT_ID_TOOLTIP")); //$NON-NLS-1$
 
-    versionLabel = new Label(coordinatesGroup, SWT.LEAD);
+    versionLabel = new Label(container, SWT.LEAD);
     versionLabel.setText(Messages.getString("ARTIFACT_VERSION")); //$NON-NLS-1$
-    versionField = new Text(coordinatesGroup, SWT.BORDER);
+    versionField = new Text(container, SWT.BORDER);
     versionField.setText(DEFAULT_VERSION);
 
-    updateEnablement();
-
-    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(coordinatesGroup);
-  }
-
-  public boolean uiEnabled() {
-    return asMavenProjectButton.getSelection();
+    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(container);
   }
 
   public String getGroupId() {
@@ -101,35 +75,26 @@ public class MavenCoordinatesUi {
     groupIdField.addListener(SWT.Modify, listener);
     artifactIdField.addListener(SWT.Modify, listener);
     versionField.addListener(SWT.Modify, listener);
-    if (asMavenProjectButton != null) {
-      asMavenProjectButton.addListener(SWT.Selection, listener);
-    }
   }
 
   public void addGroupIdModifyListener(ModifyListener listener) {
     groupIdField.addModifyListener(listener);
   }
 
-  private void updateEnablement() {
-    boolean checked = asMavenProjectButton.getSelection();
-    coordinatesGroup.setEnabled(checked);
-    groupIdLabel.setEnabled(checked);
-    groupIdField.setEnabled(checked);
-    artifactIdLabel.setEnabled(checked);
-    artifactIdField.setEnabled(checked);
-    versionLabel.setEnabled(checked);
-    versionField.setEnabled(checked);
+  public void setEnabled(boolean enabled) {
+    groupIdLabel.setEnabled(enabled);
+    groupIdField.setEnabled(enabled);
+    artifactIdLabel.setEnabled(enabled);
+    artifactIdField.setEnabled(enabled);
+    versionLabel.setEnabled(enabled);
+    versionField.setEnabled(enabled);
   }
 
   /**
-   * @return {@link IStatus#OK} if there was no validation problem or the UI is disabled; otherwise
-   *     a status describing a validation problem (with a non-OK status)
+   * @return {@link IStatus#OK} if there was no validation problem; otherwise a status describing a
+   *     validation problem (with a non-OK status)
    */
   public IStatus validateMavenSettings() {
-    if (!uiEnabled()) {
-      return Status.OK_STATUS;
-    }
-
     if (getGroupId().isEmpty()) {
       return StatusUtil.info(this, Messages.getString("PROVIDE_GROUP_ID")); //$NON-NLS-1$
     } else if (getArtifactId().isEmpty()) {
@@ -147,29 +112,5 @@ public class MavenCoordinatesUi {
           Messages.getString("ILLEGAL_VERSION", getVersion())); //$NON-NLS-1$
     }
     return Status.OK_STATUS;
-  }
-
-  /**
-   * Convenience method to set a validation message on {@link DialogPage} from the result of calling
-   * {@link #validateMavenSettings()}.
-   *
-   * @return {@code true} if no validation message was set; {@code false} otherwise
-   *
-   * @see #validateMavenSettings()
-   */
-  public boolean setValidationMessage(DialogPage page) {
-    IStatus status = validateMavenSettings();
-    if (status.isOK()) {
-      return true;
-    }
-
-    if (IStatus.ERROR == status.getSeverity()) {
-      page.setErrorMessage(status.getMessage());
-    } else if (IStatus.WARNING == status.getSeverity()) {
-      page.setMessage(status.getMessage(), IMessageProvider.WARNING);
-    } else if (IStatus.INFO == status.getSeverity()) {
-      page.setMessage(status.getMessage(), IMessageProvider.INFORMATION);
-    }
-    return false;
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesUi.java
@@ -25,11 +25,12 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
-public class MavenCoordinatesUi {
+public class MavenCoordinatesUi extends Group {
 
   private static final String DEFAULT_VERSION = "0.1.0-SNAPSHOT"; //$NON-NLS-1$
 
@@ -40,23 +41,30 @@ public class MavenCoordinatesUi {
   private final Label artifactIdLabel;
   private final Label versionLabel;
 
-  public MavenCoordinatesUi(Composite container) {
-    groupIdLabel = new Label(container, SWT.LEAD);
+  public MavenCoordinatesUi(Composite container, int style) {
+    super(container, style);
+
+    groupIdLabel = new Label(this, SWT.LEAD);
     groupIdLabel.setText(Messages.getString("GROUP_ID")); //$NON-NLS-1$
-    groupIdField = new Text(container, SWT.BORDER);
+    groupIdField = new Text(this, SWT.BORDER);
     groupIdField.setToolTipText(Messages.getString("GROUP_ID_TOOLTIP")); //$NON-NLS-1$
 
-    artifactIdLabel = new Label(container, SWT.LEAD);
+    artifactIdLabel = new Label(this, SWT.LEAD);
     artifactIdLabel.setText(Messages.getString("ARTIFACT_ID")); //$NON-NLS-1$
-    artifactIdField = new Text(container, SWT.BORDER);
+    artifactIdField = new Text(this, SWT.BORDER);
     artifactIdField.setToolTipText(Messages.getString("ARTIFACT_ID_TOOLTIP")); //$NON-NLS-1$
 
-    versionLabel = new Label(container, SWT.LEAD);
+    versionLabel = new Label(this, SWT.LEAD);
     versionLabel.setText(Messages.getString("ARTIFACT_VERSION")); //$NON-NLS-1$
-    versionField = new Text(container, SWT.BORDER);
+    versionField = new Text(this, SWT.BORDER);
     versionField.setText(DEFAULT_VERSION);
 
-    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(container);
+    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(this);
+  }
+
+  @Override
+  protected void checkSubclass () {
+    // Allow subclassing by not calling super().
   }
 
   public String getGroupId() {
@@ -81,7 +89,9 @@ public class MavenCoordinatesUi {
     groupIdField.addModifyListener(listener);
   }
 
+  @Override
   public void setEnabled(boolean enabled) {
+    super.setEnabled(enabled);
     groupIdLabel.setEnabled(enabled);
     groupIdField.setEnabled(enabled);
     artifactIdLabel.setEnabled(enabled);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
@@ -28,18 +28,18 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Listener;
 
-public class MavenCoordinatesWizardUi {
+public class MavenCoordinatesWizardUi extends Composite {
 
   private final Button asMavenProjectButton;
 
   private final MavenCoordinatesUi mavenCoordinatesUi;
-  private final Group coordinatesGroup;
 
-  public MavenCoordinatesWizardUi(Composite container) {
-    asMavenProjectButton = new Button(container, SWT.CHECK);
+  public MavenCoordinatesWizardUi(Composite container, int style) {
+    super(container, style);
+
+    asMavenProjectButton = new Button(this, SWT.CHECK);
     asMavenProjectButton.setText(Messages.getString("CREATE_AS_MAVEN_PROJECT")); //$NON-NLS-1$
     asMavenProjectButton.addSelectionListener(new SelectionAdapter() {
       @Override
@@ -48,14 +48,12 @@ public class MavenCoordinatesWizardUi {
       }
     });
 
-    coordinatesGroup = new Group(container, SWT.NONE);
-    coordinatesGroup.setText(Messages.getString("MAVEN_PROJECT_COORDINATES")); //$NON-NLS-1$
-
-    mavenCoordinatesUi = new MavenCoordinatesUi(coordinatesGroup);
+    mavenCoordinatesUi = new MavenCoordinatesUi(this, SWT.NONE);
+    mavenCoordinatesUi.setText(Messages.getString("MAVEN_PROJECT_COORDINATES")); //$NON-NLS-1$
 
     updateEnablement();
 
-    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(coordinatesGroup);
+    GridLayoutFactory.swtDefaults().generateLayout(this);
   }
 
   public boolean uiEnabled() {
@@ -87,7 +85,6 @@ public class MavenCoordinatesWizardUi {
 
   private void updateEnablement() {
     boolean checked = asMavenProjectButton.getSelection();
-    coordinatesGroup.setEnabled(checked);
     mavenCoordinatesUi.setEnabled(checked);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.newproject.maven;
+
+import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.dialogs.DialogPage;
+import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Listener;
+
+public class MavenCoordinatesWizardUi {
+
+  private final Button asMavenProjectButton;
+
+  private final MavenCoordinatesUi mavenCoordinatesUi;
+  private final Group coordinatesGroup;
+
+  public MavenCoordinatesWizardUi(Composite container) {
+    asMavenProjectButton = new Button(container, SWT.CHECK);
+    asMavenProjectButton.setText(Messages.getString("CREATE_AS_MAVEN_PROJECT")); //$NON-NLS-1$
+    asMavenProjectButton.addSelectionListener(new SelectionAdapter() {
+      @Override
+      public void widgetSelected(SelectionEvent event) {
+        updateEnablement();
+      }
+    });
+
+    coordinatesGroup = new Group(container, SWT.NONE);
+    coordinatesGroup.setText(Messages.getString("MAVEN_PROJECT_COORDINATES")); //$NON-NLS-1$
+
+    mavenCoordinatesUi = new MavenCoordinatesUi(coordinatesGroup);
+
+    updateEnablement();
+
+    GridLayoutFactory.swtDefaults().numColumns(2).generateLayout(coordinatesGroup);
+  }
+
+  public boolean uiEnabled() {
+    return asMavenProjectButton.getSelection();
+  }
+
+  public String getGroupId() {
+    return mavenCoordinatesUi.getGroupId();
+  }
+
+  public String getArtifactId() {
+    return mavenCoordinatesUi.getArtifactId();
+  }
+
+  public String getVersion() {
+    return mavenCoordinatesUi.getVersion();
+  }
+
+  public void addChangeListener(Listener listener) {
+    mavenCoordinatesUi.addChangeListener(listener);
+    if (asMavenProjectButton != null) {
+      asMavenProjectButton.addListener(SWT.Selection, listener);
+    }
+  }
+
+  public void addGroupIdModifyListener(ModifyListener listener) {
+    mavenCoordinatesUi.addGroupIdModifyListener(listener);
+  }
+
+  private void updateEnablement() {
+    boolean checked = asMavenProjectButton.getSelection();
+    coordinatesGroup.setEnabled(checked);
+    mavenCoordinatesUi.setEnabled(checked);
+  }
+
+  /**
+   * @return {@link IStatus#OK} if there was no validation problem or the UI is disabled; otherwise
+   *     a status describing a validation problem (with a non-OK status)
+   */
+  public IStatus validateMavenSettings() {
+    if (!uiEnabled()) {
+      return Status.OK_STATUS;
+    } else {
+      return mavenCoordinatesUi.validateMavenSettings();
+    }
+  }
+
+  /**
+   * Convenience method to set a validation message on {@link DialogPage} from the result of calling
+   * {@link #validateMavenSettings()}.
+   *
+   * @return {@code true} if no validation message was set; {@code false} otherwise
+   *
+   * @see #validateMavenSettings()
+   */
+  public boolean setValidationMessage(DialogPage page) {
+    IStatus status = validateMavenSettings();
+    if (status.isOK()) {
+      return true;
+    }
+
+    if (IStatus.ERROR == status.getSeverity()) {
+      page.setErrorMessage(status.getMessage());
+    } else if (IStatus.WARNING == status.getSeverity()) {
+      page.setMessage(status.getMessage(), IMessageProvider.WARNING);
+    } else if (IStatus.INFO == status.getSeverity()) {
+      page.setMessage(status.getMessage(), IMessageProvider.INFORMATION);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Separating out the "Create as Maven Project" checkbox and the surrounding UI group from `MavenCoordinatesUi` into a new class `MavenCoordinatesWizardUi`.

This is in preparation for #2470, where we will only support creating a Maven project.

There is no visual or functional change. I verified that the wizards work fine, as they should.