### PR TITLE
Hide job fields in RunOptionsDefaultsComponent

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/preferences/RunOptionsDefaultsComponent.java
@@ -105,12 +105,9 @@ public class RunOptionsDefaultsComponent {
   private SelectFirstMatchingPrefixListener completionListener;
   private ControlDecoration stagingLocationResults;
 
-  @VisibleForTesting
-  GcpProjectServicesJob checkProjectConfigurationJob;
-  @VisibleForTesting
-  FetchStagingLocationsJob fetchStagingLocationsJob;
-  @VisibleForTesting
-  VerifyStagingLocationJob verifyStagingLocationJob;
+  private GcpProjectServicesJob checkProjectConfigurationJob;
+  private FetchStagingLocationsJob fetchStagingLocationsJob;
+  private VerifyStagingLocationJob verifyStagingLocationJob;
 
   public RunOptionsDefaultsComponent(Composite target, int columns, MessageTarget messageTarget,
       DataflowPreferences preferences) {


### PR DESCRIPTION
Follow-on from #2599 as these fields aren't used by tests.