### PR TITLE
Provide category descriptions, shown in the Available Software dialog

### DIFF
--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -39,6 +39,8 @@ units.1.properties.4.name=org.eclipse.equinox.p2.contact
 units.1.properties.4.value=https://github.com/GoogleCloudPlatform/google-cloud-eclipse
 units.1.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.1.properties.5.value=https://cloud.google.com/eclipse/docs/
+units.1.properties.5.name=org.eclipse.equinox.p2.description
+units.1.properties.5.value=Support development of Google Cloud Platform projects in Eclipse
 units.1.copyright =Copyright 2016, 2017 Google Inc.
 units.1.licenses.0 =\
 Cloud Tools for Eclipse is made available under the Apache License, Version 2.0. \
@@ -54,7 +56,7 @@ units.1.provides.1.version=1.0.0
 
 # Define the YEdit category IU
 units.2.id=org.dadacoalition.yedit.category
-units.2.version=1.0.20
+units.2.version=0.0.0
 units.2.properties.1.name=org.eclipse.equinox.p2.type.category
 units.2.properties.1.value=true
 units.2.properties.2.name=org.eclipse.equinox.p2.name
@@ -65,6 +67,8 @@ units.2.properties.4.name=org.eclipse.equinox.p2.contact
 units.2.properties.4.value=https://github.com/oyse/yedit
 units.2.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.2.properties.5.value=https://github.com/oyse/yedit/wiki
+units.2.properties.6.name=org.eclipse.equinox.p2.description
+units.2.properties.6.value=Support editing YAML files in Eclipse
 units.2.licenses.0=\
 YEdit is made available under the Eclipse Public License
 units.2.licenses.0.location=https://www.eclipse.org/legal/epl-v10.html
@@ -77,7 +81,7 @@ units.2.provides.1.version=1.0.0
 
 # Define the Dockerfile Editor category IU
 units.3.id=eu.openanalytics.editor.docker.category
-units.3.version=1.0.0
+units.3.version=0.0.0
 units.3.properties.1.name=org.eclipse.equinox.p2.type.category
 units.3.properties.1.value=true
 units.3.properties.2.name=org.eclipse.equinox.p2.name
@@ -88,6 +92,8 @@ units.3.properties.4.name=org.eclipse.equinox.p2.contact
 units.3.properties.4.value=https://github.com/openanalytics/docker-editor/
 units.3.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.3.properties.5.value=https://github.com/openanalytics/docker-editor/wiki/Getting-Started-with-Dockerfile-Editor
+units.3.properties.6.name=org.eclipse.equinox.p2.description
+units.3.properties.6.value=Support editing Dockerfiles in Eclipse
 units.3.licenses.0=\
 Docker Editor is made available under the Eclipse Public License
 units.3.licenses.0.location=https://www.eclipse.org/legal/epl-v10.html

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -39,8 +39,8 @@ units.1.properties.4.name=org.eclipse.equinox.p2.contact
 units.1.properties.4.value=https://github.com/GoogleCloudPlatform/google-cloud-eclipse
 units.1.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.1.properties.5.value=https://cloud.google.com/eclipse/docs/
-units.1.properties.5.name=org.eclipse.equinox.p2.description
-units.1.properties.5.value=Support development of Google Cloud Platform projects in Eclipse
+units.1.properties.6.name=org.eclipse.equinox.p2.description
+units.1.properties.6.value=Supports development of Google Cloud Platform projects in Eclipse.
 units.1.copyright =Copyright 2016, 2017 Google Inc.
 units.1.licenses.0 =\
 Cloud Tools for Eclipse is made available under the Apache License, Version 2.0. \
@@ -68,7 +68,7 @@ units.2.properties.4.value=https://github.com/oyse/yedit
 units.2.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.2.properties.5.value=https://github.com/oyse/yedit/wiki
 units.2.properties.6.name=org.eclipse.equinox.p2.description
-units.2.properties.6.value=Support editing YAML files in Eclipse
+units.2.properties.6.value=Supports editing YAML files in Eclipse.
 units.2.licenses.0=\
 YEdit is made available under the Eclipse Public License
 units.2.licenses.0.location=https://www.eclipse.org/legal/epl-v10.html
@@ -93,7 +93,7 @@ units.3.properties.4.value=https://github.com/openanalytics/docker-editor/
 units.3.properties.5.name=org.eclipse.equinox.p2.doc.url
 units.3.properties.5.value=https://github.com/openanalytics/docker-editor/wiki/Getting-Started-with-Dockerfile-Editor
 units.3.properties.6.name=org.eclipse.equinox.p2.description
-units.3.properties.6.value=Support editing Dockerfiles in Eclipse
+units.3.properties.6.value=Supports editing Dockerfiles in Eclipse.
 units.3.licenses.0=\
 Docker Editor is made available under the Eclipse Public License
 units.3.licenses.0.location=https://www.eclipse.org/legal/epl-v10.html

--- a/gcp-repo/metadata.p2.inf
+++ b/gcp-repo/metadata.p2.inf
@@ -16,12 +16,12 @@ requires.1.range=[1.0.0,1.0.0]
 requires.1.greedy=true
 
 requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=org.dadacoalition.yedit.category.definition
+requires.2.name=com.google.cloud.tools.eclipse.categories.yedit.definition
 requires.2.range=[1.0.0,1.0.0]
 requires.2.greedy=true
 
 requires.3.namespace=org.eclipse.equinox.p2.iu
-requires.3.name=eu.openanalytics.editor.docker.category.definition
+requires.3.name=com.google.cloud.tools.eclipse.categories.docker.definition
 requires.3.range=[1.0.0,1.0.0]
 requires.3.greedy=true
 
@@ -55,7 +55,7 @@ units.1.provides.1.name=com.google.cloud.tools.eclipse.category.definition
 units.1.provides.1.version=1.0.0
 
 # Define the YEdit category IU
-units.2.id=org.dadacoalition.yedit.category
+units.2.id=com.google.cloud.tools.eclipse.categories.yedit
 units.2.version=0.0.0
 units.2.properties.1.name=org.eclipse.equinox.p2.type.category
 units.2.properties.1.value=true
@@ -76,11 +76,11 @@ units.2.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.2.requires.1.name=org.dadacoalition.yedit.feature.feature.group
 units.2.requires.1.greedy=true
 units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=org.dadacoalition.yedit.category.definition
+units.2.provides.1.name=com.google.cloud.tools.eclipse.categories.yedit.definition
 units.2.provides.1.version=1.0.0
 
 # Define the Dockerfile Editor category IU
-units.3.id=eu.openanalytics.editor.docker.category
+units.3.id=com.google.cloud.tools.eclipse.categories.docker
 units.3.version=0.0.0
 units.3.properties.1.name=org.eclipse.equinox.p2.type.category
 units.3.properties.1.value=true
@@ -101,6 +101,6 @@ units.3.requires.1.namespace=org.eclipse.equinox.p2.iu
 units.3.requires.1.name=eu.openanalytics.editor.docker.feature.group
 units.3.requires.1.greedy=true
 units.3.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.3.provides.1.name=eu.openanalytics.editor.docker.category.definition
+units.3.provides.1.name=com.google.cloud.tools.eclipse.categories.docker.definition
 units.3.provides.1.version=1.0.0
 


### PR DESCRIPTION
Bashed the version number to 0.0.0, and changed the category IDs to indicate that we created them.  Which shouldn't matter since they're only ever shown in the IU property dialogs.

<img width="583" alt="screen shot 2017-12-04 at 2 46 40 pm" src="https://user-images.githubusercontent.com/202851/33572807-09cd6266-d902-11e7-8040-0b02d6d81373.PNG">


<img width="367" alt="screen shot 2017-12-04 at 2 41 32 pm" src="https://user-images.githubusercontent.com/202851/33572544-3f0c62e8-d901-11e7-8afa-fe5485daf560.PNG">
