### PR TITLE
Mark the App Engine local server for asynchronous start

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelperTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelperTest.java
@@ -65,7 +65,8 @@ public class LaunchHelperTest {
   public void setUp() {
     handler = new LaunchHelper() {
       @Override
-      protected void launch(IServer server, String launchMode, SubMonitor progress) {
+      protected void launch(IServer server, String launchMode, SubMonitor progress)
+          throws CoreException {
         // do nothing
       }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/plugin.xml
@@ -44,8 +44,7 @@
             runtime="true"
             runtimeTypeId="com.google.cloud.tools.eclipse.appengine.standard.runtime"
             startBeforePublish="false"
-            supportsRemoteHosts="true"
-            synchronousStart="true">
+            supportsRemoteHosts="true">
       </serverType>
    </extension>
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -130,6 +130,7 @@ public class LaunchHelper {
     return serverWorkingCopy.save(false, progress.newChild(2));
   }
 
+  @VisibleForTesting
   protected void launch(IServer server, String launchMode, SubMonitor progress)
       throws CoreException {
     // Explicitly offer to save dirty editors to avoid the puzzling prompt-to-save in

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/launching/LaunchHelper.java
@@ -35,11 +35,7 @@ import java.util.logging.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -134,7 +130,8 @@ public class LaunchHelper {
     return serverWorkingCopy.save(false, progress.newChild(2));
   }
 
-  protected void launch(final IServer server, final String launchMode, SubMonitor progress) {
+  protected void launch(IServer server, String launchMode, SubMonitor progress)
+      throws CoreException {
     // Explicitly offer to save dirty editors to avoid the puzzling prompt-to-save in
     // IServer#start() that prompts the user *as the server continues to launch*.
     // ServerUIPlugin.saveEditors() respects the "Save editors before starting the server"
@@ -142,21 +139,7 @@ public class LaunchHelper {
     if (!ServerUIPlugin.saveEditors()) {
       return;
     }
-
-    // Launch in a Job. IServer#start()'s javadoc is incorrect: the server is not launched
-    // asynchronously but instead respects the serverType's `synchronousStart` setting.
-    Job launchJob = new Job(Messages.getString("LAUNCHING_SERVER", server.getName())) { //$NON-NLS-1$
-      @Override
-      protected IStatus run(IProgressMonitor monitor) {
-        try {
-          server.start(launchMode, monitor);
-          return Status.OK_STATUS;
-        } catch (CoreException ex) {
-          return ex.getStatus();
-        }
-      }
-    };
-    launchJob.schedule();
+    server.start(launchMode, progress);
   }
 
   /** Identify the relevant modules from the selection. */
@@ -198,7 +181,7 @@ public class LaunchHelper {
         return module;
       }
     }
-    logger.warning("Unable to map to a module: " + object); //$NON-NLS-1$
+    logger.warning("Unable to map to a module: " + object);
     throw new CoreException(
         StatusUtil.error(this, Messages.getString("CANNOT_DETERMINE_EXECUTION_CONTEXT"))); //$NON-NLS-1$
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/messages.properties
@@ -22,7 +22,6 @@ SERVER_ALREADY_RUNNING_IN_MODE=Server is already running in "{0}" mode
 UNABLE_TO_LAUNCH=Unable to launch App Engine server
 STALE_RESOURCES_DETECTED=Stale resources detected
 STALE_RESOURCES_LAUNCH_CONFIRMATION=Some recently changed resources are not yet published.  Continue with launch?
-LAUNCHING_SERVER=Launching {0}
 
 target.terminated=<terminated>{0}
 cloudsdk.server.description=Google Cloud SDK Dev App Server

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -41,6 +41,7 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
@@ -106,8 +107,11 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     SWTBotTree launchTree =
         new SWTBotTree(bot.widget(widgetOfType(Tree.class), debugView.getWidget()));
 
-    // avoid any stray processes that may be lying around
-    launchTree.contextMenu("Remove All Terminated").click();
+    // clean up any stray processes that may be lying around
+    SWTBotMenu launchMenu = launchTree.contextMenu("Remove All Terminated");
+    if (launchMenu.isEnabled()) {
+      launchMenu.click();
+    }
 
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, launchTree);
     SWTBotTreeItem[] allItems = launchTree.getAllItems();


### PR DESCRIPTION
As discovered in #2728, `synchronousStart` is not actually required for serializing the server publish and start steps.  This reverts the fix in #2728 and removes the `synchronousStart` attribute.

Fixes #2727 