### PR TITLE
Download and unpack M2 repo cache for Kokoro builds

### DIFF
--- a/kokoro/windows/continuous.bat
+++ b/kokoro/windows/continuous.bat
@@ -1,4 +1,12 @@
 @echo on
+
+rem To speed up build, download and unpack an M2 repo cache.
+pushd %USERPROFILE%
+call gsutil -q cp "gs://ct4e-m2-repositories/m2-oxygen.tar" .
+echo on
+tar xf m2-oxygen.tar && del m2-oxygen.tar
+popd
+
 cd github\google-cloud-eclipse
 
 rem Pre-download all dependency JARs that test projects from the integration


### PR DESCRIPTION
So, I've tar'ed up an M2 repo (`$HOME/.m2`) containing almost all artifacts and bundles used in Kokoro Oxygen builds. Its size is about 690MB. I uploaded it to a GCS bucket.

I tested downloading the tar and unpacking on Kokoro, and surprisingly, the whole process takes only a few seconds. No more artifact/bundle downloading (for now), so this saves a lot of time.