### PR TITLE
Add diagnostic message on project import failure in integration test

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ClientApisLibrariesSelectorGroupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/ClientApisLibrariesSelectorGroupTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.ui;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -139,16 +139,8 @@ public class SwtBotAppEngineActions {
 
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
     SWTBotTreeItem treeItem = bot.tree().expandNode("General");
-    try {
-      SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
-          "Existing Projects into Workspace");
-    } catch (TimeoutException e) {
-      System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());
-      for (SWTBotTreeItem childNode : treeItem.getItems()) {
-        System.err.println("    " + childNode);
-      }
-      throw e;
-    }
+    SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
+        "Existing Projects into Workspace");
     treeItem.select("Existing Projects into Workspace");
     bot.button("Next >").click();
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -171,7 +171,6 @@ public class SwtBotAppEngineActions {
 
         SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
         SWTBotTreeItem treeItem = bot.tree().expandNode("General");
-        if (tries == 1) throw new TimeoutException("");
         SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
             "Existing Projects into Workspace");
         treeItem.select("Existing Projects into Workspace");
@@ -179,8 +178,7 @@ public class SwtBotAppEngineActions {
       } catch (TimeoutException e) {
         if (tries == 2) {
           throw e;
-        }
-        if (shell != null) {
+        } else if (shell != null) {
           shell.close();
         }
       }

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -139,8 +139,16 @@ public class SwtBotAppEngineActions {
 
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
     SWTBotTreeItem treeItem = bot.tree().expandNode("General");
-    SwtBotTreeUtilities.waitUntilTreeItemhasChild(bot, treeItem,
-        "Existing Projects into Workspace");
+    try {
+      SwtBotTreeUtilities.waitUntilTreeItemhasChild(bot, treeItem,
+          "Existing Projects into Workspace");
+    } catch (TimeoutException e) {
+      System.out.println(treeItem + ": expanded? " + treeItem.isExpanded());
+      for (SWTBotTreeItem childNode : treeItem.getItems()) {
+        System.out.println("    " + childNode);
+      }
+      throw e;
+    }
     treeItem.select("Existing Projects into Workspace");
     bot.button("Next >").click();
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -140,7 +140,7 @@ public class SwtBotAppEngineActions {
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
     SWTBotTreeItem treeItem = bot.tree().expandNode("General");
     try {
-      SwtBotTreeUtilities.waitUntilTreeItemhasChild(bot, treeItem,
+      SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
           "Existing Projects into Workspace");
     } catch (TimeoutException e) {
       System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -143,9 +143,9 @@ public class SwtBotAppEngineActions {
       SwtBotTreeUtilities.waitUntilTreeItemhasChild(bot, treeItem,
           "Existing Projects into Workspace");
     } catch (TimeoutException e) {
-      System.out.println(treeItem + ": expanded? " + treeItem.isExpanded());
+      System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());
       for (SWTBotTreeItem childNode : treeItem.getItems()) {
-        System.out.println("    " + childNode);
+        System.err.println("    " + childNode);
       }
       throw e;
     }

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/SwtBotAppEngineActions.java
@@ -132,16 +132,8 @@ public class SwtBotAppEngineActions {
    */
   public static IProject importNativeProject(SWTWorkbenchBot bot, String projectName,
       File extractedLocation) {
-    bot.menu("File").menu("Import...").click();
 
-    SWTBotShell shell = bot.shell("Import");
-    shell.activate();
-
-    SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
-    SWTBotTreeItem treeItem = bot.tree().expandNode("General");
-    SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
-        "Existing Projects into Workspace");
-    treeItem.select("Existing Projects into Workspace");
+    openImportExistingProjectsWizard(bot);
     bot.button("Next >").click();
 
     // current comboBox is associated with a radio button
@@ -169,6 +161,31 @@ public class SwtBotAppEngineActions {
     return project;
   }
 
+  private static void openImportExistingProjectsWizard(SWTWorkbenchBot bot) {
+    for (int tries = 1; true; tries++) {
+      SWTBotShell shell = null;
+      try {
+        bot.menu("File").menu("Import...").click();
+        shell = bot.shell("Import");
+        shell.activate();
+
+        SwtBotTreeUtilities.waitUntilTreeHasItems(bot, bot.tree());
+        SWTBotTreeItem treeItem = bot.tree().expandNode("General");
+        if (tries == 1) throw new TimeoutException("");
+        SwtBotTreeUtilities.waitUntilTreeItemHasChild(bot, treeItem,
+            "Existing Projects into Workspace");
+        treeItem.select("Existing Projects into Workspace");
+        break;
+      } catch (TimeoutException e) {
+        if (tries == 2) {
+          throw e;
+        }
+        if (shell != null) {
+          shell.close();
+        }
+      }
+    }
+  }
 
   /**
    * Import a Maven project from a zip file

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -366,25 +366,21 @@ public class SwtBotTreeUtilities {
    */
   public static void waitUntilTreeItemHasChild(SWTWorkbenchBot bot, final SWTBotTreeItem treeItem,
       final String childText) {
-    try {
-      bot.waitUntil(new DefaultCondition() {
-        @Override
-        public String getFailureMessage() {
-          return "Tree item never appeared";
+    bot.waitUntil(new DefaultCondition() {
+      @Override
+      public String getFailureMessage() {
+        System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());
+        for (SWTBotTreeItem childNode : treeItem.getItems()) {
+          System.err.println("    " + childNode);
         }
-  
-        @Override
-        public boolean test() throws Exception {
-          return treeItem.getNodes().contains(childText);
-        }
-      });
-    } catch (TimeoutException e) {
-      System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());
-      for (SWTBotTreeItem childNode : treeItem.getItems()) {
-        System.err.println("    " + childNode);
+        return "Tree item never appeared";
       }
-      throw e;
-    }
+
+      @Override
+      public boolean test() throws Exception {
+        return treeItem.getNodes().contains(childText);
+      }
+    });
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -369,7 +369,7 @@ public class SwtBotTreeUtilities {
     bot.waitUntil(new DefaultCondition() {
       @Override
       public String getFailureMessage() {
-        return "Tree items never disappeared";
+        return "Tree item never appeared";
       }
 
       @Override

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -364,19 +364,27 @@ public class SwtBotTreeUtilities {
    * 
    * @throws TimeoutException if the child does not appear within the default timeout
    */
-  public static void waitUntilTreeItemhasChild(SWTWorkbenchBot bot, final SWTBotTreeItem treeItem,
+  public static void waitUntilTreeItemHasChild(SWTWorkbenchBot bot, final SWTBotTreeItem treeItem,
       final String childText) {
-    bot.waitUntil(new DefaultCondition() {
-      @Override
-      public String getFailureMessage() {
-        return "Tree item never appeared";
+    try {
+      bot.waitUntil(new DefaultCondition() {
+        @Override
+        public String getFailureMessage() {
+          return "Tree item never appeared";
+        }
+  
+        @Override
+        public boolean test() throws Exception {
+          return treeItem.getNodes().contains(childText);
+        }
+      });
+    } catch (TimeoutException e) {
+      System.err.println(treeItem + ": expanded? " + treeItem.isExpanded());
+      for (SWTBotTreeItem childNode : treeItem.getItems()) {
+        System.err.println("    " + childNode);
       }
-
-      @Override
-      public boolean test() throws Exception {
-        return treeItem.getNodes().contains(childText);
-      }
-    });
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
About #2569. Trying to see what's going on if this fails.

This should log below if all goes right.
```
TreeItem with text {General}: expanded? true
  TreeItem with text {Archive File}
  TreeItem with text {Existing Projects into Workspace}
  TreeItem with text {File System}
  TreeItem with text {Preferences}
```