### PR TITLE
Use a Job in LaunchHelper to call IServer#start() asynchronously

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelperTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelperTest.java
@@ -65,8 +65,7 @@ public class LaunchHelperTest {
   public void setUp() {
     handler = new LaunchHelper() {
       @Override
-      protected void launch(IServer server, String launchMode, SubMonitor progress)
-          throws CoreException {
+      protected void launch(IServer server, String launchMode, SubMonitor progress) {
         // do nothing
       }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -35,7 +35,11 @@ import java.util.logging.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -130,8 +134,7 @@ public class LaunchHelper {
     return serverWorkingCopy.save(false, progress.newChild(2));
   }
 
-  protected void launch(IServer server, String launchMode, SubMonitor progress)
-      throws CoreException {
+  protected void launch(final IServer server, final String launchMode, SubMonitor progress) {
     // Explicitly offer to save dirty editors to avoid the puzzling prompt-to-save in
     // IServer#start() that prompts the user *as the server continues to launch*.
     // ServerUIPlugin.saveEditors() respects the "Save editors before starting the server"
@@ -139,7 +142,21 @@ public class LaunchHelper {
     if (!ServerUIPlugin.saveEditors()) {
       return;
     }
-    server.start(launchMode, progress);
+
+    // Launch in a Job. IServer#start()'s javadoc is incorrect: the server is not launched
+    // asynchronously but instead respects the serverType's `synchronousStart` setting.
+    Job launchJob = new Job(Messages.getString("STARTING_SERVER", server.getName())) { //$NON-NLS-1$
+      @Override
+      protected IStatus run(IProgressMonitor monitor) {
+        try {
+          server.start(launchMode, monitor);
+          return Status.OK_STATUS;
+        } catch (CoreException ex) {
+          return ex.getStatus();
+        }
+      }
+    };
+    launchJob.schedule();
   }
 
   /** Identify the relevant modules from the selection. */
@@ -181,7 +198,7 @@ public class LaunchHelper {
         return module;
       }
     }
-    logger.warning("Unable to map to a module: " + object);
+    logger.warning("Unable to map to a module: " + object); //$NON-NLS-1$
     throw new CoreException(
         StatusUtil.error(this, Messages.getString("CANNOT_DETERMINE_EXECUTION_CONTEXT"))); //$NON-NLS-1$
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
@@ -22,6 +22,7 @@ SERVER_ALREADY_RUNNING_IN_MODE=Server is already running in "{0}" mode
 UNABLE_TO_LAUNCH=Unable to launch App Engine server
 STALE_RESOURCES_DETECTED=Stale resources detected
 STALE_RESOURCES_LAUNCH_CONFIRMATION=Some recently changed resources are not yet published.  Continue with launch?
+STARTING_SERVER=Starting {0}
 
 target.terminated=<terminated>{0}
 cloudsdk.server.description=Google Cloud SDK Dev App Server


### PR DESCRIPTION
Fixes #2727 by causing `LaunchHelper`, which normally runs in the UI thread, to start the `IServer` instance in a background thread using a `Job`.  The Job is named _Launching {server}_, so that it appears in the progress area; I use "Launching" rather than "Starting" as WTP already creates a "Starting" job internally.

<img width="771" alt="screen shot 2018-01-16 at 10 17 36 am" src="https://user-images.githubusercontent.com/202851/34996083-820bda44-faa6-11e7-8730-9981f222d6a6.PNG">


Problems are reported normally: the use of several jobs has no effect.

<img width="773" alt="screen shot 2018-01-16 at 10 17 01 am" src="https://user-images.githubusercontent.com/202851/34996062-6ac8ab14-faa6-11e7-8cae-7483239652b5.PNG">

