### PR TITLE
Lock versions of static libraryFile

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/PomTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/PomTest.java
@@ -225,7 +225,7 @@ public class PomTest {
     Pom.removeUnusedDependencies(dependencies, Arrays.asList(library1),
         Arrays.asList(library1, library2));
     Assert.assertEquals(1, dependencies.getElementsByTagName("dependency").getLength());
-    Element dependency = getOnlyChild(((Element) dependencies), "dependency");
+    Element dependency = getOnlyChild(dependencies, "dependency");
     Element groupId = getOnlyChild(dependency, "groupId");
     Assert.assertEquals("com.example.group1", groupId.getTextContent());
     Element artifactId = getOnlyChild(dependency, "artifactId");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -76,7 +76,6 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(mavenCoordinates.getRepository(), is("central"));
     assertThat(mavenCoordinates.getGroupId(), is("com.google.appengine"));
     assertThat(mavenCoordinates.getArtifactId(), is("appengine-api-1.0-sdk"));
-    assertThat(mavenCoordinates.getVersion(), is("1.9.59"));
     assertThat(mavenCoordinates.getType(), is("jar"));
     assertNull(mavenCoordinates.getClassifier());
 
@@ -114,7 +113,6 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(mavenCoordinates.getRepository(), is("central"));
     assertThat(mavenCoordinates.getGroupId(), is("com.google.endpoints"));
     assertThat(mavenCoordinates.getArtifactId(), is("endpoints-framework"));
-    assertThat(mavenCoordinates.getVersion(), is("2.0.9"));
     assertThat(mavenCoordinates.getType(), is("jar"));
     assertNull(mavenCoordinates.getClassifier());
     assertThat(libraryFile.getJavadocUri(),
@@ -157,14 +155,13 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(objectifyMavenCoordinates.getRepository(), is("central"));
     assertThat(objectifyMavenCoordinates.getGroupId(), is("com.googlecode.objectify"));
     assertThat(objectifyMavenCoordinates.getArtifactId(), is("objectify"));
-    assertThat(objectifyMavenCoordinates.getVersion(), is("5.1.21"));
     assertThat(objectifyMavenCoordinates.getType(), is("jar"));
     assertNull(objectifyMavenCoordinates.getClassifier());
 
     assertNotNull(objectifyLibraryFile.getFilters());
     assertTrue(objectifyLibraryFile.getFilters().isEmpty());
     assertThat(objectifyLibraryFile.getJavadocUri(),
-        is(new URI("https://www.javadoc.io/doc/com.googlecode.objectify/objectify/5.1.21")));
+        is(new URI("https://www.javadoc.io/doc/com.googlecode.objectify/objectify/")));
     
     assertNull(guavaLibraryFile.getSourceUri());
     assertTrue("Guava not exported", guavaLibraryFile.isExport());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -170,7 +170,6 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(guavaMavenCoordinates.getRepository(), is("central"));
     assertThat(guavaMavenCoordinates.getGroupId(), is("com.google.guava"));
     assertThat(guavaMavenCoordinates.getArtifactId(), is("guava"));
-    assertThat(guavaMavenCoordinates.getVersion(), is("20.0"));
     assertThat(guavaMavenCoordinates.getType(), is("jar"));
     assertNull(guavaMavenCoordinates.getClassifier());
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactoryTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactoryTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.libraries.model;
 
+import java.net.URISyntaxException;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.junit.Assert;
@@ -75,6 +76,24 @@ public class LibraryFactoryTest {
     String version = library.getAllDependencies().get(0).getMavenCoordinates().getVersion();
     int majorVersion = new DefaultArtifactVersion(version).getMajorVersion();
     Assert.assertEquals(19, majorVersion);
+  }
+
+  @Test
+  public void testLoadSingleFile_versionGiven() throws URISyntaxException {
+    Mockito.when(mavenCoordinates[0].getAttribute("version")).thenReturn("19.0");
+
+    LibraryFile libraryFile = LibraryFactory.loadSingleFile(libraryFiles[0],
+        Mockito.mock(MavenCoordinates.class));
+    Assert.assertTrue(libraryFile.isVersionFixed());
+  }
+
+  @Test
+  public void testLoadSingleFile_latestVersion() throws URISyntaxException {
+    Mockito.when(mavenCoordinates[0].getAttribute("version")).thenReturn("LATEST");
+
+    LibraryFile libraryFile = LibraryFactory.loadSingleFile(libraryFiles[0],
+        Mockito.mock(MavenCoordinates.class));
+    Assert.assertFalse(libraryFile.isVersionFixed());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -6,7 +6,7 @@
 
   <extension point="com.google.cloud.tools.eclipse.appengine.libraries"
              id="com.google.cloud.tools.eclipse.appengine.libraries.defaultapis">       
-             
+
     <library 
           id="appengine-api"
           group="appengine-api"
@@ -17,8 +17,7 @@
           export="false">
         <mavenCoordinates
               artifactId="appengine-api-1.0-sdk"
-              groupId="com.google.appengine" 
-              version="1.9.59" />
+              groupId="com.google.appengine" />
         <exclusionFilter pattern="com/google/appengine/repackaged/**" />
         <exclusionFilter pattern="com/google/appengine/labs/repackaged/**" />
         <inclusionFilter pattern="com/google/apphosting/api/**" />
@@ -36,8 +35,7 @@
             javadocUri="https://cloud.google.com/endpoints/docs/frameworks/java/javadoc/">
         <mavenCoordinates
               artifactId="endpoints-framework"
-              groupId="com.google.endpoints" 
-              version="2.0.9"/>
+              groupId="com.google.endpoints" />
         <exclusionFilter pattern="com/google/appengine/repackaged/**" />
       </libraryFile>
     </library>
@@ -54,8 +52,7 @@
           javadocUri="https://www.javadoc.io/doc/com.googlecode.objectify/objectify/5.1.21">
         <mavenCoordinates
               artifactId="objectify"
-              groupId="com.googlecode.objectify"
-              version="5.1.21" />
+              groupId="com.googlecode.objectify" />
       </libraryFile>
     </library>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -49,7 +49,7 @@
           siteUri="https://github.com/objectify/objectify/wiki" >
       <libraryFile
           export="true"
-          javadocUri="https://www.javadoc.io/doc/com.googlecode.objectify/objectify/5.1.21">
+          javadocUri="https://www.javadoc.io/doc/com.googlecode.objectify/objectify/">
         <mavenCoordinates
               artifactId="objectify"
               groupId="com.googlecode.objectify" />

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -17,7 +17,8 @@
           export="false">
         <mavenCoordinates
               artifactId="appengine-api-1.0-sdk"
-              groupId="com.google.appengine" />
+              groupId="com.google.appengine"
+              version="LATEST" />
         <exclusionFilter pattern="com/google/appengine/repackaged/**" />
         <exclusionFilter pattern="com/google/appengine/labs/repackaged/**" />
         <inclusionFilter pattern="com/google/apphosting/api/**" />
@@ -35,7 +36,8 @@
             javadocUri="https://cloud.google.com/endpoints/docs/frameworks/java/javadoc/">
         <mavenCoordinates
               artifactId="endpoints-framework"
-              groupId="com.google.endpoints" />
+              groupId="com.google.endpoints"
+              version="LATEST" />
         <exclusionFilter pattern="com/google/appengine/repackaged/**" />
       </libraryFile>
     </library>
@@ -52,7 +54,8 @@
           javadocUri="https://www.javadoc.io/doc/com.googlecode.objectify/objectify/">
         <mavenCoordinates
               artifactId="objectify"
-              groupId="com.googlecode.objectify" />
+              groupId="com.googlecode.objectify"
+              version="LATEST" />
       </libraryFile>
     </library>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFactory.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.eclipse.appengine.libraries.model;
 import com.google.cloud.tools.eclipse.appengine.libraries.Messages;
 import com.google.cloud.tools.eclipse.util.ArtifactRetriever;
 import com.google.cloud.tools.eclipse.util.DependencyResolver;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -129,7 +130,8 @@ class LibraryFactory {
     return dependencies;
   }
 
-  private static LibraryFile loadSingleFile(IConfigurationElement libraryFileElement,
+  @VisibleForTesting
+  static LibraryFile loadSingleFile(IConfigurationElement libraryFileElement,
       MavenCoordinates mavenCoordinates) throws URISyntaxException {
     IConfigurationElement mavenCoordinatesElement = getMavenCoordinatesElement(libraryFileElement);
     String version = mavenCoordinatesElement.getAttribute(ATTRIBUTE_NAME_VERSION);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
@@ -38,15 +37,20 @@ public class LibraryFile implements Comparable<LibraryFile> {
   private URI javadocUri;
   private URI sourceUri;
   private boolean export = true;
-  
-  /** Version has been checked against Maven Central **/
+
+  /** Version can no longer be updated **/
   // todo could mark this transient and on deserialization set depending on whether
   // version is still LATEST_VERSION or not
   private boolean fixedVersion = false;
 
   public LibraryFile(MavenCoordinates mavenCoordinates) {
+    this(mavenCoordinates, false /* fixedVersion */);
+  }
+
+  public LibraryFile(MavenCoordinates mavenCoordinates, boolean fixedVersion) {
     Preconditions.checkNotNull(mavenCoordinates, "mavenCoordinates is null");
     this.mavenCoordinates = mavenCoordinates;
+    this.fixedVersion = fixedVersion;
   }
 
   public MavenCoordinates getMavenCoordinates() {
@@ -95,7 +99,7 @@ public class LibraryFile implements Comparable<LibraryFile> {
 
   @Override
   public int compareTo(LibraryFile other) {
-    return this.mavenCoordinates.toStringCoordinates()
+    return mavenCoordinates.toStringCoordinates()
         .compareTo(other.mavenCoordinates.toStringCoordinates());
   }
 
@@ -104,13 +108,13 @@ public class LibraryFile implements Comparable<LibraryFile> {
     if (other == null || !(other instanceof LibraryFile)) {
       return false;
     }
-    return this.mavenCoordinates.toStringCoordinates()
+    return mavenCoordinates.toStringCoordinates()
         .equals((((LibraryFile) other).mavenCoordinates.toStringCoordinates()));
   }
   
   @Override
   public int hashCode() {
-    return this.mavenCoordinates.toStringCoordinates().hashCode();
+    return mavenCoordinates.toStringCoordinates().hashCode();
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/LibraryFile.java
@@ -136,4 +136,8 @@ public class LibraryFile implements Comparable<LibraryFile> {
     }
   }
 
+  @VisibleForTesting
+  boolean isVersionFixed() {
+    return fixedVersion;
+  }
 }


### PR DESCRIPTION
Fixes #2691.

However, let's first discuss if this PR makes sense. What this PR does:

1. If versions are explicitly stated in `plugin.xml` such as `servlet-api-2.5` or `jsp-api-2.1`, it locks down the versions forever. It makes sense particularly for the aforementioned Servlet and JSP examples.
1. Since we don't really want to lock down versions of `appengine-api-1.0-sdk`, `appengine-endpoints`, and `objectify`, this PR specifies `LATEST` for their versions. Do we have a reason to use fixed versions? Given that these libraries can all be updated at the current state, I assume not. Otherwise, we would need a redesign of the library framework.