### PR TITLE
Make App Engine Standard facet default as JRE8

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -11,7 +11,7 @@
              class="com.google.cloud.tools.eclipse.appengine.facets.StringVersionComparator">
        </version-comparator>
        <default-version
-             version="JRE7">
+             version="JRE8">
        </default-version>
     </project-facet>
     <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.standard" version="JRE7">


### PR DESCRIPTION
Towards #2572

My steps for testing:
  1. Create new plain Java project. I've tested specifying a JavaSE-1.7 execution environment, a 1.8 ExEnv, and selecting a specific 1.7 JRE.
  2. Right-click on the project and select _Configure > Convert to App Engine Standard Project_.

Contents of resulting `WebContent/WEB-INF/appengine-web.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>
<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">

  <threadsafe>true</threadsafe>
  <sessions-enabled>false</sessions-enabled>

  <runtime>java8</runtime>
</appengine-web-app>
```

Project facets:
<img width="481" alt="screen shot 2017-11-20 at 12 58 22 pm" src="https://user-images.githubusercontent.com/202851/33033508-8cc22924-cdf2-11e7-8d5f-2f3985c3de77.PNG">