### PR TITLE
Default to java8 runtime

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -10,9 +10,7 @@
        <version-comparator
              class="com.google.cloud.tools.eclipse.appengine.facets.StringVersionComparator">
        </version-comparator>
-       <default-version
-             version="JRE7">
-       </default-version>
+       <default-version version="JRE8" />
     </project-facet>
     <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.standard" version="JRE7">
        <constraint>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacet.java
@@ -237,7 +237,6 @@ public class AppEngineStandardFacet {
       }
 
       // So we must have a project with no appengine-web.xml.
-      // Need to figure out: what AES version do we install?
 
       /*
        * https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -20,7 +20,9 @@ import com.google.cloud.tools.eclipse.util.Templates;
 import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -148,9 +150,10 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     ResourceUtils.createFolders(webInfDir, progress.newChild(1));
     appEngineWebXml.create(new ByteArrayInputStream(new byte[0]), true, progress.newChild(2));
     String configFileLocation = appEngineWebXml.getLocation().toString();
-    Templates.createFileContent(
-        configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE,
-        Collections.<String, String>emptyMap());
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("runtime", "java8");
+    Templates.createFileContent(configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE,
+        parameters);
     progress.worked(4);
     appEngineWebXml.refreshLocal(IFile.DEPTH_ZERO, progress.newChild(1));
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -151,7 +151,7 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     appEngineWebXml.create(new ByteArrayInputStream(new byte[0]), true, progress.newChild(2));
     String configFileLocation = appEngineWebXml.getLocation().toString();
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("runtime", "java8");
+  // parameters.put("runtime", "java8");
     Templates.createFileContent(configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE,
         parameters);
     progress.worked(4);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -151,7 +151,7 @@ public class StandardFacetInstallDelegate extends AppEngineFacetInstallDelegate 
     appEngineWebXml.create(new ByteArrayInputStream(new byte[0]), true, progress.newChild(2));
     String configFileLocation = appEngineWebXml.getLocation().toString();
     Map<String, String> parameters = new HashMap<>();
-  // parameters.put("runtime", "java8");
+    parameters.put("runtime", "java8");
     Templates.createFileContent(configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE,
         parameters);
     progress.worked(4);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineDescriptorTransform.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineDescriptorTransform.java
@@ -29,11 +29,11 @@ import org.eclipse.core.runtime.CoreException;
  * Utility class for adding and removing the {@code <runtime>java8</runtime>} to/from an
  * {@code appengine-web.xml}.
  */
-public class AppEngineDescriptorTransform {
+class AppEngineDescriptorTransform {
   private static final Logger logger =
       Logger.getLogger(AppEngineDescriptorTransform.class.getName());
 
-  public static void removeJava8Runtime(IFile descriptor) {
+  static void removeJava8Runtime(IFile descriptor) {
     URL xslTemplate =
         AppEngineDescriptorTransform.class.getResource("/xslt/removeJava8Runtime.xsl");
     try {
@@ -44,7 +44,7 @@ public class AppEngineDescriptorTransform {
     }
   }
 
-  public static void addJava8Runtime(IFile descriptor) {
+  static void addJava8Runtime(IFile descriptor) {
     URL xslTemplate = AppEngineDescriptorTransform.class.getResource("/xslt/addJava8Runtime.xsl");
     try {
       logger.fine("Adding runtime:java8 from " + descriptor);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetChangeListener.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetChangeListener.java
@@ -78,9 +78,6 @@ public class AppEngineStandardFacetChangeListener implements IFacetedProjectList
         if (isFacetJava8) {
           logger.fine(project + ": adding <runtime>java8</runtime> to appengine-web.xml");
           AppEngineDescriptorTransform.addJava8Runtime(descriptor);
-        } else {
-          logger.fine(project + ": removing <runtime>java8</runtime> from appengine-web.xml");
-          AppEngineDescriptorTransform.removeJava8Runtime(descriptor);
         }
       }
     } catch (SAXException | IOException | CoreException ex) {

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -84,6 +84,18 @@ public class TemplatesTest {
 
     compareToFile("appengineWebXmlWithService.txt");
   }
+  
+  @Test
+  public void testCreateFileContent_appengineWebXmlWithRuntime()
+      throws CoreException, IOException {
+    dataMap.put("runtime", "java8");
+    Templates.createFileContent(fileLocation,
+        Templates.APPENGINE_WEB_XML_TEMPLATE,
+        dataMap);
+
+    compareToFile("appengineWebXmlWithRuntime.txt");
+  }
+
 
   @Test
   public void testCreateFileContent_appYamlWithService()

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -174,6 +174,9 @@ public class TemplatesTest {
   private static InputStream getDataFile(String fileName) throws IOException {
     Bundle bundle = FrameworkUtil.getBundle(TemplatesTest.class);
     URL expectedFileUrl = bundle.getResource("/testData/templates/appengine/" + fileName);
+    if (expectedFileUrl == null) {
+      throw new IOException("Could not find comparison file " + fileName);
+    }
     return expectedFileUrl.openStream();
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -93,7 +93,7 @@ public class TemplatesTest {
         Templates.APPENGINE_WEB_XML_TEMPLATE,
         dataMap);
 
-    compareToFile("appengineWebXmlWithRuntime.txt");
+    compareToFile("appEngineWebXmlWithRuntime.txt");
   }
 
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appEngineWebXmlWithRuntime.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appEngineWebXmlWithRuntime.txt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+
+  <threadsafe>true</threadsafe>
+  <sessions-enabled>false</sessions-enabled>
+  <runtime>java8</runtime>
+
+</appengine-web-app>


### PR DESCRIPTION
@briandealwis fix #2572

A possible fix: this PR now simply removes all automatic downgrades to the java7 runtime. 
The proposal is that if there's a `<runtime>java8</runtime>` in appengine-web.xml, then we leave it alone. The user can manually edit that file to remove it if they really want the legacy runtime.

However we allow people to deploy Java 7 and Servlet 2.5 apps to the Java 8 runtime. 
