### PR TITLE
Add basic FileFieldSetter

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui/src/com/google/cloud/tools/eclipse/appengine/deploy/ui/flexible/FlexDeployPreferencesPanel.java
@@ -21,9 +21,9 @@ import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexDeployPreference
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.AppEngineDeployPreferencesPanel;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.Messages;
 import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.AppYamlValidator;
-import com.google.cloud.tools.eclipse.appengine.deploy.ui.internal.RelativeFileFieldSetter;
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.projectselector.ProjectRepository;
+import com.google.cloud.tools.eclipse.ui.util.event.RelativeFileFieldSetter;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.layout.GridDataFactory;

--- a/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/util/event/FileFieldSetterTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/util/event/FileFieldSetterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.ui.util.event;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Text;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileFieldSetterTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Mock private Text field;
+  @Mock private FileDialog dialog;
+  @Mock private SelectionEvent event;
+  private final String[] filter = new String[0];
+
+  @Test
+  public void testFileDialogCanceled() {
+    when(field.getText()).thenReturn("");
+    when(dialog.open()).thenReturn(null /* means canceled */);
+
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    verify(field, never()).setText(anyString());
+  }
+
+  @Test
+  public void testSetField() {
+    when(field.getText()).thenReturn("");
+    when(dialog.open()).thenReturn("/absolute/path/to/app.yaml");
+
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    verify(field).setText("/absolute/path/to/app.yaml");
+  }
+
+  @Test
+  public void testFileDialogFilterSet_relativePathInField() {
+    when(field.getText()).thenReturn("relative/path/file.txt");
+    when(dialog.open()).thenReturn(null);
+
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    verify(dialog).setFilterPath("");  // Empty means the FileDialog opens the "default" directory.
+  }
+
+  @Test
+  public void testFileDialogFilterSet_absolutePathInField() {
+    IPath absolutePath = new Path(tempFolder.getRoot().getAbsolutePath());
+    when(field.getText()).thenReturn(absolutePath + "/sub/directory/file.txt");
+    when(dialog.open()).thenReturn(null);
+
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    // "absolutePath" is the first physically existing directory.
+    verify(dialog).setFilterPath(absolutePath.toString());
+
+    absolutePath.append("sub").toFile().mkdir();
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    verify(dialog).setFilterPath(absolutePath + "/sub");
+  }
+
+  @Test
+  public void testFileDialogFileterExtensionSet() {
+    when(field.getText()).thenReturn("");
+    new FileFieldSetter(field, filter, dialog).widgetSelected(event);
+    verify(dialog).setFilterExtensions(filter);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/util/event/RelativeFileFieldSetterTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/util/event/RelativeFileFieldSetterTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.appengine.deploy.ui.internal;
+package com.google.cloud.tools.eclipse.ui.util.event;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
@@ -59,7 +60,9 @@ public class RelativeFileFieldSetterTest {
     try {
       new RelativeFileFieldSetter(field, new Path("non/absolute/base/path"), filter, dialog);
       fail();
-    } catch (IllegalArgumentException ex) {}
+    } catch (IllegalArgumentException ex) {
+      assertEquals("basePath not absolute", ex.getMessage());
+    }
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.ui/src/com/google/cloud/tools/eclipse/ui/util/event/FileFieldSetter.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui/src/com/google/cloud/tools/eclipse/ui/util/event/FileFieldSetter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.ui.util.event;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * {@link SelectionListener} that opens a {@link FileDialog} to show the file set in the associated
+ * {@link Text} field (if possible) and sets the field after the user chooses a file.
+ */
+public class FileFieldSetter extends SelectionAdapter {
+
+  private final Text fileField;
+  private final FileDialog dialog;
+  private final String[] filterExtensions;
+
+  public FileFieldSetter(Text fileField, String[] filterExtensions) {
+    this(fileField, filterExtensions, new FileDialog(fileField.getShell(), SWT.SHEET));
+  }
+
+  @VisibleForTesting
+  FileFieldSetter(Text fileField, String[] filterExtensions, FileDialog fileDialog) {
+    this.fileField = fileField;
+    this.filterExtensions = filterExtensions;
+    dialog = fileDialog;
+  }
+
+  @Override
+  public void widgetSelected(SelectionEvent event) {
+    IPath inputPath = new Path(fileField.getText().trim());
+
+    IPath filterPath = preProcessInputPath(inputPath);
+    while (!filterPath.isEmpty() && !filterPath.isRoot() && !filterPath.toFile().isDirectory()) {
+      filterPath = filterPath.removeLastSegments(1);
+    }
+    dialog.setFilterPath(filterPath.toString());
+    dialog.setFilterExtensions(filterExtensions);
+
+    String result = dialog.open();
+    if (result != null) {
+      IPath pathToSet = postProcessResultPath(new Path(result));
+      fileField.setText(pathToSet.toString());
+    }
+  }
+
+  protected IPath preProcessInputPath(IPath inputPath) {
+    return inputPath;
+  }
+
+  protected IPath postProcessResultPath(IPath result) {
+    return result;
+  }
+}


### PR DESCRIPTION
- Moved `RelativeFileFieldSetter` to the UI util bundle.
- Created the basic `FileFieldSetter` (extracted from `RelativeFileFieldSetter`). Will be used in the near future.
- Made `RelativeFileFieldSetter` extend `FileFieldSetter`.