### PR TITLE
Wait until no build error

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
@@ -66,7 +66,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
     updateOldContainers();
 
     ProjectUtils.waitForProjects(project);
-    ProjectUtils.waitUntilNoBuildError(project);
+    ProjectUtils.waitUntilNoBuildErrors(project);
 
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     assertNotNull("should be a faceted project", facetedProject);
@@ -94,7 +94,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
     updateOldContainers();
 
     ProjectUtils.waitForProjects(project);
-    ProjectUtils.waitUntilNoBuildError(project);
+    ProjectUtils.waitUntilNoBuildErrors(project);
 
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     assertNotNull("should be a faceted project", facetedProject);

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ImportNativeAppEngineStandardProjectTest.java
@@ -66,8 +66,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
     updateOldContainers();
 
     ProjectUtils.waitForProjects(project);
-    ProjectUtils.failIfBuildErrors("Imported App Engine standard Java 7 project has errors",
-        project);
+    ProjectUtils.waitUntilNoBuildError(project);
 
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     assertNotNull("should be a faceted project", facetedProject);
@@ -95,8 +94,7 @@ public class ImportNativeAppEngineStandardProjectTest extends BaseProjectTest {
     updateOldContainers();
 
     ProjectUtils.waitForProjects(project);
-    ProjectUtils.failIfBuildErrors("Imported App Engine standard Java 8 project has errors",
-        project);
+    ProjectUtils.waitUntilNoBuildError(project);
 
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     assertNotNull("should be a faceted project", facetedProject);

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -142,7 +142,7 @@ public class ProjectUtils {
     // wait for any post-import operations too
     waitForProjects(projects);
     if (checkBuildErrors) {
-      waitUntilNoBuildError();
+      waitUntilNoBuildErrors();
       // changed from specific projects to see all possible errors
       failIfBuildErrors("Imported projects have errors");
     }
@@ -150,12 +150,12 @@ public class ProjectUtils {
     return projects;
   }
 
-  public static void waitUntilNoBuildError() throws CoreException {
+  public static void waitUntilNoBuildErrors() throws CoreException {
     IProject[] projects = getWorkspace().getRoot().getProjects();
-    waitUntilNoBuildError(projects);
+    waitUntilNoBuildErrors(projects);
   }
 
-  public static void waitUntilNoBuildError(IProject... projects) throws CoreException {
+  public static void waitUntilNoBuildErrors(IProject... projects) throws CoreException {
     try {
       Stopwatch elapsed = Stopwatch.createStarted();
       while (true) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -150,11 +150,16 @@ public class ProjectUtils {
     return projects;
   }
 
-  private static void waitUntilNoBuildError() throws CoreException {
+  public static void waitUntilNoBuildError() throws CoreException {
+    IProject[] projects = getWorkspace().getRoot().getProjects();
+    waitUntilNoBuildError(projects);
+  }
+
+  public static void waitUntilNoBuildError(IProject... projects) throws CoreException {
     try {
       Stopwatch elapsed = Stopwatch.createStarted();
       while (true) {
-        Set<String> errors = getAllBuildErrors();
+        Set<String> errors = getAllBuildErrors(projects);
         if (errors.isEmpty() || elapsed.elapsed(TimeUnit.SECONDS) > 300) {
           return;
         }


### PR DESCRIPTION
Fixes #2714.

There was another bug that I did not pass any project to `getAllBuildErrors()`.