### PR TITLE
Log and screencap timeouts on project-deletion, and avoid disposed shells

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -19,10 +19,14 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 import com.google.cloud.tools.appengine.cloudsdk.CloudSdk;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotWorkbenchActions;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.eclipse.swtbot.swt.finder.utils.SWTUtils;
 import org.eclipse.swtbot.swt.finder.widgets.TimeoutException;
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -31,6 +35,7 @@ import org.junit.BeforeClass;
  * Common infrastructure for workbench-based tests that create a single project.
  */
 public class BaseProjectTest {
+  private static final Logger logger = Logger.getLogger(BaseProjectTest.class.getName());
 
   protected static SWTWorkbenchBot bot;
   protected IProject project;
@@ -60,6 +65,10 @@ public class BaseProjectTest {
         SwtBotProjectActions.deleteProject(bot, project.getName());
       } catch (TimeoutException ex) {
         // If this fails it shouldn't fail the test, which has already run
+        logger.log(Level.SEVERE, "Timeout deleting project: " + project.getName(), ex);
+        String fileName = SWTBotPreferences.SCREENSHOTS_DIR + "/" + "timeout-" + project.getName()
+            + "." + SWTBotPreferences.SCREENSHOT_FORMAT.toLowerCase();
+        SWTUtils.captureScreenshot(fileName);
       }
       project = null;
     }

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -69,6 +69,7 @@ public class BaseProjectTest {
         String fileName = SWTBotPreferences.SCREENSHOTS_DIR + "/" + "timeout-" + project.getName()
             + "." + SWTBotPreferences.SCREENSHOT_FORMAT.toLowerCase();
         SWTUtils.captureScreenshot(fileName);
+        logger.log(Level.INFO, "Screenshot saved as " + fileName);
       }
       project = null;
     }

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotWorkbenchActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotWorkbenchActions.java
@@ -200,7 +200,7 @@ public final class SwtBotWorkbenchActions {
         IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
         Shell[] shells = bot.getDisplay().getShells();
         for (Shell shell : shells) {
-          if (!isEclipseShell(shell, activeWindow)) {
+          if (!shell.isDisposed() && !isEclipseShell(shell, activeWindow)) {
             if (forceKill) {
               shell.dispose();
             } else {


### PR DESCRIPTION
Two changes for testing purposes to fix #2602.

`BaseProjectTest#tearDown()` resets the workbench, which calls our [`closeAllShells()`](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/v1.4.1A/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotWorkbenchActions.java#L202) to close all `Shell`s providing that they are neither the active workbench window nor the special internal _limbo_ shell (#1362).  But it's possible that closing a shell may trigger other actions such as closing another shell. So we may see SWT exceptions when accessing a now-disposed shell.

The delete-project cleanup in `BaseProjectTest#tearDown()` also seems to produce an error message. So this takes a screen shot (for #501).