### PR TITLE
Pull org.apache.commons.compress bundle in

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -36,6 +36,7 @@
    <bundle id="com.google.guava" version="20.0.0"/>
    <bundle id="com.google.gson" version="2.7.0"/>
    <bundle id="com.google.cloud.tools.appengine" version="0.0.0"/>
+   <bundle id="org.apache.commons.compress" version="0.0.0"/>
    <bundle id="jackson-core-asl" version="1.9.13"/>
    <bundle id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
    <bundle id="ch.qos.logback.slf4j" version="0.0.0"/>

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -38,6 +38,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.apache.commons.compress"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="com.google.guava"
          download-size="0"
          install-size="0"

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,10 @@
       <version>0.4.1</version>
     </dependency>
     <dependency>
-      <!-- bundle: org.apache.commons.compress -->
+      <!--
+        dependency used by appengine-plugins-core
+        bundle: org.apache.commons.compress
+      -->
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>1.14</version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
       <version>0.4.1</version>
     </dependency>
     <dependency>
+      <!-- bundle: org.apache.commons.compress -->
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.14</version>
+    </dependency>
+    <dependency>
       <!-- bundle: com.google.guava -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>


### PR DESCRIPTION
I've not specified the bundle version (i.e., 0.0.0), as I thought we don't need to pin a certain version. Not sure if it'd be better to pin down.