### PR TITLE
Do not put WEB-INF/lib/jstl-1.2.jar for Maven projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,
+ com.google.common.cache;version="15.0.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.jdt.core,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,
- com.google.common.cache;version="15.0.0",
+ com.google.common.cache;version="[20.0.0,21.0.0)",
  org.eclipse.core.resources,
  org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.jdt.core,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
@@ -21,13 +21,24 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
+import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
+import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.util.MavenUtils;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -47,10 +58,21 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
+@RunWith(MockitoJUnitRunner.class)
 public abstract class CreateAppEngineWtpProjectTest {
 
   @Rule public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Mock protected ILibraryRepositoryService repositoryService;
 
   protected final IProgressMonitor monitor = new NullProgressMonitor();
   protected final AppEngineProjectConfig config = new AppEngineProjectConfig();
@@ -58,12 +80,13 @@ public abstract class CreateAppEngineWtpProjectTest {
 
   protected abstract CreateAppEngineWtpProject newCreateAppEngineWtpProject();
 
-  // Let subclasses throw arbitrary exceptions during "setUp()"
   @Before
-  public void setUp() throws Exception {
+  public void setUp() throws CoreException {
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     project = workspace.getRoot().getProject("testproject" + Math.random());
     config.setProject(project);
+
+    mockRepositoryService();
   }
 
   @After
@@ -73,6 +96,32 @@ public abstract class CreateAppEngineWtpProjectTest {
       ProjectUtils.waitForProjects(project);
       project.delete(true, monitor);
     }
+  }
+
+  private void mockRepositoryService() throws CoreException {
+    final LoadingCache<String, Artifact> fakeArtifactStore = CacheBuilder.newBuilder().build(
+        new CacheLoader<String, Artifact>() {
+          @Override
+          public Artifact load(String artifactKey) throws Exception {
+            Artifact artifact = mock(Artifact.class);
+            File jar = tempFolder.newFile("fake-" + artifactKey + ".jar");
+            when(artifact.getFile()).thenReturn(jar);
+            return artifact;
+          }
+        });
+
+    Answer<Artifact> answerFakeArtifact = new Answer<Artifact>() {
+      @Override
+      public Artifact answer(InvocationOnMock invocation) throws Throwable {
+        LibraryFile libraryFile = invocation.getArgumentAt(0, LibraryFile.class);
+        MavenCoordinates coordinates = libraryFile.getMavenCoordinates();
+        String artifactKey = coordinates.getGroupId() + "-" + coordinates.getArtifactId()
+            + "-" + coordinates.getVersion();
+        return fakeArtifactStore.get(artifactKey);
+      }
+    };
+    when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
+        .thenAnswer(answerFakeArtifact);
   }
 
   @Test
@@ -207,5 +256,22 @@ public abstract class CreateAppEngineWtpProjectTest {
       }
     }
     return false;
+  }
+
+  @Test
+  public void testJstl12JarIfnonMavenProject() throws InvocationTargetException, CoreException {
+    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    creator.execute(monitor);
+
+    assertTrue(project.getFile("src/main/webapp/WEB-INF/lib/fake-jstl-jstl-1.2.jar").exists());
+  }
+
+  @Test
+  public void testNoJstl12JarIfMavenProject() throws InvocationTargetException, CoreException {
+    config.setUseMaven("my.group.id", "my-other-artifact-id", "12.34.56");
+    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    creator.execute(monitor);
+
+    assertFalse(project.getFile("src/main/webapp/WEB-INF/lib/fake-jstl-jstl-1.2.jar").exists());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
@@ -259,7 +259,7 @@ public abstract class CreateAppEngineWtpProjectTest {
   }
 
   @Test
-  public void testJstl12JarIfnonMavenProject() throws InvocationTargetException, CoreException {
+  public void testJstl12JarIfNonMavenProject() throws InvocationTargetException, CoreException {
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
     creator.execute(monitor);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProjectTest.java
@@ -17,22 +17,14 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.flex;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
-import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProjectTest;
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import org.apache.maven.artifact.Artifact;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -42,71 +34,9 @@ import org.eclipse.jst.j2ee.classpathdep.IClasspathDependencyConstants;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProjectTest {
-
-  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
-
-  @Mock private ILibraryRepositoryService repositoryService;
-
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    super.setUp();
-    mockRepositoryService();
-  }
-
-  private void mockRepositoryService() throws IOException, CoreException {
-    final Artifact someArtifact = mock(Artifact.class);
-    when(someArtifact.getFile()).thenReturn(tempFolder.newFile());
-
-    final Artifact servletApi31 = mock(Artifact.class);
-    File servletApi31Jar = tempFolder.newFile("fake-servlet-api-3.1.jar");
-    when(servletApi31.getFile()).thenReturn(servletApi31Jar);
-
-    final Artifact jspApi231 = mock(Artifact.class);
-    File jspApi231Jar = tempFolder.newFile("fake-jsp-api-2.3.1.jar");
-    when(jspApi231.getFile()).thenReturn(jspApi231Jar);
-
-    final Artifact jstl12 = mock(Artifact.class);
-    File jstl12Jar = tempFolder.newFile("fake-jstl-1.2.jar");
-    when(jstl12.getFile()).thenReturn(jstl12Jar);
-
-    when(repositoryService.resolveArtifact(any(LibraryFile.class), any(IProgressMonitor.class)))
-        .thenAnswer(new Answer<Artifact>() {
-          @Override
-          public Artifact answer(InvocationOnMock invocation) throws Throwable {
-            LibraryFile libraryFile = invocation.getArgumentAt(0, LibraryFile.class);
-            MavenCoordinates coordinates = libraryFile.getMavenCoordinates();
-
-            if ("javax.servlet".equals(coordinates.getGroupId())
-                && "javax.servlet-api".equals(coordinates.getArtifactId())
-                && "3.1.0".equals(coordinates.getVersion())) {
-              return servletApi31;
-            } else if ("javax.servlet.jsp".equals(coordinates.getGroupId())
-                && "javax.servlet.jsp-api".equals(coordinates.getArtifactId())
-                && "2.3.1".equals(coordinates.getVersion())) {
-              return jspApi231;
-            } else if ("jstl".equals(coordinates.getGroupId())
-                && "jstl".equals(coordinates.getArtifactId())
-                && "1.2".equals(coordinates.getVersion())) {
-              return jstl12;
-            } else {
-              return someArtifact;
-            }
-          }
-        });
-  }
 
   @Override
   protected CreateAppEngineWtpProject newCreateAppEngineWtpProject() {
@@ -118,7 +48,7 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
     creator.execute(monitor);
 
-    assertTrue(project.getFile("lib/fake-servlet-api-3.1.jar").exists());
+    assertTrue(project.getFile("lib/fake-javax.servlet-javax.servlet-api-3.1.0.jar").exists());
   }
 
   @Test
@@ -126,15 +56,8 @@ public class CreateAppEngineFlexWtpProjectTest extends CreateAppEngineWtpProject
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
     creator.execute(monitor);
 
-    assertTrue(project.getFile("lib/fake-jsp-api-2.3.1.jar").exists());
-  }
-
-  @Test
-  public void testJstl12Added() throws InvocationTargetException, CoreException {
-    CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
-    creator.execute(monitor);
-
-    assertTrue(project.getFile("src/main/webapp/WEB-INF/lib/fake-jstl-1.2.jar").exists());
+    assertTrue(project.getFile("lib/fake-javax.servlet.jsp-javax.servlet.jsp-api-2.3.1.jar")
+        .exists());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/CreateAppEngineFlexWtpProject.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.eclipse.appengine.newproject.flex;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
@@ -60,7 +59,6 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
       Logger.getLogger(CreateAppEngineFlexWtpProject.class.getName());
 
   private static final List<MavenCoordinates> SERVLET_DEPENDENCIES;
-  private static final List<MavenCoordinates> PROJECT_DEPENDENCIES;
 
   static {
     // servlet-api and jsp-api are marked as not being included
@@ -74,13 +72,6 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
         .setVersion("2.3.1") //$NON-NLS-1$
         .build();
     SERVLET_DEPENDENCIES = ImmutableList.of(servletApi, jsp);
-
-    MavenCoordinates jstl = new MavenCoordinates.Builder().setGroupId("jstl") //$NON-NLS-1$
-        .setArtifactId("jstl") //$NON-NLS-1$
-        .setVersion("1.2") //$NON-NLS-1$
-        .build();
-    PROJECT_DEPENDENCIES = ImmutableList.of(jstl);
-
   }
 
   CreateAppEngineFlexWtpProject(AppEngineProjectConfig config, IAdaptable uiInfoAdapter,
@@ -166,25 +157,5 @@ public class CreateAppEngineFlexWtpProject extends CreateAppEngineWtpProject {
 
     ClasspathUtil.addClasspathEntries(project, newEntries, monitor);
   }
-
-  @Override
-  protected void addAdditionalDependencies(IProject newProject, IProgressMonitor monitor)
-      throws CoreException {
-    SubMonitor progress = SubMonitor.convert(monitor, 20);
-    super.addAdditionalDependencies(newProject, progress.newChild(10));
-
-    // locate WEB-INF/lib
-    IFolder webInfFolder = WebProjectUtil.getWebInfDirectory(newProject);
-    IFolder libFolder = webInfFolder.getFolder("lib"); //$NON-NLS-1$
-    if (!libFolder.exists()) {
-      libFolder.create(true, true, progress.newChild(5));
-    }
-
-    progress.setWorkRemaining(PROJECT_DEPENDENCIES.size());
-    for (MavenCoordinates dependency : PROJECT_DEPENDENCIES) {
-      installArtifact(dependency, libFolder, progress.newChild(10));
-    }
-  }
-
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProject.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProject.java
@@ -17,17 +17,12 @@
 package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
-import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
 import com.google.cloud.tools.eclipse.appengine.newproject.CodeTemplates;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
@@ -40,16 +35,6 @@ import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
  * Utility to make a new Eclipse project with the App Engine Standard facets in the workspace.
  */
 public class CreateAppEngineStandardWtpProject extends CreateAppEngineWtpProject {
-
-  private static final List<MavenCoordinates> PROJECT_DEPENDENCIES;
-
-  static {
-    MavenCoordinates jstl = new MavenCoordinates.Builder().setGroupId("jstl") //$NON-NLS-1$
-        .setArtifactId("jstl") //$NON-NLS-1$
-        .setVersion("1.2") //$NON-NLS-1$
-        .build();
-    PROJECT_DEPENDENCIES = ImmutableList.of(jstl);
-  }
 
   public CreateAppEngineStandardWtpProject(AppEngineProjectConfig config,
       IAdaptable uiInfoAdapter, ILibraryRepositoryService repositoryService) {
@@ -76,27 +61,5 @@ public class CreateAppEngineStandardWtpProject extends CreateAppEngineWtpProject
   public IFile createAndConfigureProjectContent(IProject newProject, AppEngineProjectConfig config,
       IProgressMonitor monitor) throws CoreException {
     return CodeTemplates.materializeAppEngineStandardFiles(newProject, config, monitor);
-  }
-
-  /**
-   * Install dependencies into {@code WEB-INF/lib}.
-   */
-  @Override
-  protected void addAdditionalDependencies(IProject newProject, IProgressMonitor monitor)
-      throws CoreException {
-    SubMonitor progress = SubMonitor.convert(monitor, 20);
-    super.addAdditionalDependencies(newProject, progress.newChild(10));
-
-    IFolder webInfFolder = WebProjectUtil.getWebInfDirectory(newProject);
-    IFolder libFolder = webInfFolder.getFolder("lib"); //$NON-NLS-1$
-    if (!libFolder.exists()) {
-      libFolder.create(true, true, progress.newChild(5));
-    }
-
-    // Download the dependencies from maven
-    progress.setWorkRemaining(PROJECT_DEPENDENCIES.size());
-    for (MavenCoordinates dependency : PROJECT_DEPENDENCIES) {
-      installArtifact(dependency, libFolder, progress.newChild(1));
-    }
   }
 }


### PR DESCRIPTION
Fixes #2535.

Both flex and standard (regardless of Java 7 or Java 8) add JSTL 1.2, so I decided to push down it to the base class.

I suggest to review from bottom to top of the screen — easy to see which code got moved around.

Let's see if tests will pass.