### PR TITLE
bump request size to 700 and paginate

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
@@ -193,7 +193,7 @@ public class ProjectRepositoryTest {
   @Test
   public void testHasAppengineApplication_hasApplication()
       throws IOException, ProjectRepositoryException {
-    com.google.api.services.appengine.v1.Appengine.Apps.Get get = initializeGetRequest();
+    Apps.Get get = initializeGetRequest();
     Application application = new Application();
     application.setId("id");
     when(get.execute()).thenReturn(application);
@@ -205,7 +205,7 @@ public class ProjectRepositoryTest {
   @Test
   public void testHasAppengineApplication_noApplication()
       throws IOException, ProjectRepositoryException {
-    com.google.api.services.appengine.v1.Appengine.Apps.Get get = initializeGetRequest();
+    Apps.Get get = initializeGetRequest();
     GoogleJsonResponseException notFoundException =
         GoogleJsonResponseExceptionFactoryTesting.newMock(new JacksonFactory(), 404, "Not found");
     when(get.execute()).thenThrow(notFoundException);
@@ -217,7 +217,7 @@ public class ProjectRepositoryTest {
   @Test(expected = ProjectRepositoryException.class)
   public void testHasAppengineApplication_exception()
       throws IOException, ProjectRepositoryException {
-    com.google.api.services.appengine.v1.Appengine.Apps.Get get = initializeGetRequest();
+    Apps.Get get = initializeGetRequest();
     when(get.execute()).thenThrow(new IOException("test exception"));
 
     repository.getAppEngineApplication(mock(Credential.class), "projectId");
@@ -226,7 +226,7 @@ public class ProjectRepositoryTest {
   @Test(expected = ProjectRepositoryException.class)
   public void testHasAppengineApplication_GoogleJsonResponseException()
       throws IOException, ProjectRepositoryException {
-    com.google.api.services.appengine.v1.Appengine.Apps.Get get = initializeGetRequest();
+    Apps.Get get = initializeGetRequest();
     GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting
         .newMock(new JacksonFactory(), 500, "Server Error");
     when(get.execute()).thenThrow(exception);

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
@@ -206,8 +206,8 @@ public class ProjectRepositoryTest {
   public void testHasAppengineApplication_GoogleJsonResponseException()
       throws IOException, ProjectRepositoryException {
     com.google.api.services.appengine.v1.Appengine.Apps.Get get = initializeGetRequest();
-    GoogleJsonResponseException exception =
-        GoogleJsonResponseExceptionFactoryTesting.newMock(new JacksonFactory(), 500, "Server Error");
+    GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting
+        .newMock(new JacksonFactory(), 500, "Server Error");
     when(get.execute()).thenThrow(exception);
 
     repository.getAppEngineApplication(mock(Credential.class), "projectId");
@@ -219,8 +219,8 @@ public class ProjectRepositoryTest {
     Assert.assertTrue(projects.isEmpty());
   }
 
-  private com.google.api.services.appengine.v1.Appengine.Apps.Get
-  initializeGetRequest() throws IOException {
+  private com.google.api.services.appengine.v1.Appengine.Apps.Get initializeGetRequest()
+      throws IOException {
     Apps apps = mock(Apps.class);
     when(apiFactory.newAppsApi(any(Credential.class))).thenReturn(apps);
 

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
@@ -255,6 +255,7 @@ public class ProjectRepositoryTest {
     Projects.List list = mock(Projects.List.class);
     when(projects.list()).thenReturn(list);
     when(list.setPageSize(anyInt())).thenReturn(list);
+    when(list.setPageToken(anyString())).thenReturn(list);
     return list;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepositoryTest.java
@@ -56,12 +56,11 @@ public class ProjectRepositoryTest {
 
   @Mock private IGoogleApiFactory apiFactory;
   private ProjectRepository repository;
-  private Project project;
+  private Project project = new Project();
 
   @Before
   public void setUp() {
     repository = new ProjectRepository(apiFactory);
-    project = new Project();
     project.setName("projectName").setProjectId("projectId");
   }
 
@@ -73,8 +72,7 @@ public class ProjectRepositoryTest {
 
   @Test(expected = ProjectRepositoryException.class)
   public void testGetProjects_exceptionInRequest() throws IOException, ProjectRepositoryException {
-    com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List list =
-        initializeListRequest();
+    Projects.List list = initializeListRequest();
     when(list.execute()).thenThrow(new IOException("test exception"));
 
     repository.getProjects(mock(Credential.class));
@@ -82,8 +80,7 @@ public class ProjectRepositoryTest {
 
   @Test
   public void testGetProjects_successful() throws IOException, ProjectRepositoryException {
-    com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List list =
-        initializeListRequest();
+    Projects.List list = initializeListRequest();
     ListProjectsResponse response = new ListProjectsResponse();
     response.setProjects(Collections.singletonList(project));
     when(list.execute()).thenReturn(response);
@@ -96,12 +93,36 @@ public class ProjectRepositoryTest {
     assertThat(gcpProject.getName(), is("projectName"));
     assertThat(gcpProject.getId(), is("projectId"));
   }
+  
+  @Test
+  public void testGetProjects_pagination() throws IOException, ProjectRepositoryException {
+    Projects.List list = initializeListRequest();
+    ListProjectsResponse response1 = new ListProjectsResponse();
+    response1.setProjects(Collections.singletonList(project));
+    response1.setNextPageToken("a token");
+    
+    ListProjectsResponse response2 = new ListProjectsResponse();
+    Project project2 = new Project();
+    project2.setName("project 2").setProjectId("project_2");
+    response2.setProjects(Collections.singletonList(project2));
+    
+    when(list.execute()).thenReturn(response1, response2);
+
+    List<GcpProject> gcpProjects = repository.getProjects(mock(Credential.class));
+
+    assertThat(gcpProjects.size(), is(2));
+    GcpProject gcpProject = gcpProjects.get(0);
+    assertThat(gcpProject.getName(), is("projectName"));
+    assertThat(gcpProject.getId(), is("projectId"));
+    GcpProject gcpProject2 = gcpProjects.get(1);
+    assertThat(gcpProject2.getName(), is("project 2"));
+    assertThat(gcpProject2.getId(), is("project_2"));
+  }
 
   @Test
   public void testGetProjects_onlyDeletedProjectsReturned()
       throws IOException, ProjectRepositoryException {
-    com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List list =
-        initializeListRequest();
+    Projects.List list = initializeListRequest();
     ListProjectsResponse response = new ListProjectsResponse();
     response.setProjects(Collections.singletonList(project));
     project.setLifecycleState("DELETE_REQUESTED");
@@ -219,23 +240,19 @@ public class ProjectRepositoryTest {
     Assert.assertTrue(projects.isEmpty());
   }
 
-  private com.google.api.services.appengine.v1.Appengine.Apps.Get initializeGetRequest()
-      throws IOException {
+  private Apps.Get initializeGetRequest() throws IOException {
     Apps apps = mock(Apps.class);
     when(apiFactory.newAppsApi(any(Credential.class))).thenReturn(apps);
 
-    com.google.api.services.appengine.v1.Appengine.Apps.Get get =
-        mock(com.google.api.services.appengine.v1.Appengine.Apps.Get.class);
+    Apps.Get get = mock(Apps.Get.class);
     when(apps.get(anyString())).thenReturn(get);
     return get;
   }
 
-  private com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List
-  initializeListRequest() throws IOException {
+  private Projects.List initializeListRequest() throws IOException {
     Projects projects = mock(Projects.class);
     when(apiFactory.newProjectsApi(any(Credential.class))).thenReturn(projects);
-    com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List list =
-        mock(com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects.List.class);
+    Projects.List list = mock(Projects.List.class);
     when(projects.list()).thenReturn(list);
     when(list.setPageSize(anyInt())).thenReturn(list);
     return list;

--- a/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepository.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepository.java
@@ -38,7 +38,7 @@ import java.util.List;
  */
 public class ProjectRepository {
 
-  private static final int PROJECT_LIST_PAGESIZE = 300;
+  private static final int PROJECT_LIST_PAGESIZE = 700;
   private static final String PROJECT_DELETE_REQUESTED = "DELETE_REQUESTED";
 
   private final IGoogleApiFactory apiFactory;

--- a/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepository.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectRepository.java
@@ -38,7 +38,10 @@ import java.util.List;
  */
 public class ProjectRepository {
 
+  // API may return fewer than 700 results in one request, but 600 and change is the
+  // most we've seen in any one account to date.
   private static final int PROJECT_LIST_PAGESIZE = 700;
+  
   private static final String PROJECT_DELETE_REQUESTED = "DELETE_REQUESTED";
 
   private final IGoogleApiFactory apiFactory;
@@ -56,9 +59,20 @@ public class ProjectRepository {
     // TODO cache results https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1374
     try {
       Projects projects = apiFactory.newProjectsApi(credential);
-      ListProjectsResponse execute =
-          projects.list().setPageSize(PROJECT_LIST_PAGESIZE).execute();
-      return convertToGcpProjects(execute.getProjects());
+      
+      String token = null;
+      List<Project> projectList = new ArrayList<>();
+      do {
+        Projects.List listRequest = projects.list().setPageSize(PROJECT_LIST_PAGESIZE);
+        if (token != null) {
+          listRequest = listRequest.setPageToken(token); 
+        }
+        ListProjectsResponse response = listRequest.execute();
+        projectList.addAll(response.getProjects());
+        token = response.getNextPageToken();
+      } while (token != null);
+      List<GcpProject> gcpProjects = convertToGcpProjects(projectList);
+      return gcpProjects;
     } catch (IOException ex) {
       throw new ProjectRepositoryException(ex);
     }


### PR DESCRIPTION
fix #2578 
@chanseokoh Bump maximum number of projects to 700

Do we want to loop with the refresh token to make multiple requests instead?