### PR TITLE
Remove unused messages

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties
@@ -8,9 +8,3 @@ appengine.add.facet.to.project=Add App Engine facet to "{0}"
 appengine.install.runtime.to.project=Install App Engine runtimes in "{0}"
 appengine.remove.runtimes.from.project=Remove App Engine runtimes from "{0}"
 project.conversion.error=Failed to convert project "{0}".
-web.facet.incompatible.title=Incompatible Dynamic Web Module Facet version
-web.facet.incompatible.message=Cannot convert project "{0}": installed Dynamic Web Module facet \
- version {1} is incompatible with an App Engine Standard project.
-java.facet.incompatible.title=Incompatible Java Facet Version
-java.facet.incompatible.message=Cannot convert project "{0}": installed Java facet \
- version {1} is incompatible with an App Engine Standard project.

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/messages.properties
@@ -32,7 +32,6 @@ select.project.location=Select project location
 set.pipeline.run.option.defaults=Set pipeline run option defaults
 verified.bucket.is.accessible=Verified bucket {0} is accessible.
 search=&Search...
-update.hierarchy=Update Hierarchy
 use.default.workspace.location=Use default &workspace location
 example.group.id=com.company.product
 group.id=&Group ID:


### PR DESCRIPTION
These 5 identifiers are never referenced.

```
$ git grep update.hierarchy
plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/messages.properties:update.hierarchy=Update Hierarchy
$
$ git grep web.facet.incompatible.title
plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties:web.facet.incompatible.title=Incompatible Dynamic Web Module Facet version
$
$ git grep web.facet.incompatible.message
plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties:web.facet.incompatible.message=Cannot convert project "{0}": installed Dynamic Web Module facet \
$
$ git grep java.facet.incompatible.title
plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties:java.facet.incompatible.title=Incompatible Java Facet Version
$
$ git grep java.facet.incompatible.message
plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/messages.properties:java.facet.incompatible.message=Cannot convert project "{0}": installed Java facet \
```