### PR TITLE
Test Mars using GTK2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ env:
   matrix:
     # ECLIPSE_TARGET is the targeted platform: mars is the default target
     # JAVA_RUNTIME specifies the execution runtime for tests; must match an <id> in .travis-toolchains.xml
+    # SWT_GTK3=0 to force GTK2 on Mars as its GTK3 support is buggy
     - JAVA_RUNTIME=JavaSE-1.7 SWT_GTK3=0
-    - JAVA_RUNTIME=JavaSE-1.8 SWT_GTK3=0 ECLIPSE_TARGET=neon
+    - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=neon
     - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=oxygen MAVEN_FLAGS=-Pjacoco
   global:
     - PATH=$PWD/google-cloud-sdk/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   matrix:
     # ECLIPSE_TARGET is the targeted platform: mars is the default target
     # JAVA_RUNTIME specifies the execution runtime for tests; must match an <id> in .travis-toolchains.xml
-    - JAVA_RUNTIME=JavaSE-1.7
-    - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=neon
+    - JAVA_RUNTIME=JavaSE-1.7 SWT_GTK3=0
+    - JAVA_RUNTIME=JavaSE-1.8 SWT_GTK3=0 ECLIPSE_TARGET=neon
     - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=oxygen MAVEN_FLAGS=-Pjacoco
   global:
     - PATH=$PWD/google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
Set `SWT_GTK3=0` to cause tests to run against GTK2.

Mitigates #2602.