### PR TITLE
support prefixed project IDs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.localserver
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.api.services.iam.v1;version="1.23.0",
- com.google.cloud.tools.eclipse.swtbot,
+Import-Package: com.google.cloud.tools.eclipse.swtbot,
  com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.localserver
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.swtbot,
+Import-Package: com.google.api.services.iam.v1;version="1.23.0",
+ com.google.cloud.tools.eclipse.swtbot,
  com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.test.util.ui,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.eclipse.appengine.localserver;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -53,44 +53,39 @@ public class ServiceAccountUtilTest {
 
   @Mock private Credential credential;
   @Mock private IGoogleApiFactory apiFactory;
+  @Mock private Keys keys;
+  @Mock private Create create;
 
   private Path keyFile;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     keyFile = tempFolder.getRoot().toPath().resolve("key.json");
-  }
 
-  public static void setUpServiceKeyCreation(
-      IGoogleApiFactory mockApiFactory, boolean throwException) throws IOException {
     Iam iam = mock(Iam.class);
     Projects projects = mock(Projects.class);
     ServiceAccounts serviceAccounts = mock(ServiceAccounts.class);
-    Keys keys = mock(Keys.class);
-    Create create = mock(Create.class);
+        
+    when(apiFactory.newIamApi(any(Credential.class))).thenReturn(iam);
+    when(iam.projects()).thenReturn(projects);
+    when(projects.serviceAccounts()).thenReturn(serviceAccounts);
+    when(serviceAccounts.keys()).thenReturn(keys);
+    when(keys.create(
+        eq("projects/my-project/serviceAccounts/my-project@appspot.gserviceaccount.com"),
+        any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
 
     ServiceAccountKey serviceAccountKey = new ServiceAccountKey();
     byte[] keyContent = "key data in JSON format".getBytes();
     serviceAccountKey.setPrivateKeyData(Base64.encodeBase64String(keyContent));
-
-    when(mockApiFactory.newIamApi(any(Credential.class))).thenReturn(iam);
-    when(iam.projects()).thenReturn(projects);
-    when(projects.serviceAccounts()).thenReturn(serviceAccounts);
-    when(serviceAccounts.keys()).thenReturn(keys);
-    when(keys.create(anyString(), any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
-
-    if (throwException) {
-      when(create.execute()).thenThrow(new IOException("log from unit test"));
-    } else {
-      when(create.execute()).thenReturn(serviceAccountKey);
-    }
+    
+    when(create.execute()).thenReturn(serviceAccountKey);
   }
 
   @Test
   public void testCreateServiceAccountKey_destinationShouldBeAbsolute() throws IOException {
     try {
       ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
-          "my-service-account@example.com", Paths.get("relative/path/to.json"));
+          Paths.get("relative/path/to.json"));
     } catch (IllegalArgumentException e) {
       assertEquals("destination not absolute", e.getMessage());
     }
@@ -98,10 +93,9 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey() throws IOException {
-    setUpServiceKeyCreation(apiFactory, false);
 
     ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
-        "my-service-account@example.com", keyFile);
+        keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
@@ -109,11 +103,10 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey_replacesExistingFile() throws IOException {
-    setUpServiceKeyCreation(apiFactory, false);
 
     Files.write(keyFile, new byte[] {0, 1, 2});
     ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
-        "my-service-account@example.com", keyFile);
+        keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
@@ -121,11 +114,12 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey_ioException() throws IOException {
-    setUpServiceKeyCreation(apiFactory, true);
 
+    when(create.execute()).thenThrow(new IOException("log from unit test"));
+    
     try {
       ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
-          "my-service-account@example.com", keyFile);
+          keyFile);
     } catch (IOException e) {
       assertEquals("log from unit test", e.getMessage());
     }
@@ -134,11 +128,10 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey_createsRequiredDirectories() throws IOException {
-    setUpServiceKeyCreation(apiFactory, false);
 
     Path keyFile = tempFolder.getRoot().toPath().resolve("non/existing/directory/key.json");
     ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
-          "my-service-account@example.com", keyFile);
+          keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
@@ -75,7 +75,7 @@ public class ServiceAccountUtilTest {
         any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
 
     ServiceAccountKey serviceAccountKey = new ServiceAccountKey();
-    byte[] keyContent = "key data in JSON format".getBytes();
+    byte[] keyContent = "key data in JSON format".getBytes(StandardCharsets.UTF_8);
     serviceAccountKey.setPrivateKeyData(Base64.encodeBase64String(keyContent));
     
     when(create.execute()).thenReturn(serviceAccountKey);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
@@ -84,7 +84,7 @@ public class ServiceAccountUtilTest {
   @Test
   public void testCreateServiceAccountKey_destinationShouldBeAbsolute() throws IOException {
     try {
-      ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+      ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
           Paths.get("relative/path/to.json"));
     } catch (IllegalArgumentException e) {
       assertEquals("destination not absolute", e.getMessage());
@@ -93,7 +93,7 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey() throws IOException {
-    ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
         keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
@@ -106,7 +106,7 @@ public class ServiceAccountUtilTest {
         eq("projects/google.com:my-project/serviceAccounts/my-project.google.com@appspot.gserviceaccount.com"),
         any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
 
-    ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "google.com:my-project",
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "google.com:my-project",
         keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
@@ -117,7 +117,7 @@ public class ServiceAccountUtilTest {
   public void testCreateServiceAccountKey_replacesExistingFile() throws IOException {
 
     Files.write(keyFile, new byte[] {0, 1, 2});
-    ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
         keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
@@ -130,7 +130,7 @@ public class ServiceAccountUtilTest {
     when(create.execute()).thenThrow(new IOException("log from unit test"));
     
     try {
-      ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+      ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
           keyFile);
     } catch (IOException e) {
       assertEquals("log from unit test", e.getMessage());
@@ -142,7 +142,7 @@ public class ServiceAccountUtilTest {
   public void testCreateServiceAccountKey_createsRequiredDirectories() throws IOException {
 
     Path keyFile = tempFolder.getRoot().toPath().resolve("non/existing/directory/key.json");
-    ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
           keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
@@ -93,8 +93,20 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey() throws IOException {
-
     ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "my-project",
+        keyFile);
+
+    byte[] bytesRead = Files.readAllBytes(keyFile);
+    assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
+  }
+  
+  @Test
+  public void testCreateServiceAccountKey_prefixedProject() throws IOException {
+    when(keys.create(
+        eq("projects/google.com:my-project/serviceAccounts/my-project.google.com@appspot.gserviceaccount.com"),
+        any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
+
+    ServiceAccountUtil.createServiceAccountKey(apiFactory, credential, "google.com:my-project",
         keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTabTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTabTest.java
@@ -455,4 +455,16 @@ public class GcpLocalRunTabTest {
         .resolve("app-engine-default-service-account-key-project-A.json");
     assertEquals(expected, tab.getServiceAccountKeyPath());
   }
+  
+  @Test
+  public void testGetServiceAccountKeyPath_internal() {
+    tab.initializeFrom(launchConfig);
+    accountSelector.selectAccount("account2@example.com");
+    projectSelector.selectProjectId("google.com:project-D");
+
+    Path expected = Paths.get(Platform.getConfigurationLocation().getURL().getPath())
+        .resolve("com.google.cloud.tools.eclipse")
+        .resolve("app-engine-default-service-account-key-google.com.project-D.json");
+    assertEquals(expected, tab.getServiceAccountKeyPath());
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
@@ -41,12 +41,10 @@ public class ServiceAccountUtil {
    * @param destination path of a key file to be saved
    */
   public static void createServiceAccountKey(IGoogleApiFactory apiFactory,
-      Credential credential, String projectId, String serviceAccountId, Path destination)
+      Credential credential, String projectId, Path destination)
           throws FileAlreadyExistsException, IOException {
     Preconditions.checkNotNull(credential, "credential not given");
     Preconditions.checkState(!projectId.isEmpty(), "project ID empty");
-    Preconditions.checkState(!serviceAccountId.isEmpty(), "service account empty");
-    Preconditions.checkState(!serviceAccountId.contains(":"), "service account ID malformed");
     Preconditions.checkArgument(destination.isAbsolute(), "destination not absolute");
 
     if (!Files.exists(destination.getParent())) {
@@ -55,6 +53,15 @@ public class ServiceAccountUtil {
 
     Iam iam = apiFactory.newIamApi(credential);
     Keys keys = iam.projects().serviceAccounts().keys();
+    
+    String projectEmail = projectId;
+    // The appengine service account for google.com:gcloud-for-eclipse-testing 
+    // would be gcloud-for-eclipse-testing.google.com@appspot.gserviceaccount.com.
+    if (projectId.contains(":")) {
+      String[] parts = projectId.split(":"); //$NON-NLS-1$ 
+      projectEmail = parts[1] + "." + parts[0];
+    }
+    String serviceAccountId = projectEmail + "@appspot.gserviceaccount.com"; //$NON-NLS-1$   
 
     String keyId = "projects/" + projectId + "/serviceAccounts/" + serviceAccountId;
     CreateServiceAccountKeyRequest createRequest = new CreateServiceAccountKeyRequest();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
@@ -32,15 +32,13 @@ import java.nio.file.Path;
 public class ServiceAccountUtil {
 
   /**
-   * Creates and saves a service account key (JSON) for a service account.
+   * Creates and saves a service account key the App Engine default service account.
    *
    * @param credential credential to use to create a service account key
    * @param projectId GCP project ID for {@code serviceAccountId} 
-   * @param serviceAccountId the service account ID (for example, {@code
-   *     project-id@appspot.gserviceaccount.com}
    * @param destination path of a key file to be saved
    */
-  public static void createServiceAccountKey(IGoogleApiFactory apiFactory,
+  public static void createAppEngineDefaultServiceAccountKey(IGoogleApiFactory apiFactory,
       Credential credential, String projectId, Path destination)
           throws FileAlreadyExistsException, IOException {
     Preconditions.checkNotNull(credential, "credential not given");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtil.java
@@ -46,6 +46,7 @@ public class ServiceAccountUtil {
     Preconditions.checkNotNull(credential, "credential not given");
     Preconditions.checkState(!projectId.isEmpty(), "project ID empty");
     Preconditions.checkState(!serviceAccountId.isEmpty(), "service account empty");
+    Preconditions.checkState(!serviceAccountId.contains(":"), "service account ID malformed");
     Preconditions.checkArgument(destination.isAbsolute(), "destination not absolute");
 
     if (!Files.exists(destination.getParent())) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
@@ -406,6 +406,10 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
     String projectId = projectSelector.getSelectedProjectId();
     String filename = "app-engine-default-service-account-key-" //$NON-NLS-1$
         + projectId + ".json"; //$NON-NLS-1$
+    
+    // can't use colons in filenames on Windows
+    filename = filename.replace(':', '.');
+    
     String configurationLocation = Platform.getConfigurationLocation().getURL().getPath();
     return Paths.get(configurationLocation + "/com.google.cloud.tools.eclipse/" + filename);
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
@@ -417,18 +417,9 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
     Preconditions.checkNotNull(credential, "no account selected"); //$NON-NLS-1$
     Preconditions.checkState(!projectId.isEmpty(), "no project selected"); //$NON-NLS-1$
     
-    String projectEmail = projectId;
-    // The appengine service account for google.com:gcloud-for-eclipse-testing 
-    // would be gcloud-for-eclipse-testing.google.com@appspot.gserviceaccount.com.
-    if (projectEmail.contains(":")) {
-      String[] parts = projectEmail.split(":");
-      projectEmail = parts[1] + "." + parts[0];
-    }
-    String appEngineServiceAccountId = projectEmail + "@appspot.gserviceaccount.com"; //$NON-NLS-1$   
-    
     try { 
       ServiceAccountUtil.createServiceAccountKey(googleApiFactory,
-          credential, projectId, appEngineServiceAccountId, keyFile);
+          credential, projectId, keyFile);
 
       serviceKeyInput.setText(keyFile.toString());
       String message = Messages.getString("service.key.created", keyFile); //$NON-NLS-1$
@@ -436,7 +427,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
 
     } catch (IOException e) {
       logger.log(Level.SEVERE, e.getMessage(), e);
-      String message = Messages.getString("cannot.create.service.key",  //$NON-NLS-1$
+      String message = Messages.getString("cannot.create.service.key", //$NON-NLS-1$
           e.getLocalizedMessage());
       showServiceKeyDecorationMessage(message, true /* isError */);
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
@@ -102,7 +102,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
   private String gcpProjectIdModel;
   // To prevent updating above models when programmatically setting up UI components.
   private boolean initializingUiValues;
-
+  
   /**
    * True if this tab is the currently visible tab. See {@link
    * #performApply(ILaunchConfigurationWorkingCopy)} for details.
@@ -196,7 +196,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
           // 2. Otherwise (no project selected), clear the saved project only when it is certain
           // that the user explicitly removed selection (i.e., not because of logout).
           if (projectSelected || savedIdAvailable) {
-            gcpProjectIdModel = projectSelector.getSelectProjectId();
+            gcpProjectIdModel = projectSelector.getSelectedProjectId();
             updateLaunchConfigurationDialog();
           }
         }
@@ -299,7 +299,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
 
   @Override
   public void initializeFrom(ILaunchConfiguration configuration) {
-    accountEmailModel = getAttribute(configuration, ATTRIBUTE_ACCOUNT_EMAIL, ""); //$NON-NLS-1$
+    this.accountEmailModel = getAttribute(configuration, ATTRIBUTE_ACCOUNT_EMAIL, ""); //$NON-NLS-1$
 
     Map<String, String> environmentMap = getEnvironmentMap(configuration);
     gcpProjectIdModel = Strings.nullToEmpty(environmentMap.get(PROJECT_ID_ENVIRONMENT_VARIABLE));
@@ -403,7 +403,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
   Path getServiceAccountKeyPath() {
     Preconditions.checkState(!projectSelector.getSelection().isEmpty());
 
-    String projectId = projectSelector.getSelectProjectId();
+    String projectId = projectSelector.getSelectedProjectId();
     String filename = "app-engine-default-service-account-key-" //$NON-NLS-1$
         + projectId + ".json"; //$NON-NLS-1$
     String configurationLocation = Platform.getConfigurationLocation().getURL().getPath();
@@ -413,13 +413,17 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
   @VisibleForTesting
   void createServiceAccountKey(Path keyFile) {
     Credential credential = accountSelector.getSelectedCredential();
-    String projectId = projectSelector.getSelectProjectId();
-    Preconditions.checkNotNull(credential, "account not selected"); //$NON-NLS-1$
-    Preconditions.checkState(!projectId.isEmpty(), "project not selected"); //$NON-NLS-1$
-
-    try {
-      String appEngineServiceAccountId = projectId + "@appspot.gserviceaccount.com"; //$NON-NLS-1$
-
+    String projectId = projectSelector.getSelectedProjectId();
+    Preconditions.checkNotNull(credential, "no account selected"); //$NON-NLS-1$
+    Preconditions.checkState(!projectId.isEmpty(), "no project selected"); //$NON-NLS-1$
+    
+    String projectEmail = projectId;
+    if (projectEmail.contains(":")) {
+      projectEmail = projectEmail.split(":")[1];
+    }
+    String appEngineServiceAccountId = projectEmail + "@appspot.gserviceaccount.com"; //$NON-NLS-1$   
+    
+    try { 
       ServiceAccountUtil.createServiceAccountKey(googleApiFactory,
           credential, projectId, appEngineServiceAccountId, keyFile);
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
@@ -418,8 +418,11 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
     Preconditions.checkState(!projectId.isEmpty(), "no project selected"); //$NON-NLS-1$
     
     String projectEmail = projectId;
+    // The appengine service account for google.com:gcloud-for-eclipse-testing 
+    // would be gcloud-for-eclipse-testing.google.com@appspot.gserviceaccount.com.
     if (projectEmail.contains(":")) {
-      projectEmail = projectEmail.split(":")[1];
+      String[] parts = projectEmail.split(":");
+      projectEmail = parts[1] + "." + parts[0];
     }
     String appEngineServiceAccountId = projectEmail + "@appspot.gserviceaccount.com"; //$NON-NLS-1$   
     

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/GcpLocalRunTab.java
@@ -418,7 +418,7 @@ public class GcpLocalRunTab extends AbstractLaunchConfigurationTab {
     Preconditions.checkState(!projectId.isEmpty(), "no project selected"); //$NON-NLS-1$
     
     try { 
-      ServiceAccountUtil.createServiceAccountKey(googleApiFactory,
+      ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(googleApiFactory,
           credential, projectId, keyFile);
 
       serviceKeyInput.setText(keyFile.toString());

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelectorTest.java
@@ -99,34 +99,34 @@ public class ProjectSelectorTest {
   @Test
   public void testGetSelectedProjectId_nothingSelected() {
     projectSelector.setProjects(getUnsortedProjectList());
-    assertEquals("", projectSelector.getSelectProjectId());
+    assertEquals("", projectSelector.getSelectedProjectId());
   }
 
   @Test
   public void testGetSelectedProjectId() {
     projectSelector.setProjects(getUnsortedProjectList());
     projectSelector.setSelection(new StructuredSelection(new GcpProject("d", "d")));
-    assertEquals("d", projectSelector.getSelectProjectId());
+    assertEquals("d", projectSelector.getSelectedProjectId());
   }
 
   @Test
   public void testSelectProjectId() {
     projectSelector.setProjects(getUnsortedProjectList());
     assertTrue(projectSelector.selectProjectId("b"));
-    assertEquals("b", projectSelector.getSelectProjectId());
+    assertEquals("b", projectSelector.getSelectedProjectId());
 
     assertTrue(projectSelector.selectProjectId("d"));
-    assertEquals("d", projectSelector.getSelectProjectId());
+    assertEquals("d", projectSelector.getSelectedProjectId());
   }
 
   @Test
   public void testSelectProjectId_deselect() {
     projectSelector.setProjects(getUnsortedProjectList());
     assertTrue(projectSelector.selectProjectId("b"));
-    assertEquals("b", projectSelector.getSelectProjectId());
+    assertEquals("b", projectSelector.getSelectedProjectId());
 
     assertFalse(projectSelector.selectProjectId("non-existing-id"));
-    assertEquals("", projectSelector.getSelectProjectId());
+    assertEquals("", projectSelector.getSelectedProjectId());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector/src/com/google/cloud/tools/eclipse/projectselector/ProjectSelector.java
@@ -100,10 +100,10 @@ public class ProjectSelector extends Composite implements ISelectionProvider {
   }
 
   /**
-   * Returns the GCP project ID of a selected project. Returns an empty string if nothing is
+   * Returns the GCP project ID of the selected project. Returns an empty string if nothing is
    * selected. Never returns null.
    */
-  public String getSelectProjectId() {
+  public String getSelectedProjectId() {
     if (getSelection().isEmpty()) {
       return "";
     }


### PR DESCRIPTION
fix #2604 

@chanseokoh This gets us from a 400 to a 404 for prefixed projects. Not clear why it still doesn't work. Maybe we need a slightly different format for the keyId:

```
    String keyId = "projects/" + projectId + "/serviceAccounts/" + serviceAccountId;
```
I'm afraid I had to do a lot of renaming in the tests to wrap my head around the setup. 

```
Nov 27, 2017 6:49:57 PM com.google.cloud.tools.eclipse.appengine.localserver.ui.GcpLocalRunTab createServiceAccountKey
SEVERE: 404 Not Found
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Service account projects/google.com:gcloud-for-eclipse-testing/serviceAccounts/gcloud-for-eclipse-testing@appspot.gserviceaccount.com does not exist.",
    "reason" : "notFound"
  } ],
  "message" : "Service account projects/google.com:gcloud-for-eclipse-testing/serviceAccounts/gcloud-for-eclipse-testing@appspot.gserviceaccount.com does not exist.",
  "status" : "NOT_FOUND"
}
com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
{
  "code" : 404,
  "errors" : [ {
    "domain" : "global",
    "message" : "Service account projects/google.com:gcloud-for-eclipse-testing/serviceAccounts/gcloud-for-eclipse-testing@appspot.gserviceaccount.com does not exist.",
    "reason" : "notFound"
  } ],
  "message" : "Service account projects/google.com:gcloud-for-eclipse-testing/serviceAccounts/gcloud-for-eclipse-testing@appspot.gserviceaccount.com does not exist.",
  "status" : "NOT_FOUND"
}
```
