### PR TITLE
Log diagnostic messages for ServerUtil.getModule() failure

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -35,6 +36,8 @@ import org.eclipse.wst.server.core.IServerType;
 import org.eclipse.wst.server.core.IServerWorkingCopy;
 import org.eclipse.wst.server.core.ServerCore;
 import org.eclipse.wst.server.core.ServerUtil;
+import org.eclipse.wst.server.core.internal.ModuleFactory;
+import org.eclipse.wst.server.core.internal.ServerPlugin;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,6 +68,10 @@ public class LocalAppEnginePublishOperationTest {
     assertNotNull("sox-server", serverProject);
     sharedProject = projects.get("sox-shared".equals(projects.get(0).getName()) ? 0 : 1);
     assertNotNull("sox-shared", sharedProject);
+
+    // To diagnose https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1798.
+    logModules(serverProject);
+    logModules(sharedProject);
 
     serverModule = ServerUtil.getModule(serverProject);
     assertNotNull(serverModule);
@@ -114,5 +121,31 @@ public class LocalAppEnginePublishOperationTest {
     assertTrue(new File(webInf, "classes/sox/server/GreetingServiceImpl.class").isFile());
     assertTrue(new File(webInf, "lib/servlet-2.5.jar").isFile());
     assertTrue(new File(webInf, "lib/sox-shared.jar").isFile());
+  }
+
+  // Code taken from "ServerUtil.getModules()" (which "ServerUtil.getModule()" calls) to diagnose
+  // one of the failures in https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1798.
+  private static void logModules(IProject project) {
+    System.out.println("  #### Testing getModules(" + project.getName() + ") ####");
+
+    ModuleFactory[] factories = ServerPlugin.getModuleFactories();
+    assertNotNull(factories);
+    assertNotEquals(0, factories.length);
+
+    for (ModuleFactory factory : factories) {
+      boolean factoryEnabled = factory.isEnabled(project, null);
+      System.out.println("    * " + factory + (factoryEnabled? " (not enabled, skipping)" : ""));
+
+      if (factoryEnabled){
+        IModule[] modules = factory.getModules(project, null);
+        if (modules == null) {
+          System.out.println("      [null module list]");
+        } else {
+          for (IModule module : modules) {
+            System.out.println("      - " + module.getName());
+          }
+        }
+      }
+    }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -56,7 +56,7 @@ public class LocalAppEnginePublishOperationTest {
   private IServer server;
 
   @Before
-  public void setUp() throws IOException, CoreException {
+  public void setUp() throws IOException, CoreException, InterruptedException {
     projects = ProjectUtils.importProjects(getClass(),
         "projects/test-submodules.zip", true /* checkBuildErrors */, null);
     assertEquals(2, projects.size());
@@ -136,15 +136,24 @@ public class LocalAppEnginePublishOperationTest {
       boolean factoryEnabled = factory.isEnabled(project, null);
       System.out.println("    * " + factory + (!factoryEnabled? " (not enabled, skipping)" : ""));
 
-      if (factoryEnabled){
-        IModule[] modules = factory.getModules(project, null);
-        if (modules == null) {
-          System.out.println("      [null module list]");
-        } else {
-          for (IModule module : modules) {
-            System.out.println("      - " + module.getName());
-          }
-        }
+      System.out.print("      - All modules of the factory:");
+      printModules(factory.getDelegate(null).getModules());
+
+      if (factoryEnabled) {
+        System.out.print("      - Project modules:");
+        printModules(factory.getModules(project, null));
+      }
+    }
+  }
+
+  private static void printModules(IModule[] modules) {
+    if (modules == null) {
+      System.out.println(" <null>");
+    } else if (modules.length == 0) {
+      System.out.println(" <empty>");
+    } else {
+      for (IModule module : modules) {
+        System.out.println(" " + module.getName());
       }
     }
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -56,7 +56,7 @@ public class LocalAppEnginePublishOperationTest {
   private IServer server;
 
   @Before
-  public void setUp() throws IOException, CoreException, InterruptedException {
+  public void setUp() throws IOException, CoreException {
     projects = ProjectUtils.importProjects(getClass(),
         "projects/test-submodules.zip", true /* checkBuildErrors */, null);
     assertEquals(2, projects.size());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -136,7 +136,7 @@ public class LocalAppEnginePublishOperationTest {
       boolean factoryEnabled = factory.isEnabled(project, null);
       System.out.println("    * " + factory + (!factoryEnabled? " (not enabled, skipping)" : ""));
 
-      System.out.print("      - All modules of the factory:");
+      System.out.print("      - All factory modules:");
       printModules(factory.getDelegate(null).getModules());
 
       if (factoryEnabled) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -134,7 +134,7 @@ public class LocalAppEnginePublishOperationTest {
 
     for (ModuleFactory factory : factories) {
       boolean factoryEnabled = factory.isEnabled(project, null);
-      System.out.println("    * " + factory + (factoryEnabled? " (not enabled, skipping)" : ""));
+      System.out.println("    * " + factory + (!factoryEnabled? " (not enabled, skipping)" : ""));
 
       if (factoryEnabled){
         IModule[] modules = factory.getModules(project, null);


### PR DESCRIPTION
One of the failures in #1798 is `ServerUtil.getModule(project)` returning null. (I saw this today too.) This PR is to log the module state at that point to understand which part is failing.

In a normal case, it logs below:
```
[Watchdog] > testPublishingSubmodules(com.google.cloud.tools.eclipse.appengine.localserver.server.LocalAppEnginePublishOperationTest)
Importing 2 projects:
    /usr/local/google/home/chanseok/junit-workspace/sox-server/.project
    /usr/local/google/home/chanseok/junit-workspace/sox-shared/.project
  #### Testing getModules(sox-server) ####
    * ModuleFactory[org.eclipse.jst.j2ee.server] (not enabled, skipping)
      - All factory modules: sox-shared
    * ModuleFactory[org.eclipse.jst.jee.server]
      - All factory modules: sox-server
      - Project modules: sox-server
    * ModuleFactory[org.eclipse.wst.web.internal.deployables.static]
      - All factory modules: <empty>
      - Project modules: <empty>
  #### Testing getModules(sox-shared) ####
    * ModuleFactory[org.eclipse.jst.j2ee.server]
      - All factory modules: sox-shared
      - Project modules: sox-shared
    * ModuleFactory[org.eclipse.jst.jee.server]
      - All factory modules: sox-server
      - Project modules: <empty>
    * ModuleFactory[org.eclipse.wst.web.internal.deployables.static]
      - All factory modules: <empty>
      - Project modules: <empty>
```