### PR TITLE
Enable GcpLocalRunTab

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroupTest.java
@@ -32,6 +32,7 @@ public class AppEngineTabGroupTest {
     Assert.assertEquals("Server", group.getTabs()[0].getName());
     Assert.assertEquals("Arguments", group.getTabs()[1].getName());
     Assert.assertEquals("Environment", group.getTabs()[2].getName());
+    Assert.assertEquals("Cloud Platform", group.getTabs()[3].getName());
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/AppEngineTabGroup.java
@@ -40,13 +40,16 @@ public class AppEngineTabGroup extends AbstractLaunchConfigurationTabGroup {
 
   @Override
   public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-    ILaunchConfigurationTab[] tabs = new ILaunchConfigurationTab[3];
+    ILaunchConfigurationTab[] tabs = new ILaunchConfigurationTab[4];
     tabs[0] = new AppEngineServerLaunchConfigurationTab(SERVER_TYPE_IDS);
     tabs[0].setLaunchConfigurationDialog(dialog);
     tabs[1] = new JavaArgumentsTab();
     tabs[1].setLaunchConfigurationDialog(dialog);
-    tabs[2] = new EnvironmentTab();
+    EnvironmentTab environmentTab = new EnvironmentTab();
+    tabs[2] = environmentTab;
     tabs[2].setLaunchConfigurationDialog(dialog);
+    tabs[3] = new GcpLocalRunTab(environmentTab);
+    tabs[3].setLaunchConfigurationDialog(dialog);
     setTabs(tabs);
   }
 


### PR DESCRIPTION
This wires up the tab. Since the tab defines the env variables, things work as soon as this is wired. I tested the credential env var with a simple Google Translate app locally, and it does work. Couldn't the project ID env var though, as I am not immediately aware of a way to test it.