### PR TITLE
Suppress updating launch configuration dialog during Pipeline Options updates

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTabTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui.test/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTabTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.dataflow.core.launcher.PipelineConfigurationAttr;
@@ -87,6 +88,19 @@ public class PipelineArgumentsTabTest {
       tab.initializeFrom(configuration);  // Should not throw NPE.
 
       ProjectUtils.waitForProjects();  // Suppress some non-terminated-job error logs
+    }
+
+    @Test
+    public void testSuppressingUpdates() {
+      IWorkspaceRoot workspaceRoot = mock(IWorkspaceRoot.class);
+      when(workspaceRoot.getProject(anyString())).thenReturn(mock(IProject.class));
+      ILaunchConfigurationDialog dialog = mock(ILaunchConfigurationDialog.class);
+
+      PipelineArgumentsTab tab = new PipelineArgumentsTab(workspaceRoot);
+      tab.setLaunchConfigurationDialog(dialog);
+      tab.suppressDialogUpdates = true;
+      tab.dialogChangedListener.run();
+      verifyZeroInteractions(dialog);
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -90,7 +90,7 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
   private Executor displayExecutor;
 
   /**
-   * When true, suppresses calls {@link #updateLaunchConfigurationDialog()} to avoid frequent
+   * When true, suppresses calls to {@link #updateLaunchConfigurationDialog()} to avoid frequent
    * updates during batch UI changes.
    */
   @VisibleForTesting

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/launcher/PipelineArgumentsTab.java
@@ -89,6 +89,17 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
 
   private Executor displayExecutor;
 
+  /**
+   * When true, suppresses calls {@link #updateLaunchConfigurationDialog()} to avoid frequent
+   * updates during batch UI changes.
+   */
+  @VisibleForTesting
+  boolean suppressDialogUpdates = false;
+
+  @VisibleForTesting
+  UpdateLaunchConfigurationDialogChangedListener dialogChangedListener =
+      new UpdateLaunchConfigurationDialogChangedListener();
+
   private ScrolledComposite composite;
   private Composite internalComposite;
 
@@ -169,8 +180,8 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
 
     pipelineOptionsForm =
         new PipelineOptionsFormComponent(runnerOptionsGroup, ARGUMENTS_SEPARATOR, filterProperties);
-    pipelineOptionsForm.addModifyListener(new UpdateLaunchConfigurationDialogChangedListener());
-    pipelineOptionsForm.addExpandListener(new UpdateLaunchConfigurationDialogChangedListener());
+    pipelineOptionsForm.addModifyListener(dialogChangedListener);
+    pipelineOptionsForm.addExpandListener(dialogChangedListener);
 
     composite.setContent(internalComposite);
     composite.setExpandHorizontal(true);
@@ -254,8 +265,6 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
     defaultOptionsComponent =
         new DefaultedPipelineOptionsComponent(composite, layoutData, target, getPreferences());
 
-    UpdateLaunchConfigurationDialogChangedListener dialogChangedListener =
-        new UpdateLaunchConfigurationDialogChangedListener();
     defaultOptionsComponent.addAccountSelectionListener(dialogChangedListener);
     defaultOptionsComponent.addButtonSelectionListener(dialogChangedListener);
     defaultOptionsComponent.addModifyListener(dialogChangedListener);
@@ -411,10 +420,13 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
           @Override
           public void run() {
             try {
+              suppressDialogUpdates = true;
               pipelineOptionsForm.updateForm(launchConfiguration, optionsHierarchyFuture.get());
               updateLaunchConfigurationDialog();
             } catch (InterruptedException | ExecutionException ex) {
               DataflowUiPlugin.logError(ex, "Exception while updating available Pipeline Options"); //$NON-NLS-1$
+            } finally {
+              suppressDialogUpdates = false;
             }
           }
         });
@@ -517,8 +529,10 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
    * arguments tab; and 2) the min size of the {@code ScrolledComposite} is updated to fit the
    * entire form.
    */
-  private class UpdateLaunchConfigurationDialogChangedListener
+  @VisibleForTesting
+  class UpdateLaunchConfigurationDialogChangedListener
       extends SelectionAdapter implements ModifyListener, IExpansionListener, Runnable {
+
     @Override
     public void widgetSelected(SelectionEvent event) {
       run();
@@ -540,7 +554,9 @@ public class PipelineArgumentsTab extends AbstractLaunchConfigurationTab {
 
     @Override
     public void run() {
-      updateLaunchConfigurationDialog();
+      if (!suppressDialogUpdates) {
+        updateLaunchConfigurationDialog();
+      }
     }
   }
 }


### PR DESCRIPTION
Updating the pipeline options form triggers modify events for each text field changed; each modify event triggers an `updateLaunchConfigurationDialog()`.  With this patch, selecting the DataflowPipelineRunner went from 48 calls to PipelineArgumentsTab#isValid() to 4.

Fixes #2654