### PR TITLE
Reload pipeline descriptions as required

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/DataflowPipelineLaunchDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/DataflowPipelineLaunchDelegateTest.java
@@ -395,16 +395,12 @@ public class DataflowPipelineLaunchDelegateTest {
     when(configuration.getName()).thenReturn(configurationName);
 
     PipelineRunner runner = PipelineRunner.BLOCKING_DATAFLOW_PIPELINE_RUNNER;
-    when(
-        configuration.getAttribute(
-            PipelineConfigurationAttr.RUNNER_ARGUMENT.toString(),
-            PipelineLaunchConfiguration.defaultRunner(MajorVersion.ONE).getRunnerName()))
-        .thenReturn(runner.getRunnerName());
+    when(configuration.getAttribute(eq(PipelineConfigurationAttr.RUNNER_ARGUMENT.toString()),
+        anyString())).thenReturn(runner.getRunnerName());
 
     String projectName = "Test-project,Name";
-    when(configuration.getAttribute(
-        eq(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME), anyString()))
-        .thenReturn(projectName);
+    when(configuration.getAttribute(eq(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME),
+        anyString())).thenReturn(projectName);
     when(workspaceRoot.getProject(projectName)).thenReturn(project);
     when(project.exists()).thenReturn(true);
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/MajorVersionPipelineRunnerConfigurationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/MajorVersionPipelineRunnerConfigurationTest.java
@@ -16,18 +16,24 @@
 
 package com.google.cloud.tools.eclipse.dataflow.core.launcher;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.google.cloud.tools.eclipse.dataflow.core.project.MajorVersion;
 import java.util.Arrays;
 import java.util.Set;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * Test that each {@link MajorVersion} has associated configuration settings in the
@@ -66,4 +72,21 @@ public class MajorVersionPipelineRunnerConfigurationTest {
     Set<PipelineRunner> runners = PipelineRunner.inMajorVersion(majorVersion);
     assertThat(runners, CoreMatchers.hasItem(defaultRunner));
   }
+
+  /** Ensure the default runner chosen is appropriate for the majorVersion. */
+  @Test
+  public void testFromLaunchConfiguration_defaultRunner() throws CoreException {
+    ILaunchConfiguration empty = mock(ILaunchConfiguration.class, new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        // for getAttribute(attr, default)
+        Object[] arguments = invocation.getArguments();
+        return arguments.length == 2 ? arguments[1] : null;
+      }
+    });
+    PipelineLaunchConfiguration lc =
+        PipelineLaunchConfiguration.fromLaunchConfiguration(empty, majorVersion);
+    assertEquals(PipelineLaunchConfiguration.defaultRunner(majorVersion), lc.getRunner());
+  }
+
 }

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineLaunchConfigurationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core.test/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineLaunchConfigurationTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.tools.eclipse.dataflow.core.launcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,15 +69,14 @@ public class PipelineLaunchConfigurationTest {
             PipelineConfigurationAttr.ALL_ARGUMENT_VALUES.toString(),
             Collections.<String, String>emptyMap())).thenReturn(requiredArgumentValues);
 
+    // set a different runner from the default
     PipelineRunner runner = PipelineRunner.DATAFLOW_PIPELINE_RUNNER;
     when(
-        launchConfiguration.getAttribute(
-            PipelineConfigurationAttr.RUNNER_ARGUMENT.toString(),
-            PipelineLaunchConfiguration.defaultRunner(majorVersion).getRunnerName()))
-        .thenReturn(runner.getRunnerName());
+        launchConfiguration.getAttribute(eq(PipelineConfigurationAttr.RUNNER_ARGUMENT.toString()),
+            anyString())).thenReturn(runner.getRunnerName());
 
     PipelineLaunchConfiguration lc =
-        PipelineLaunchConfiguration.fromLaunchConfiguration(launchConfiguration);
+        PipelineLaunchConfiguration.fromLaunchConfiguration(launchConfiguration, majorVersion);
 
     assertEquals(requiredArgumentValues, lc.getArgumentValues());
     assertEquals(runner, lc.getRunner());

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/DataflowPipelineLaunchDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/DataflowPipelineLaunchDelegate.java
@@ -112,10 +112,10 @@ public class DataflowPipelineLaunchDelegate implements ILaunchConfigurationDeleg
       ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
       throws CoreException {
     SubMonitor progress = SubMonitor.convert(monitor, 3);
-    PipelineLaunchConfiguration pipelineConfig =
-        PipelineLaunchConfiguration.fromLaunchConfiguration(configuration);
 
-    String projectName = pipelineConfig.getEclipseProjectName();
+    String projectName =
+        configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, "");
+    checkArgument(!projectName.isEmpty(), "Cannot determine project");
     IProject project = workspaceRoot.getProject(projectName);
     checkArgument(
         project.exists(),
@@ -124,6 +124,8 @@ public class DataflowPipelineLaunchDelegate implements ILaunchConfigurationDeleg
         configuration.getAttributes());
     MajorVersion majorVersion = dependencyManager.getProjectMajorVersion(project);
 
+    PipelineLaunchConfiguration pipelineConfig =
+        PipelineLaunchConfiguration.fromLaunchConfiguration(configuration, majorVersion);
     PipelineOptionsHierarchy hierarchy;
     try {
       hierarchy = optionsRetrieverFactory.forProject(project, majorVersion, progress.newChild(1));

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineLaunchConfiguration.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.core/src/com/google/cloud/tools/eclipse/dataflow/core/launcher/PipelineLaunchConfiguration.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -272,6 +273,24 @@ public class PipelineLaunchConfiguration {
     } else {
       return !Strings.isNullOrEmpty(argumentValues.get(propertyName));
     }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    PipelineLaunchConfiguration other = (PipelineLaunchConfiguration) obj;
+    return Objects.equals(argumentValues, other.argumentValues)
+        && Objects.equals(runner, other.runner)
+        && Objects.equals(userOptionsName, other.userOptionsName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(argumentValues, runner, userOptionsName);
   }
 
   @Override


### PR DESCRIPTION
A configuration tab's `isValid()` may be called even when the tab is not active (i.e., after a `deactivated()`/`performApply()` and — more importantly — before an `activated()`/`initializeFrom()`), and it may be called frequently.  This PR improves loading and detecting changed launch configuration details.

Fixes #2232 