### PR TITLE
Fix pom.xml

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.ui/pom.xml
@@ -4,6 +4,7 @@
     <groupId>com.google.cloud.tools.eclipse</groupId>
     <artifactId>trunk</artifactId>
     <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.ui</artifactId>
   <version>0.1.0-SNAPSHOT</version>


### PR DESCRIPTION
This got missed in #2556. Running `mvn` on the command line fails. (I noticed Maven 3.5.0 works without this, and that's why Travis has been working.)