### PR TITLE
Do not fail if "gsutil rm" fails when the destination folder does not exist

### DIFF
--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -230,7 +230,7 @@ echo "THIS WILL DELETE ALL FILES IN '$DESTINATION' IF THEY EXIST!"
 ask_proceed
 
 set -x
-gsutil -m rm $DESTINATION/** || true
+gsutil -m rm $DESTINATION/**
 gsutil cp $LOCAL_REPO/artifacts.jar $LOCAL_REPO/content.jar \
     $SIGNED_DIR/index.html \
     $DESTINATION && \

--- a/release/release_after_kokoro.sh
+++ b/release/release_after_kokoro.sh
@@ -230,7 +230,7 @@ echo "THIS WILL DELETE ALL FILES IN '$DESTINATION' IF THEY EXIST!"
 ask_proceed
 
 set -x
-gsutil -m rm $DESTINATION/** && \
+gsutil -m rm $DESTINATION/** || true
 gsutil cp $LOCAL_REPO/artifacts.jar $LOCAL_REPO/content.jar \
     $SIGNED_DIR/index.html \
     $DESTINATION && \


### PR DESCRIPTION
We clean up the GCS bucket first before uploading binaries to make sure old binaries from previous builds get cleaned up first. However, when doing a build for the first time, the folder doesn't exist, and `gsutil rm` fails with a non-zero exit code.