### PR TITLE
Add .appengine.localserver dependency to prevent spurious NPEs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy
+Comment: .appengine.localserver required for WTP server runtime definitions
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
  com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy
-Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
+Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
+ com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.ui.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy.ui
+Comment: .appengine.localserver required for WTP server runtime definitions
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
  com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.swtbot,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.ui.test/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.deploy.ui.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.deploy.ui
-Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
+Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
+ com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.swtbot,
  com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.facets.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.facets
+Comment: .appengine.localserver required for WTP server runtime definitions
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
- org.eclipse.wst.common.project.facet.core,
  com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.libraries.ui.test;
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.libraries.ui
+Comment: .appengine.localserver required for WTP server runtime definitions
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
  com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.appengine.libraries.ui,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.libraries.ui.test;
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.libraries.ui
-Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
+Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
+ com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.appengine.libraries.ui,
  com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.validation.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.validation
+Comment: .appengine.localserver required for WTP server runtime definitions
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
  com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.test.util,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.appengine.validation.test
 Bundle-Vendor: Google Inc.
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: com.google.cloud.tools.eclipse.appengine.validation
-Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
+Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies,
+ com.google.cloud.tools.eclipse.appengine.localserver
 Import-Package: com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.project,
  com.google.cloud.tools.eclipse.ui.util,


### PR DESCRIPTION
Adds `com.google.cloud.tools.eclipse.appengine.localserver` as a bundle dependency to several of our test projects to ensure the App Engine Standard Runtime runtime and server definitions are found. This change avoids the spurious _ java.lang.NullPointerException: Could not find App Engine Standard runtime type_ errors in the build logs.

Fixes #2715