### PR TITLE
Close projects before deleting them

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/META-INF/MANIFEST.MF
@@ -42,3 +42,4 @@ Import-Package: com.google.cloud.tools.appengine.cloudsdk;version="0.4.2",
  org.eclipse.osgi.util,
  org.osgi.framework;version="1.8.0",
  org.osgi.service.component.annotations;resolution:=optional
+Bundle-Activator: com.google.cloud.tools.eclipse.appengine.libraries.Activator

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/META-INF/MANIFEST.MF
@@ -42,4 +42,3 @@ Import-Package: com.google.cloud.tools.appengine.cloudsdk;version="0.4.2",
  org.eclipse.osgi.util,
  org.osgi.framework;version="1.8.0",
  org.osgi.service.component.annotations;resolution:=optional
-Bundle-Activator: com.google.cloud.tools.eclipse.appengine.libraries.Activator

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -60,12 +60,10 @@ public class BaseProjectTest {
     if (project != null) {
       // close editors, so no property changes are dispatched on delete
       bot.closeAllEditors();
-      if (project.isOpen()) {
-        try {
-          project.close(new NullProgressMonitor());
-        } catch (CoreException ex) {
-          logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
-        }
+      try {
+        project.close(new NullProgressMonitor());
+      } catch (CoreException ex) {
+        logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
       }
 
       // ensure there are no jobs

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -23,6 +23,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
@@ -58,6 +60,13 @@ public class BaseProjectTest {
     if (project != null) {
       // close editors, so no property changes are dispatched on delete
       bot.closeAllEditors();
+      if (project.isOpen()) {
+        try {
+          project.close(new NullProgressMonitor());
+        } catch (CoreException ex) {
+          logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
+        }
+      }
 
       // ensure there are no jobs
       SwtBotWorkbenchActions.waitForProjects(bot, project);

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -60,14 +60,14 @@ public class BaseProjectTest {
     if (project != null) {
       // close editors, so no property changes are dispatched on delete
       bot.closeAllEditors();
+      // ensure there are no jobs
+      SwtBotWorkbenchActions.waitForProjects(bot, project);
+
       try {
         project.close(new NullProgressMonitor());
       } catch (CoreException ex) {
         logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
       }
-
-      // ensure there are no jobs
-      SwtBotWorkbenchActions.waitForProjects(bot, project);
       try {
         SwtBotProjectActions.deleteProject(bot, project.getName());
       } catch (TimeoutException ex) {

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -93,12 +93,10 @@ public final class TestProjectCreator extends ExternalResource {
   protected void after() {
     if (project != null) {
       try {
-        if (project.isOpen()) {
-          try {
-            project.close(new NullProgressMonitor());
-          } catch (CoreException ex) {
-            logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
-          }
+        try {
+          project.close(new NullProgressMonitor());
+        } catch (CoreException ex) {
+          logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
         }
         if (getFacetedProject().hasProjectFacet(WebFacetUtils.WEB_FACET)) {
           // Wait for the WTP validation job as it runs without the workspace protection lock

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -32,11 +32,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -58,6 +61,7 @@ import org.junit.rules.ExternalResource;
  */
 @SuppressWarnings("restriction") // For FacetedProjectNature
 public final class TestProjectCreator extends ExternalResource {
+  private static final Logger logger = Logger.getLogger(TestProjectCreator.class.getName());
 
   private IProject project;
   private IJavaProject javaProject;
@@ -89,6 +93,13 @@ public final class TestProjectCreator extends ExternalResource {
   protected void after() {
     if (project != null) {
       try {
+        if (project.isOpen()) {
+          try {
+            project.close(new NullProgressMonitor());
+          } catch (CoreException ex) {
+            logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
+          }
+        }
         if (getFacetedProject().hasProjectFacet(WebFacetUtils.WEB_FACET)) {
           // Wait for the WTP validation job as it runs without the workspace protection lock
           ProjectUtils.waitForProjects(project);

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -93,14 +93,14 @@ public final class TestProjectCreator extends ExternalResource {
   protected void after() {
     if (project != null) {
       try {
+        if (getFacetedProject().hasProjectFacet(WebFacetUtils.WEB_FACET)) {
+          // Wait for the WTP validation job as it runs without the workspace protection lock
+          ProjectUtils.waitForProjects(project);
+        }
         try {
           project.close(new NullProgressMonitor());
         } catch (CoreException ex) {
           logger.log(Level.SEVERE, "Exception closing test project: " + project, ex);
-        }
-        if (getFacetedProject().hasProjectFacet(WebFacetUtils.WEB_FACET)) {
-          // Wait for the WTP validation job as it runs without the workspace protection lock
-          ProjectUtils.waitForProjects(project);
         }
         project.delete(true, null);
       } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Hoping this will avoid occasional preference-loading exception bursts triggered by deleting a project.  For example:

```
!ENTRY org.eclipse.core.resources 4 4 2018-01-16 17:42:57.624
!MESSAGE Exception loading preferences from: /appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs.
!STACK 1
org.eclipse.core.runtime.CoreException: File not found: /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.integration.appengine/target/work/data/appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs.
	at org.eclipse.core.internal.filesystem.Policy.error(Policy.java:45)
	at org.eclipse.core.internal.filesystem.local.LocalFile.openInputStream(LocalFile.java:406)
	at org.eclipse.core.internal.localstore.FileSystemResourceManager.read(FileSystemResourceManager.java:849)
	at org.eclipse.core.internal.resources.File.getContents(File.java:277)
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:507ava:499)
	at org.eclipse.jdt.internal.core.JavaProject.buildStructure(JavaProject.java:482)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:259)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:583)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:320)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:306)
	at org.eclipse.jdt.internal.core.JavaElement.getChildren(JavaElement.java:261)
	at org.eclipse.jdt.internal.core.JavaProject.getPackageFragmentRoots(JavaProject.java:2143)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getPackageFragmentRoots(PackageExplorerContentProvider.java:308)
	at org.eclipse.jdt.ui.StandardJavaElementContentProvider.getChildren(StandardJavaElementContentProvider.java:180)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getChildren(PackageExplorerContentProvider.java:295)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getChildren(JavaNavigatorContentProvider.java:178)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getPipelinedChildren(JavaNavigatorContentProvider.java:202)
	at org.eclipse.ui.internal.navigator.extensions.SafeDelegateTreeContentProvider.getPipelinedChildren(SafeDelegateTreeContentProvider.java:172)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.pipelineChildren(NavigatorContentServiceContentProvider.java:210)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.access$1(NavigatorContentServiceContentProvider.java:198)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider$1.run(NavigatorContentServiceContentProvider.java:166)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.internalGetChildren(NavigatorContentServiceContentProvider.java:143)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.getChildren(NavigatorContentServiceContentProvider.java:122)
	at org.eclipse.jst.jee.ui.internal.navigator.JEE5ContentProvider$1.run(JEE5ContentProvider.java:142)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:165)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:369)
	at org.eclipse.ltk.internal.ui.refactoring.RefactoringWizardDialog2.run(RefactoringWizardDialog2.java:321)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.internalPerformFinish(RefactoringWizard.java:636)
	at org.eclipse.ltk.ui.refactoring.UserInputWizardPage.performFinish(UserInputWizardPage.java:145)
	at org.eclipse.ltk.ui.refactoring.resource.DeleteResourcesWizard$DeleteResourcesRefactoringConfigurationPage.performFinish(DeleteResourcesWizard.java:202)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.performFinish(RefactoringWizard.java:710)
	at org.eclipse.ltk.internayIndicator.java:70)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:203)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:122)
	at org.eclipse.ltk.internal.ui.refactoring.actions.DeleteResourcesHandler.execute(DeleteResourcesHandler.java:41)
	at org.eclipse.ui.internal.handlers.HandlerProxy.execute(HandlerProxy.java:291)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:92)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:55)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:239)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:132)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:152)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:494)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:487)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:210)
	at org.eclipse.ui.internal.handlers.LegacyHandlerService.executeCommandInContext(LegacyHandlerService.java:442)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.runCommand(LTKLauncher.java:96)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.openDeleteWizard(LTKLauncher.java:48)
	at org.eclipse.ui.actions.DeleteResourceAction.run(DeleteResourceAction.java:449)
	at org.eclipse.jdt.internal.ui.refactoring.reorg.DeleteAction.run(DeleteAction.java:194)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.dispatchRun(SelectionDispatchAction.java:271)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.run(SelectionDispatchAction.java:249)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:473)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:565)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:397)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1374)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1357)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot$2.run(AbstractSWTBot.java:174)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.run(UIThreadRunnable.java:76)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.asyncExec(UIThreadRunnable.java:224)
	at org.eclipse.swtbot.swt.finder.widgets.A
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1499)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1472)
Caused by: java.io.FileNotFoundException: /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.integration.appengine/target/work/data/appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at org.eclipse.core.internal.filesystem.local.LocalFile.openInputStream(LocalFile.java:401)
	... 147 more
!SUBENTRY 1 org.eclipse.core.filesystem 4 269 2018-01-16 17:42:57.637
!MESSAGE File not found: /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.integration.appengine/target/work/data/appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs.
!STACK 0
java.io.FileNotFoundException: /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.integration.appengine/target/work/data/appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at org.eclipse.core.internal.filesystem.local.LocalFile.openInputStream(LocalFile.java:401)
	at org.eclipse.core.internal.localstore.FileSystemResourceManager.read(FileSystemResourceManager.java:849)
	at org.eclipse.core.internal.resources.File.getContents(File.java:277)
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:507)
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:492)
	at org.eclipse.core.internal.preferences.EclipsePreferences.create(EclipsePreferences.java:370)
	at org.eclipse.core.internal.preferences.EclipsePreferences.internalNode(EclipsePreferences.java:623)
	at org.eclipse.core.internal.preferences.EclipsePreferences.node(EclipsePreferences.java:766)
	at org.eclipse.core.resources.ProjectScope.getNode(ProjectScope.java:69)
	at org.eclipse.jdt.internal.core.JavaProject.getEclipsePreferences(JavaProject.java:1762)
	at org.eclipse.jdt.internal.core.JavaProject.getOption(JavaProject.java:1941)
	at org.eclipse.jdt.internal.core.PackageFragment.internalIsValidPackageName(PackageFragment.java:453)
	at org.eclipse.jdt.internal.core.PackageFragment.<init>(PackageFragment.java:70)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.getPackageFragment(PackageFragmentRoot.java:531)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.computeFolderChildren(PackageFragmentRoot.java:229)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.computeChildren(PackageFragmentRoot.java:201)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.buildStructure(PackageFragmentRoot.java:158)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:259)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:583)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:320)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:306)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.getKind(PackageFragmentRoot.java:499)
	at org.eclipse.jdt.internal.core.JavaProject.buildStructure(JavaProject.java:482)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:259)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:583)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:320)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:306)
	at org.eclipse.jdt.internal.core.JavaElement.getChildren(JavaElement.java:261)
	at org.eclipse.jdt.internal.core.JavaProject.getPackageFragmentRoots(JavaProject.java:2143)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getPackageFragmentRoots(PackageExplorerContentProvider.java:308)
	at org.eclipse.jdt.ui.StandardJavaElementContentProvider.getChildren(StandardJavaElementContentProvider.java:180)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getChildren(PackageExplorerContentProvider.java:295)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getChildren(JavaNavigatorContentProvider.java:178)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getPipelinedChildren(JavaNavigatorContentProvider.java:202)
	at org.eclipse.ui.internal.navigator.extensions.SafeDelegateTreeContentProvider.getPipelinedChildren(SafeDelegateTreeContentProvider.java:172)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.pipelineChildren(NavigatorContentServiceContentProvider.java:210)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.access$1(NavigatorContentServiceContentProvider.java:198)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider$1.run(NavigatorContentServiceContentProvider.java:166)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.internalGetChildren(NavigatorContentServiceContentProvider. org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$1.run(UIThreadRunnable.java:88)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:818)
	at org.eclipse.jface.window.Window.open(Window.java:794)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation$1.run(RefactoringWizardOpenOperation.java:188)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:203)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:122)
	at org.eclipse.ltk.internal.ui.refactoring.actions.DeleteResourcesHandler.execute(DeleteResourcesHandler.java:41)
	at org.eclipse.ui.internal.handlers.HandlerProxy.execute(HandlerProxy.java:291)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:92)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:55)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:239)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:132)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:152)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:494)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:487)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:210)
	at org.eclipse.ui.internal.handlers.LegacyHandlerService.executeCommandInContext(LegacyHandlerService.java:442)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.runCommand(LTKLauncher.java:96)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.openDeleteWizard(LTKLauncher.java:48)
	at org.eclipse.ui.actions.DeleteResourceAction.run(DeleteResourceAction.java:449)
	at org.eclipse.jdt.internal.ui.refactoring.reorg.DeleteAction.run(DeleteAction.java:194)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.dispatchRun(SelectionDispatchAction.java:271)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.run(SelectionDispatchAction.java:249)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:473)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:565)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:397)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1374)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1357)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot$2.run(AbstractSWTBot.java:174)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.run(UIThreadRunnable.java:76)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.asyncExec(UIThreadRunnable.java:224)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.asyncExec(AbstractSWTBot.java:640)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:162)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:132)
	at org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu$1.run(SWTBotMenu.java:88)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$1.run(UIThreadRunnable.java:88)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1039)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:680)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:594)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:151)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1499)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1472)
!ENTRY org.eclipse.equinox.preferences 4 4 2018-01-16 17:42:57.639
!MESSAGE Exception loading preferences from: /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.integration.appengine/target/work/data/appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs.
!STACK 0
org.osgi.service.prefs.BackingStoreException: Exception loading preferences from: /appWithPackage_java8/.settings/org.eclipse.jdt.core.prefs.
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:515)
	at org.eclipse.core.internal.resources.ProjectPreferences.load(ProjectPreferences.java:492)
	at org.eclipse.core.internal.preferences.EclipsePreferences.create(EclipsePreferences.java:370)
	at org.eclipse.core.internal.preferences.EclipsePreferences.internalNode(EclipsePreferences.java:623)
	at org.eclipse.core.internal.preferences.EclipsePreferences.node(EclipsePreferences.java:766)
	at org.eclipse.core.resources.ProjectScope.getNode(ProjectScope.java:69)
	at org.eclipse.jdt.internal.core.JavaProject.getEclipsePreferences(JavaProject.java:1762)
	at org.eclipse.jdt.internal.core.JavaProject.getOption(JavaProject.java:1941)
	at org.eclipse.jdt.ntProvider.getPackageFragmentRoots(PackageExplorerContentProvider.java:308)
	at org.eclipse.jdt.ui.StandardJavaElementContentProvider.getChildren(StandardJavaElementContentProvider.java:180)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getChildren(PackageExplorerContentProvider.java:295)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getChildren(JavaNavigatorContentProvider.java:178)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getPipelinedChildren(JavaNavigatorContentProvider.java:202)
	at org.eclipse.ui.internal.navigator.extensions.SafeDelegateTreeContentProvider.getPipelinedChildren(SafeDelegateTreeContentProvider.java:172)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.pipelineChildren(NavigatorContentServiceContentProvider.java:210)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.access$1(NavigatorContentServiceContentProvider.java:198)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider$1.run(NavigatorContentServiceContentProvider.java:166)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.internalGetChildren(NavigatorContentServiceContentProvider.java:143)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.getChildren(NavigatorContentServiceContentProvider.java:122)
	at org.eclipse.jst.jee.ui.internal.navigator.JEE5ContentProvider$1.run(JEE5ContentProvider.java:142)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:165)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:369)
	at org.eclipse.ltk.internal.ui.refactoring.RefactoringWizardDialog2.run(RefactoringWizardDialog2.java:321)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.internalPerformFinish(RefactoringWizard.java:636)
	at org.eclipse.ltk.ui.refactoring.UserInputWizardPage.performFinish(UserInputWizardPage.java:145)
	at org.eclipse.ltk.ui.refactoring.resource.DeleteResourcesWizard$DeleteResourcesRefactoringConfigurationPage.performFinish(DeleteResourcesWizard.java:202)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.performFinish(RefactoringWizard.java:710)
	at org.eclipse.ltk.internal.ui.refactoring.RefactoringWizardDialog2.okPressed(RefactoringWizardDialog2.java:447)
	at org.eclipse.jface.dialogs.Dialog.buttonPressed(Dialog.java:466)
	at org.eclipse.jface.dialogs.Dialog.lambda$0(Dialog.java:619)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:81)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:249)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1374)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1357)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot$2.run(AbstractSWTBot.java:174)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$1.run(UIThreadRunnable.java:88)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:818)
	at org.eclipse.jface.window.Window.open(Window.java:794)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation$1.run(RefactoringWizardOpenOperation.java:188)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:203)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:122)
	at org.eclipse.ltk.internal.ui.refactoring.actions.DeleteResourcesHandler.execute(DeleteResourcesHandler.java:41)
	at org.eclipse.ui.internal.handlers.HandlerProxy.execute(HandlerProxy.java:291)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:92)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:55)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:239)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:132)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:152)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:494)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:487)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:210)
	at org.eclipse.ui.internal.handlers.LegacyHandlerService.executeCommandInContext(LegacyHandlerService.java:442)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.runCommand(LTKLauncher.java:96)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.openDeleteWizard(LTKLauncher.java:48)
	at org.eclipse.ui.actions.DeleteResourceAction.run(DeleteResourceAction.java:449)
	at org.eclipse.jdt.internal.ui.refactoring.reorg.DeleteAction.run(DeleteAction.java:194)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.dispatchRun(SelectionDispatchAction.java:271)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.run(SelectionDispatchAction.java:249)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:473)
	at org.eclipse.jface.ac.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1039)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:680)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:594)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:151)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(E)
	at org.eclipse.jdt.internal.core.PackageFragment.internalIsValidPackageName(PackageFragment.java:453)
	at org.eclipse.jdt.internal.core.PackageFragment.<init>(PackageFragment.java:70)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.getPackageFragment(PackageFragmentRoot.java:531)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.computeFolderChildren(PackageFragmentRoot.java:229)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.computeChildren(PackageFragmentRoot.java:201)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.buildStructure(PackageFragmentRoot.java:158)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:259)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:583)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:320)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:306)
	at org.eclipse.jdt.internal.core.PackageFragmentRoot.getKind(PackageFragmentRoot.java:499)
	at org.eclipse.jdt.internal.core.JavaProject.buildStructure(JavaProject.java:482)
	at org.eclipse.jdt.internal.core.Openable.generateInfos(Openable.java:259)
	at org.eclipse.jdt.internal.core.JavaElement.openWhenClosed(JavaElement.java:583)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:320)
	at org.eclipse.jdt.internal.core.JavaElement.getElementInfo(JavaElement.java:306)
	at org.eclipse.jdt.internal.core.JavaElement.getChildren(JavaElement.java:261)
	at org.eclipse.jdt.internal.core.JavaProject.getPackageFragmentRoots(JavaProject.java:2143)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getPackageFragmentRoots(PackageExplorerContentProvider.java:308)
	at org.eclipse.jdt.ui.StandardJavaElementContentProvider.getChildren(StandardJavaElementContentProvider.java:180)
	at org.eclipse.jdt.internal.ui.packageview.PackageExplorerContentProvider.getChildren(PackageExplorerContentProvider.java:295)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getChildren(JavaNavigatorContentProvider.java:178)
	at org.eclipse.jdt.internal.ui.navigator.JavaNavigatorContentProvider.getPipelinedChildren(JavaNavigatorContentProvider.java:202)
	at org.eclipse.ui.internal.navigator.extensions.SafeDelegateTreeContentProvider.getPipelinedChildren(SafeDelegateTreeContentProvider.java:172)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.pipelineChildren(NavigatorContentServiceContentProvider.java:210)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.access$1(NavigatorContentServiceContentProvider.java:198)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider$1.run(NavigatorContentServiceContentProvider.java:166)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.internalGetChildren(NavigatorContentServiceContentProvider.java:143)
	at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider.getChildren(NavigatorContentServiceContentProvider.java:122)
	at org.eclipse.jst.jee.ui.internal.navigator.JEE5ContentProvider$1.run(JEE5ContentProvider.java:142)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.operation.ModalContext$ModalContextThread.block(ModalContext.java:165)
	at org.eclipse.jface.operation.ModalContext.run(ModalContext.java:369)
	at org.eclipse.ltk.internal.ui.refactoring.RefactoringWizardDialog2.run(RefactoringWizardDialog2.java:321)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.internalPerformFinish(RefactoringWizard.java:636)
	at org.eclipse.ltk.ui.refactoring.UserInputWizardPage.performFinish(UserInputWizardPage.java:145)
	at org.eclipse.ltk.ui.refactoring.resource.DeleteResourcesWizard$DeleteResourcesRefactoringConfigurationPage.performFinish(DeleteResourcesWizard.java:202)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizard.performFinish(RefactoringWizard.java:710)
	at org.eclipse.ltk.internal.ui.refactoring.RefactoringWizardDialog2.okPressed(RefactoringWizardDialog2.java:447)
	at org.eclipse.jface.dialogs.Dialog.buttonPressed(Dialog.java:466)
	at org.eclipse.jface.dialogs.Dialog.lambda$0(Dialog.java:619)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:81)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:249)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1374)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1357)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot$2.run(AbstractSWTBot.java:174)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$1.run(UIThreadRunnable.java:88)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:818)
	at org.eclipse.jface.window.Window.open(Window.java:794)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation$1.run(RefactoringWizardOpenOperation.java:188)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:203)
	at org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation.run(RefactoringWizardOpenOperation.java:122)
	at org.eclipse.ltk.internal.ui.refactoring.actions.DeleteResourcesHandler.execute(DeleteResourcesHandler.java:41)
	at org.eclipse.ui.internal.handlers.HandlerProxy.execute(HandlerProxy.java:291)
	at org.eclipse.ui.internal.handlers.E4HandlerProxy.execute(E4HandlerProxy.java:92)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:55)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invokeUsingClass(InjectorImpl.java:305)
	at org.eclipse.e4.core.internal.di.InjectorImpl.invoke(InjectorImpl.java:239)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.invoke(ContextInjectionFactory.java:132)
	at org.eclipse.e4.core.commands.internal.HandlerServiceHandler.execute(HandlerServiceHandler.java:152)
	at org.eclipse.core.commands.Command.executeWithChecks(Command.java:494)
	at org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:487)
	at org.eclipse.e4.core.commands.internal.HandlerServiceImpl.executeHandler(HandlerServiceImpl.java:210)
	at org.eclipse.ui.internal.handlers.LegacyHandlerService.executeCommandInContext(LegacyHandlerService.java:442)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.runCommand(LTKLauncher.java:96)
	at org.eclipse.ui.internal.ide.actions.LTKLauncher.openDeleteWizard(LTKLauncher.java:48)
	at org.eclipse.ui.actions.DeleteResourceAction.run(DeleteResourceAction.java:449)
	at org.eclipse.jdt.internal.ui.refactoring.reorg.DeleteAction.run(DeleteAction.java:194)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.dispatchRun(SelectionDispatchAction.java:271)
	at org.eclipse.jdt.ui.actions.SelectionDispatchAction.run(SelectionDispatchAction.java:249)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:473)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:565)
	at org.eclipse.jface.action.ActionContributionItem.lambda$4(ActionContributionItem.java:397)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:86)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1348)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1374)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1357)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot$2.run(AbstractSWTBot.java:174)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.run(UIThreadRunnable.java:76)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable.asyncExec(UIThreadRunnable.java:224)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.asyncExec(AbstractSWTBot.java:640)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:162)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:142)
	at org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot.notify(AbstractSWTBot.java:132)
	at org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu$1.run(SWTBotMenu.java:88)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$5.doRun(UIThreadRunnable.java:222)
	at org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable$1.run(UIThreadRunnable.java:88)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:37)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4577)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4186)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1039)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:680)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:594)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:151)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
```