### PR TITLE
Add missing fail() to tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/M2RepositoryServiceTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/M2RepositoryServiceTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.libraries.repository;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
@@ -38,6 +39,7 @@ public class M2RepositoryServiceTest {
     URI noSchemeUri = new URI("host");
     try {
       noSchemeUri.toURL();
+      fail();
     } catch (IllegalArgumentException ex) {
       assertEquals("URI is not absolute", ex.getMessage());
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/ServiceAccountUtilTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.localserver;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -86,6 +87,7 @@ public class ServiceAccountUtilTest {
     try {
       ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
           Paths.get("relative/path/to.json"));
+      fail();
     } catch (IllegalArgumentException e) {
       assertEquals("destination not absolute", e.getMessage());
     }
@@ -93,8 +95,8 @@ public class ServiceAccountUtilTest {
 
   @Test
   public void testCreateServiceAccountKey() throws IOException {
-    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
-        keyFile);
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential,
+        "my-project", keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
@@ -106,8 +108,8 @@ public class ServiceAccountUtilTest {
         eq("projects/google.com:my-project/serviceAccounts/my-project.google.com@appspot.gserviceaccount.com"),
         any(CreateServiceAccountKeyRequest.class))).thenReturn(create);
 
-    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "google.com:my-project",
-        keyFile);
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential,
+        "google.com:my-project", keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
@@ -117,8 +119,8 @@ public class ServiceAccountUtilTest {
   public void testCreateServiceAccountKey_replacesExistingFile() throws IOException {
 
     Files.write(keyFile, new byte[] {0, 1, 2});
-    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
-        keyFile);
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential,
+        "my-project", keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));
@@ -130,8 +132,9 @@ public class ServiceAccountUtilTest {
     when(create.execute()).thenThrow(new IOException("log from unit test"));
     
     try {
-      ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
-          keyFile);
+      ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential,
+          "my-project", keyFile);
+      fail();
     } catch (IOException e) {
       assertEquals("log from unit test", e.getMessage());
     }
@@ -142,8 +145,8 @@ public class ServiceAccountUtilTest {
   public void testCreateServiceAccountKey_createsRequiredDirectories() throws IOException {
 
     Path keyFile = tempFolder.getRoot().toPath().resolve("non/existing/directory/key.json");
-    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential, "my-project",
-          keyFile);
+    ServiceAccountUtil.createAppEngineDefaultServiceAccountKey(apiFactory, credential,
+        "my-project", keyFile);
 
     byte[] bytesRead = Files.readAllBytes(keyFile);
     assertEquals("key data in JSON format", new String(bytesRead, StandardCharsets.UTF_8));


### PR DESCRIPTION
Some tests were missing `fail()`.

I expect builds to pass.