### PR TITLE
Tweak target descriptors

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -9,7 +9,6 @@
    <feature id="org.eclipse.m2e.wtp.sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.mylyn.commons" version="0.0.0"/>
    <feature id="org.eclipse.jpt.jpa.feature" version="0.0.0"/>
-   <feature id="org.eclipse.datatools.sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.swtbot.eclipse" version="0.0.0"/>
    <feature id="org.eclipse.jst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.jst.server_sdk.feature" version="0.0.0"/>

--- a/eclipse/mars/gcp-eclipse-mars.target
+++ b/eclipse/mars/gcp-eclipse-mars.target
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Mars" sequenceNumber="1510598695">
+<target name="GCP for Eclipse Mars" sequenceNumber="1513015899">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.5.2.v20160212-1500"/>
@@ -16,7 +16,6 @@
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.2.1.20150819-2220"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.18.0.v20151116-1930"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.4.2.v201512181609"/>
-      <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.12.0.v201406061321-7PB21FEpPZQXdcX0z-_yMM0Hfz0w"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
       <unit id="org.eclipse.jetty.http" version="9.2.13.v20150730"/>
       <unit id="org.eclipse.jetty.servlet" version="9.2.13.v20150730"/>
@@ -35,16 +34,16 @@
       <repository location="http://download.eclipse.org/webtools/repository/mars/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -27,7 +27,6 @@ location "http://download.eclipse.org/releases/mars/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.jetty.http

--- a/eclipse/mars/gcp-eclipse-mars.tpd
+++ b/eclipse/mars/gcp-eclipse-mars.tpd
@@ -14,7 +14,7 @@
  */
 target "GCP for Eclipse Mars" with source requirements
 
-location "http://download.eclipse.org/cbi/updates/license" {
+location "http://download.eclipse.org/cbi/updates/license/" {
     org.eclipse.license.feature.group    
 }
 
@@ -27,7 +27,7 @@ location "http://download.eclipse.org/releases/mars/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.datatools.sdk.feature.feature.group
+	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.jetty.http
@@ -36,12 +36,7 @@ location "http://download.eclipse.org/releases/mars/" {
 	org.eclipse.jetty.util
 }
 
-// Commented out as the latest 2.0.5 brings in Guava 21.
-//location "http://download.eclipse.org/technology/epp/logging/stable/" {
-//	org.eclipse.epp.logging.aeri.feature.feature.group
-//	org.eclipse.epp.logging.aeri.feature.source.feature.group
-//}
-
+// WTP SDKs aren't exposed through the main release links
 location "http://download.eclipse.org/webtools/repository/mars/" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
@@ -52,16 +47,22 @@ location "http://download.eclipse.org/webtools/repository/mars/" {
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://docker-editor.openanalytics.eu/update" {
-	  eu.openanalytics.editor.docker.feature.group
-}
+// Commented out as the latest 2.0.5 brings in Guava 21.
+//location "http://download.eclipse.org/technology/epp/logging/stable/" {
+//	org.eclipse.epp.logging.aeri.feature.feature.group
+//	org.eclipse.epp.logging.aeri.feature.source.feature.group
+//}
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160221192158/repository/" {
+location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
     org.hamcrest.core [1.3.0,1.3.1)
     org.hamcrest.integration [1.3.0,1.3.1)
     org.hamcrest.library [1.3.0,1.3.1)
     ch.qos.logback.slf4j
     org.slf4j.log4j
+}
+
+location "http://docker-editor.openanalytics.eu/update/" {
+	  eu.openanalytics.editor.docker.feature.group
 }
 
 location "http://dadacoalition.org/yedit/" {

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1510598867">
+<target name="GCP for Eclipse Neon" sequenceNumber="1513015903">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
@@ -20,7 +16,6 @@
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.1.20160831-1005"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.21.0.v20160707-1856"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201607131827"/>
-      <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.13.0.201603142002"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.4.v20170307-1435"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.4.v20170307-1435"/>
@@ -28,25 +23,29 @@
       <unit id="org.eclipse.jetty.servlet" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.server" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.util" version="9.3.9.v20160517"/>
-      <repository location="http://download.eclipse.org/releases/neon"/>
+      <repository location="http://download.eclipse.org/releases/neon/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201605120129"/>
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201608191717"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201606030549"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201609072018"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.0.v201605251556"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.8.0/R-3.8.0-20160608130753/repository"/>
+      <repository location="http://download.eclipse.org/webtools/repository/neon/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -11,15 +11,11 @@
  */
 target "GCP for Eclipse Neon" with source requirements
 
-location "http://download.eclipse.org/cbi/updates/license" {
+location "http://download.eclipse.org/cbi/updates/license/" {
     org.eclipse.license.feature.group
 }
 
-location "http://docker-editor.openanalytics.eu/update" {
-	  eu.openanalytics.editor.docker.feature.group
-}
-
-location "http://download.eclipse.org/releases/neon" {
+location "http://download.eclipse.org/releases/neon/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -28,7 +24,7 @@ location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.datatools.sdk.feature.feature.group
+	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group
@@ -40,9 +36,8 @@ location "http://download.eclipse.org/releases/neon" {
 	org.eclipse.jetty.util
 }
 
-// /webtools/repository/neon currently has some issues
-// location "http://download.eclipse.org/webtools/repository/neon/" {
-location "http://download.eclipse.org/webtools/downloads/drops/R3.8.0/R-3.8.0-20160608130753/repository" {
+// WTP SDKs aren't exposed through the main release links
+location "http://download.eclipse.org/webtools/repository/neon/" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
@@ -52,12 +47,16 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.8.0/R-3.8.0-20
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/" {
+location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
     org.hamcrest.core [1.3.0,1.3.1)
     org.hamcrest.integration [1.3.0,1.3.1)
     org.hamcrest.library [1.3.0,1.3.1)
     ch.qos.logback.slf4j
     org.slf4j.log4j
+}
+
+location "http://docker-editor.openanalytics.eu/update/" {
+	  eu.openanalytics.editor.docker.feature.group
 }
 
 location "http://dadacoalition.org/yedit/" {

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -24,7 +24,6 @@ location "http://download.eclipse.org/releases/neon/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,44 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1510598997">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1513015898">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license"/>
+      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170612-1255"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.13.0.v20170612-0950"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20170516-2043"/>
-      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.0.20170516-2043"/>
-      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.2.20170517-2015"/>
-      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.2.20170517-2015"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.7.1.v20171009-0537"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.13.1.v20171009-0410"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.2.20171007-0217"/>
+      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.8.2.20171007-0217"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.3.20170823-1905"/>
+      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.3.20170823-1905"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170503-0014"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.100.v201705180510"/>
-      <unit id="org.eclipse.datatools.sdk.feature.feature.group" version="1.14.0.201701131441"/>
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.5.v20170613-1207"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.5.v20170613-1207"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.6.v20170906-1226"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.6.v20170906-1226"/>
       <unit id="org.eclipse.jetty.http" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.servlet" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.server" version="9.4.5.v20170502"/>
       <unit id="org.eclipse.jetty.util" version="9.4.5.v20170502"/>
-      <repository location="http://download.eclipse.org/releases/oxygen/201706281000/"/>
+      <repository location="http://download.eclipse.org/releases/oxygen/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201706011851"/>
-      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
-      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.0.v201706011953"/>
-      <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.0.v201701262152"/>
-      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201704201544"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.0/R-3.9.0-20170613094504/repository"/>
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201710032159"/>
+      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201707132334"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201710021614"/>
+      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.1.v201707201954"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.1.v201707252002"/>
+      <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201710021559"/>
+      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201708030026"/>
+      <repository location="http://download.eclipse.org/webtools/repository/oxygen"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
@@ -46,7 +41,11 @@
       <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
       <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -11,16 +11,11 @@
  */
 target "GCP for Eclipse Oxygen" with source requirements
 
-location "http://download.eclipse.org/cbi/updates/license" {
+location "http://download.eclipse.org/cbi/updates/license/" {
     org.eclipse.license.feature.group
 }
 
-location "http://docker-editor.openanalytics.eu/update" {
-	  eu.openanalytics.editor.docker.feature.group
-}
-
-// 201706281000 = Oxygen.0
-location "http://download.eclipse.org/releases/oxygen/201706281000/" {
+location "http://download.eclipse.org/releases/oxygen/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -29,7 +24,7 @@ location "http://download.eclipse.org/releases/oxygen/201706281000/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.datatools.sdk.feature.feature.group
+	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group
@@ -42,7 +37,7 @@ location "http://download.eclipse.org/releases/oxygen/201706281000/" {
 }
 
 // WTP SDKs aren't exposed through the main release links
-location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/R-3.9.0-20170613094504/repository" {
+location "http://download.eclipse.org/webtools/repository/oxygen" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
@@ -52,12 +47,16 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.9.0/R-3.9.0-20
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/drops/R20170516192513/repository" {
+location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
     org.hamcrest.core [1.3.0,1.3.1)
     org.hamcrest.integration [1.3.0,1.3.1)
     org.hamcrest.library [1.3.0,1.3.1)
     ch.qos.logback.slf4j
     org.slf4j.log4j
+}
+
+location "http://docker-editor.openanalytics.eu/update/" {
+	  eu.openanalytics.editor.docker.feature.group
 }
 
 location "http://dadacoalition.org/yedit/" {

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -24,7 +24,6 @@ location "http://download.eclipse.org/releases/oxygen/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	//org.eclipse.datatools.sdk.feature.feature.group
 	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group


### PR DESCRIPTION
- Use Orbit's latest release repo to get fixes/patches (recommended practice, even with older releases)
- Use WTP release train repositories (e.g., `/webtools/repository/oxygen`) rather than specific versions; we're using the main Eclipse release train repositories (e.g., `/releases/oxygen`).
- Drop org.eclipse.datatools since it's not used: I included it as it was referenced in GPE
- Use consistent ordering of repositories