### PR TITLE
Build with ErrorProne on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ before_script:
   - sleep 3 # give xvfb some time to start
   - metacity --sm-disable --replace &
   - sleep 3 # give metacity some time to start
-script: ./mvnw -V -B -Ptravis --fail-at-end verify ${MAVEN_FLAGS}
+script: ./mvnw -V -B --fail-at-end verify ${MAVEN_FLAGS}
+     -Ptravis -Perrorprone
      ${ECLIPSE_TARGET:+-Declipse.target=${ECLIPSE_TARGET}}
      --toolchains=.travis-toolchains.xml
      -Dtoolchain.java.runtime=${JAVA_RUNTIME}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -347,7 +347,7 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
     PortChecker portInUse = new PortChecker() {
       @Override
       public boolean isInUse(InetAddress addr, int port) {
-        Preconditions.checkNotNull(port);
+        Preconditions.checkArgument(port >= 0, "invalid port");
         return SocketUtil.isPortInUse(addr, port);
       }
     };

--- a/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
@@ -22,6 +22,106 @@
     on a full build.
    -->
 
+  <dependencies>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-appengine</artifactId>
+      <version>v1-rev35-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudresourcemanager</artifactId>
+      <version>v1-rev455-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-servicemanagement</artifactId>
+      <version>v1-rev368-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-storage</artifactId>
+      <version>v1-rev115-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-compute</artifactId>
+      <version>v1-rev160-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-dataflow</artifactId>
+      <version>v1b3-rev219-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-bigquery</artifactId>
+      <version>v2-rev362-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-pubsub</artifactId>
+      <version>v1-rev363-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-datastore</artifactId>
+      <version>v1-rev34-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-iam</artifactId>
+      <version>v1-rev222-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-oauth2</artifactId>
+      <version>v2-rev131-1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-jetty</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-java6</artifactId>
+      <version>1.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools.login</groupId>
+      <artifactId>plugins-login-common</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <!-- Copy listed dependencies to lib/ -->
@@ -30,112 +130,21 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy</id>
+            <id>assemble-bundle-lib</id>
             <goals>
-              <goal>copy</goal>
+              <goal>copy-dependencies</goal>
             </goals>
             <configuration>
+              <includeScope>runtime</includeScope>
+              <!-- the groupIds of the dependencies above -->
+              <includeGroupIds>
+                com.google.api-client,
+                com.google.apis,
+                com.google.oauth-client,
+                com.google.http-client,
+                com.google.cloud.tools.login,
+              </includeGroupIds>
               <outputDirectory>lib</outputDirectory>
-              <artifactItems>
-
-                <artifactItem>
-                  <groupId>com.google.api-client</groupId>
-                  <artifactId>google-api-client</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-appengine</artifactId>
-                  <version>v1-rev35-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-cloudresourcemanager</artifactId>
-                  <version>v1-rev455-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-servicemanagement</artifactId>
-                  <version>v1-rev368-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-storage</artifactId>
-                  <version>v1-rev115-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-compute</artifactId>
-                  <version>v1-rev160-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-dataflow</artifactId>
-                  <version>v1b3-rev219-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-bigquery</artifactId>
-                  <version>v2-rev362-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-pubsub</artifactId>
-                  <version>v1-rev363-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-datastore</artifactId>
-                  <version>v1-rev34-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-iam</artifactId>
-                  <version>v1-rev222-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.apis</groupId>
-                  <artifactId>google-api-services-oauth2</artifactId>
-                  <version>v2-rev131-1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.http-client</groupId>
-                  <artifactId>google-http-client</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.http-client</groupId>
-                  <artifactId>google-http-client-jackson</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.http-client</groupId>
-                  <artifactId>google-http-client-jackson2</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-
-                <artifactItem>
-                  <groupId>com.google.oauth-client</groupId>
-                  <artifactId>google-oauth-client</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.oauth-client</groupId>
-                  <artifactId>google-oauth-client-jetty</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.oauth-client</groupId>
-                  <artifactId>google-oauth-client-java6</artifactId>
-                  <version>1.23.0</version>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.cloud.tools.login</groupId>
-                  <artifactId>plugins-login-common</artifactId>
-                  <version>0.1.0</version>
-                </artifactItem>
-              </artifactItems>
             </configuration>
           </execution>
         </executions>

--- a/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
@@ -17,9 +17,10 @@
     can be consumed by Eclipse/OSGi projects as many of these APIs
     are not distributed as OSGi bundles.
 
-    This approach ideally requires use of Ian Brandt's "Maven Dependency Plugin" for m2e, which
-    causes the `dependency:copy` to be performed during the _process-sources_ phase
-    on a full build.
+    This approach requires use of Ian Brandt's "Maven Dependency
+    Plugin" for m2e, which causes the `dependency:copy-dependencies`
+    to be performed during the _process-sources_ phase on a full
+    build.
    -->
 
   <dependencies>

--- a/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/model/GcpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.projectselector.test/src/com/google/cloud/tools/eclipse/projectselector/model/GcpProjectTest.java
@@ -72,6 +72,7 @@ public class GcpProjectTest {
   }
 
   @Test
+  @SuppressWarnings("SelfEquals") // errorprone
   public void testEqualsItself() {
     GcpProject gcpProject = new GcpProject("name", "id");
     assertTrue(gcpProject.equals(gcpProject));

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.swtbot;
 
+import java.util.Arrays;
 import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.SWTBot;
@@ -99,8 +100,8 @@ public class SwtBotTreeUtilities {
       }
     }
 
-    throw new WidgetNotFoundException("One of the " + itemNames + " nodes with a child of "
-        + subchildName + " must exist in the tree.");
+    throw new WidgetNotFoundException("One of the " + Arrays.toString(itemNames)
+        + " nodes with a child of " + subchildName + " must exist in the tree.");
   }
 
   private static class TreeCollapsedCondition extends DefaultCondition {

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
@@ -23,8 +23,10 @@
 
       - it uses `Require-Bundle` to pull in and re-export the existing Hamcrest and JUnit bundles
         (which are ok)
-      - it copies all Maven dependencies with test-scope into the `lib` directory using
+      - it copies all Maven dependencies with compile-scope into the `lib` directory using
         the `dependency:copy-dependencies` goal, and then exports their packages.
+        (These dependencies must be compile scoped so that the maven-compiler-plugin sees them
+        for our .test.util bundle, which is an eclipse-plugin and not an eclipse-test-plugin.)
 
     This approach ideally requires use of Ian Brandt's "Maven Dependency Plugin" for m2e, which
     causes the `dependency:copy-dependencies` to be performed during the _process-sources_ phase
@@ -34,12 +36,22 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
     </dependency>
   </dependencies>
 
@@ -56,7 +68,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <includeScope>test</includeScope>
+              <includeScope>runtime</includeScope>
               <!-- the groupIds of the dependencies above -->
               <includeGroupIds>
                 org.mockito,

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
@@ -33,6 +33,7 @@
     on a full build.
    -->
   <dependencies>
+    <!-- dependencies with broken OSGi metadata that we repackage -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -41,6 +42,8 @@
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
     </dependency>
+
+    <!-- dependencies required only for maven-compiler-plugin/errorprone -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
@@ -69,7 +72,7 @@
             </goals>
             <configuration>
               <includeScope>runtime</includeScope>
-              <!-- the groupIds of the dependencies above -->
+              <!-- the groupIds for the dependencies-to-be-wrapped -->
               <includeGroupIds>
                 org.mockito,
                 org.objenesis,

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/pom.xml
@@ -24,12 +24,24 @@
       - it uses `Require-Bundle` to pull in and re-export the existing Hamcrest and JUnit bundles
         (which are ok)
       - it copies all Maven dependencies with test-scope into the `lib` directory using
-        the `dependency:copy` goal, and then exports their packages.
+        the `dependency:copy-dependencies` goal, and then exports their packages.
 
     This approach ideally requires use of Ian Brandt's "Maven Dependency Plugin" for m2e, which
     causes the `dependency:copy-dependencies` to be performed during the _process-sources_ phase
     on a full build.
    -->
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
@@ -39,25 +51,18 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy</id>
+            <id>assemble-bundle-lib</id>
             <goals>
-              <goal>copy</goal>
+              <goal>copy-dependencies</goal>
             </goals>
             <configuration>
+              <includeScope>test</includeScope>
+              <!-- the groupIds of the dependencies above -->
+              <includeGroupIds>
+                org.mockito,
+                org.objenesis,
+              </includeGroupIds>
               <outputDirectory>lib</outputDirectory>
-              <!--
-                Dependencies that are then exported to OSGi bundles.
-              -->
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.mockito</groupId>
-                  <artifactId>mockito-core</artifactId>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.objenesis</groupId>
-                  <artifactId>objenesis</artifactId>
-                </artifactItem>
-              </artifactItems>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
     <org.eclipse.swtbot.search.timeout>30000</org.eclipse.swtbot.search.timeout>
 
     <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
+
+    <!--
+      jgit provider uses git commit hash to generate bundle/feature version
+      qualifier; set to empty to work around bug building from git-worktrees
+    -->
+    <tycho.buildtimestamp.provider>jgit</tycho.buildtimestamp.provider>
   </properties>
 
   <!--
@@ -297,7 +303,7 @@
           </dependency>
         </dependencies>
         <configuration>
-          <timestampProvider>jgit</timestampProvider>
+          <timestampProvider>${tycho.buildtimestamp.provider}</timestampProvider>
           <jgit.dirtyWorkingTree>${jgit.dirtyWorkingTree}</jgit.dirtyWorkingTree>
           <jgit.ignore>
             pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,16 @@
         <artifactId>objenesis</artifactId>
         <version>2.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>mars</eclipse.target>
 
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+
     <!-- log surefire tests to stdout -->
     <tycho.showEclipseLog>true</tycho.showEclipseLog>
 
@@ -385,7 +388,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -666,6 +669,45 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>errorprone</id>
+      <!-- add separate compilation step using the errorprone compiler -->
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <compilerId>javac-with-errorprone</compilerId>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>2.8.1</version>
+              </dependency>
+              <!-- override plexus-compiler-javac-errorprone's dependency on
+                 Error Prone with the latest version -->
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.0.15</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This PR adds a new profile `errorprone` that invokes the ErrorProne compiler, and fixes some errors identified by ErrorProne.  It changes the Travis build to use this `errorprone` profile.

We can't replace Tycho's use of ECJ as the `tycho-compiler-plugin` is specifically brought in as part of the `eclipse-plugin` packaging, and doesn't offer an option to skip compilation.  Although this double-compilation (ecj + errorprone/javac) increases the compilation time, the additional compilation time is dwarfed by testing time.

I had to rework `com.google.cloud.tools.eclipse.googleapis` and `.test.dependencies` slightly to bring in their dependent libraries using Maven's `<dependencies>` to keep the Travis build happy.  I had tried this approach for #2390 but we were getting a substantial number of dependencies copied in the `lib/` and I wasn't aware of the `maven-dependency-plugin`'s `<includeGroupIds>` option to limit dependencies.

(Aside: I'm still a bit puzzled why the `maven-compiler-plugin` needs these `<dependencies>` but `tycho-compiler-plugin` does not, as the `maven-compiler-plugin` has no problem resolving classes that are in other bundles.  I guess the `tycho-compiler-plugin` must recompute the classpath from the `Bundle-Classpath` before passing onto the ECJ compiler?  Expressing these as `<dependencies>` ensures the `maven-compiler-plugin` sees them always.)

Fixes #2608.  

### Time impacts 
Baseline: `mvn package` (just the `tycho-compiler-plugin` using ECJ):
```
[INFO] Total time: 01:15 min
[INFO] Final Memory: 200M/493M
```

With ErrorProne: `mvn -Perrorprone package` (ECJ + ErrorProne)
```
[INFO] Total time: 01:42 min
[INFO] Final Memory: 246M/453M
```