### PR TITLE
Inject appengine-api-1.0-sdk JAR to local apps

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviourTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviourTest.java
@@ -17,28 +17,46 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.api.devserver.DefaultRunConfiguration;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
+import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour.PortChecker;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LocalAppEngineServerBehaviourTest {
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
   @Mock
   private PortChecker alwaysTrue;
   @Mock
@@ -227,5 +245,47 @@ public class LocalAppEngineServerBehaviourTest {
     serverBehavior.checkPorts(runConfig, portProber);
     assertEquals(-1, serverBehavior.adminPort);
     verify(portProber, never()).isInUse(any(InetAddress.class), eq(8000));
+  }
+
+  @Test
+  public void testAppEngineApiSdkJarExists_noJar() {
+    Path emptyFolder = tempFolder.getRoot().toPath();
+    assertFalse(LocalAppEngineServerBehaviour.appEngineApiSdkJarExists(emptyFolder));
+  }
+
+  @Test
+  public void testAppEngineApiSdkJarExists_jarExists() throws IOException {
+    tempFolder.newFile("appengine-api-1.0-sdk-99.99.99.jar");
+    Path rootFolder = tempFolder.getRoot().toPath();
+    assertTrue(LocalAppEngineServerBehaviour.appEngineApiSdkJarExists(rootFolder));
+  }
+
+  @Test
+  public void testAppEngineApiSdkJarExists_caseInsensitive() throws IOException {
+    tempFolder.newFile("AppEngine-ApI-1.0-sDK-99.99.99.JaR");
+    Path rootFolder = tempFolder.getRoot().toPath();
+    assertTrue(LocalAppEngineServerBehaviour.appEngineApiSdkJarExists(rootFolder));
+  }
+
+  @Test
+  public void testPutAppEngineApiSdkJarIntoApps() throws IOException, CoreException {
+    Artifact appEngineApi = mock(Artifact.class);
+    when(appEngineApi.getFile()).thenReturn(tempFolder.newFile("fake.jar"));
+
+    ILibraryRepositoryService repositoryService = mock(ILibraryRepositoryService.class);
+    when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
+        .thenReturn(appEngineApi);
+
+    File appDirectory1 = tempFolder.newFolder("app1");
+    File appDirectory2 = tempFolder.newFolder("app2");
+    Path libDirectory1 = appDirectory1.toPath().resolve("WEB-INF/lib");
+    Path libDirectory2 = appDirectory1.toPath().resolve("WEB-INF/lib");
+    assertTrue(libDirectory2 .toFile().mkdirs());
+
+    List<File> appDirectories = Arrays.asList(appDirectory1, appDirectory2);
+    LocalAppEngineServerBehaviour.putAppEngineApiSdkJarIntoApps(appDirectories, repositoryService);
+
+    assertTrue(Files.exists(libDirectory1.resolve("fake.jar")));
+    assertTrue(Files.exists(libDirectory2.resolve("fake.jar")));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviourTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviourTest.java
@@ -270,7 +270,7 @@ public class LocalAppEngineServerBehaviourTest {
   @Test
   public void testPutAppEngineApiSdkJarIntoApps() throws IOException, CoreException {
     Artifact appEngineApi = mock(Artifact.class);
-    when(appEngineApi.getFile()).thenReturn(tempFolder.newFile("fake.jar"));
+    when(appEngineApi.getFile()).thenReturn(tempFolder.newFile("appengine-api-1.0-sdk-9.8.7.jar"));
 
     ILibraryRepositoryService repositoryService = mock(ILibraryRepositoryService.class);
     when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
@@ -280,12 +280,35 @@ public class LocalAppEngineServerBehaviourTest {
     File appDirectory2 = tempFolder.newFolder("app2");
     Path libDirectory1 = appDirectory1.toPath().resolve("WEB-INF/lib");
     Path libDirectory2 = appDirectory1.toPath().resolve("WEB-INF/lib");
-    assertTrue(libDirectory2 .toFile().mkdirs());
+    assertTrue(libDirectory2.toFile().mkdirs());
 
     List<File> appDirectories = Arrays.asList(appDirectory1, appDirectory2);
     LocalAppEngineServerBehaviour.putAppEngineApiSdkJarIntoApps(appDirectories, repositoryService);
 
-    assertTrue(Files.exists(libDirectory1.resolve("fake.jar")));
-    assertTrue(Files.exists(libDirectory2.resolve("fake.jar")));
+    assertTrue(Files.exists(libDirectory1.resolve("appengine-api-1.0-sdk-9.8.7.jar")));
+    assertTrue(Files.exists(libDirectory2.resolve("appengine-api-1.0-sdk-9.8.7.jar")));
+  }
+
+  @Test
+  public void testPutAppEngineApiSdkJarIntoApps_noCopyIfAlreadyExists()
+      throws IOException, CoreException {
+    Artifact appEngineApi = mock(Artifact.class);
+    when(appEngineApi.getFile()).thenReturn(tempFolder.newFile("fake.jar"));
+
+    ILibraryRepositoryService repositoryService = mock(ILibraryRepositoryService.class);
+    when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
+        .thenReturn(appEngineApi);
+
+    File appDirectory = tempFolder.newFolder("app1");
+    Path libDirectory = appDirectory.toPath().resolve("WEB-INF/lib");
+    Path appEngineApiSdkJar = libDirectory.resolve("appengine-api-1.0-sdk-1.23.45.jar"); 
+    assertTrue(libDirectory.toFile().mkdirs());
+    assertTrue(appEngineApiSdkJar.toFile().createNewFile());
+
+    LocalAppEngineServerBehaviour.putAppEngineApiSdkJarIntoApps(
+        Arrays.asList(appDirectory), repositoryService);
+
+    assertFalse(Files.exists(libDirectory.resolve("appengine-api-1.0-sdk-9.8.7.jar")));
+    assertTrue(Files.exists(libDirectory.resolve("appengine-api-1.0-sdk-1.23.45.jar")));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -33,7 +33,7 @@
    <extension
          point="org.eclipse.wst.server.core.serverTypes">
       <serverType
-            behaviourClass="com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour"
+            behaviourClass="com.google.cloud.tools.eclipse.util.service.ServiceContextFactory:com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerBehaviour"
             class="com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEngineServerDelegate"
             description="%runtimeTypeDescription"
             id="com.google.cloud.tools.eclipse.appengine.standard.server"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServletClasspathProvider.java
@@ -96,8 +96,10 @@ public class ServletClasspathProvider extends RuntimeClasspathProviderDelegate {
       IClasspathEntry[] apiEntries =
           resolverService.resolveLibraryAttachSourcesSync(servletApiId);
       IClasspathEntry[] jspApiEntries = resolverService.resolveLibraryAttachSourcesSync(jspApiId);
-      IClasspathEntry[] appEngineSdkEntries = resolverService.resolveLibraryAttachSourcesSync("appengine-api");
-      IClasspathEntry[] result = ObjectArrays.concat(apiEntries, jspApiEntries, IClasspathEntry.class);
+      IClasspathEntry[] appEngineSdkEntries =
+          resolverService.resolveLibraryAttachSourcesSync("appengine-api");
+      IClasspathEntry[] result =
+          ObjectArrays.concat(apiEntries, jspApiEntries, IClasspathEntry.class);
       result = ObjectArrays.concat(result, appEngineSdkEntries, IClasspathEntry.class);
       return result;
     } catch (CoreException ex) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
@@ -31,9 +31,10 @@ cloudsdk.not.configured=Could not run project because the Cloud SDK was not foun
 cloudsdk.out.of.date=Could not run project because the installed Cloud SDK is too old. \
  Run `gcloud components update` and try again.
 conflicts.with.running.server=Conflicts with running server "{0}"
- 
- deleted.project=Deleted project: {0}
- 
+
+deleted.project=Deleted project: {0}
+
 devappserver.not.available=There is no App Engine development server available
+cannot.copy.appengine.api.sdk.jar=Cannot copy appengine-api-1.0-sdk.jar
 server.already.in.operation=Server is already in operation
 server.port=server port: {0,number,\#}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -27,28 +27,40 @@ import com.google.cloud.tools.appengine.cloudsdk.process.ProcessExitListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessStartListener;
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
+import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
 import com.google.cloud.tools.eclipse.appengine.localserver.Messages;
 import com.google.cloud.tools.eclipse.sdk.MessageConsoleWriterOutputLineListener;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.inject.Inject;
+import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.ui.console.MessageConsoleStream;
@@ -95,6 +107,9 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
 
   private static final Logger logger =
       Logger.getLogger(LocalAppEngineServerBehaviour.class.getName());
+
+  @Inject
+  private ILibraryRepositoryService repositoryService;
 
   private LocalAppEngineStartListener localAppEngineStartListener;
   private LocalAppEngineExitListener localAppEngineExitListener;
@@ -218,7 +233,6 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
   private static IStatus newErrorStatus(String message) {
     return new Status(IStatus.ERROR, Activator.PLUGIN_ID, message);
   }
-
 
   @Override
   public void setupLaunchConfiguration(ILaunchConfigurationWorkingCopy workingCopy,
@@ -344,6 +358,10 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
     setServerState(IServer.STATE_STARTING);
     setMode(mode);
 
+    // TODO(chanseok): remove once Bug 68205805 is fixed. This is a temporary workaround for
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2531.
+    putAppEngineApiSdkJarIntoApps(devServerRunConfiguration.getServices(), repositoryService);
+
     // Create dev app server instance
     initializeDevServer(outputStream, errorStream, javaHomePath);
 
@@ -354,6 +372,41 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
       Activator.logError("Error starting server: " + ex.getMessage()); //$NON-NLS-1$
       stop(true);
     }
+  }
+
+  @VisibleForTesting
+  static void putAppEngineApiSdkJarIntoApps(List<File> appDirectories,
+      ILibraryRepositoryService repositoryService) throws CoreException {
+    try {
+      Library library = CloudLibraries.getLibrary("appengine-api");
+      for (LibraryFile libraryFile : library.getAllDependencies()) {
+        Artifact artifact =
+            repositoryService.resolveArtifact(libraryFile, new NullProgressMonitor());
+        Path artifactPath = artifact.getFile().toPath();
+
+        for (File appDirectory : appDirectories) {
+          Path libDirectory = appDirectory.toPath().resolve("WEB-INF/lib");
+          libDirectory.toFile().mkdirs();
+          if (!appEngineApiSdkJarExists(libDirectory)) {
+            Files.copy(artifactPath, libDirectory.resolve(artifactPath.getFileName()));
+          }
+        }
+      }
+    } catch (IOException e) {
+      String message = Messages.getString("cannot.copy.appengine.api.sdk.jar");
+      throw new CoreException(StatusUtil.error(LocalAppEngineServerBehaviour.class, message, e));
+    }
+  }
+
+  @VisibleForTesting
+  static boolean appEngineApiSdkJarExists(Path directory) {
+    for (String file : directory.toFile().list()) {
+      String lowercase = file.toLowerCase(Locale.US);
+      if (lowercase.startsWith("appengine-api-1.0-sdk") && lowercase.endsWith(".jar")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static int ifNull(Integer value, int defaultValue) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -400,9 +399,9 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
 
   @VisibleForTesting
   static boolean appEngineApiSdkJarExists(Path directory) {
-    for (String file : directory.toFile().list()) {
-      String lowercase = file.toLowerCase(Locale.US);
-      if (lowercase.startsWith("appengine-api-1.0-sdk") && lowercase.endsWith(".jar")) {
+    Pattern pattern = Pattern.compile("^appengine-api-1.0-sdk-.+\\.jar$", Pattern.CASE_INSENSITIVE);
+    for (String filename : directory.toFile().list()) {
+      if (pattern.matcher(filename).matches()) {
         return true;
       }
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -56,8 +55,6 @@ import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
  * Utility to create a new App Engine Flexible Eclipse project.
  */
 public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
-  private static final Logger logger =
-      Logger.getLogger(CreateAppEngineFlexWtpProject.class.getName());
 
   private static final List<MavenCoordinates> SERVLET_DEPENDENCIES;
   private static final List<MavenCoordinates> PROJECT_DEPENDENCIES;


### PR DESCRIPTION
Fixes #2531.

Puts (copies) appengine-api-1.0-sdk JAR into locally published users' apps, just before starting dev_appserver1.

- Doesn't put the JAR if apps already have one in `WEB-INF/lib`.
- We can keep the current `pom.xml` template and the non-export setting of the JAR.