### PR TITLE
Fix Kokoro builds to use Java 8

### DIFF
--- a/kokoro/ubuntu/continuous.sh
+++ b/kokoro/ubuntu/continuous.sh
@@ -19,4 +19,4 @@ metacity --sm-disable --replace &
 sleep 3 
 
 cd github/google-cloud-eclipse
-mvn -Ptravis --fail-at-end verify
+mvn -V -Ptravis --fail-at-end verify

--- a/kokoro/windows/continuous.bat
+++ b/kokoro/windows/continuous.bat
@@ -1,4 +1,6 @@
 @echo on
+rem Tycho 1.0.0 does not support Java 9
+set JAVA_HOME="C:\Program Files\Java\jdk1.8.0_152"
 
 rem To speed up build, download and unpack an M2 repo cache.
 pushd %USERPROFILE%

--- a/kokoro/windows/continuous.bat
+++ b/kokoro/windows/continuous.bat
@@ -1,6 +1,6 @@
 @echo on
 rem Tycho 1.0.0 does not support Java 9
-set JAVA_HOME="C:\Program Files\Java\jdk1.8.0_152"
+set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0_152"
 
 rem To speed up build, download and unpack an M2 repo cache.
 pushd %USERPROFILE%

--- a/kokoro/windows/continuous.bat
+++ b/kokoro/windows/continuous.bat
@@ -27,9 +27,9 @@ call gcloud.cmd components update --quiet
 call gcloud.cmd components install app-engine-java --quiet
 @echo on
 
-mvn -B --settings kokoro\windows\m2-settings.xml ^
+mvn -V -B --settings kokoro\windows\m2-settings.xml ^
     -N io.takari:maven:wrapper -Dmaven=3.5.0
-mvnw.cmd -B --settings kokoro\windows\m2-settings.xml ^
+mvnw.cmd -V -B --settings kokoro\windows\m2-settings.xml ^
          --fail-at-end -Ptravis -Declipse.target=oxygen verify
 
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
Fix #2704 by ensuring builds on Kokoro use Java 8.  Kokoro's JDK/JRE installations are in `C:\Program Files\Java`:
```
T:\src\github\google-cloud-eclipse>dir "C:\Program Files\Java" 
 Volume in drive C has no label.
 Volume Serial Number is 22E5-2A46

 Directory of C:\Program Files\Java

01/04/2018  12:43 PM    <DIR>          .
01/04/2018  12:43 PM    <DIR>          ..
01/04/2018  12:33 PM    <DIR>          jdk-9.0.1
03/30/2015  05:11 PM    <DIR>          jdk1.7.0_75
04/25/2017  01:22 PM    <DIR>          jdk1.8.0_131
07/28/2017  08:56 AM    <DIR>          jdk1.8.0_144
01/04/2018  12:38 PM    <DIR>          jdk1.8.0_152
01/04/2018  12:33 PM    <DIR>          jre-9.0.1
07/28/2017  08:56 AM    <DIR>          jre1.8.0_144
01/04/2018  12:38 PM    <DIR>          jre1.8.0_152
               0 File(s)              0 bytes
              10 Dir(s)  50,136,481,792 bytes free
```

  