### PR TITLE
Bump endpoints-framework to 2.0.11

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -114,7 +114,7 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(mavenCoordinates.getRepository(), is("central"));
     assertThat(mavenCoordinates.getGroupId(), is("com.google.endpoints"));
     assertThat(mavenCoordinates.getArtifactId(), is("endpoints-framework"));
-    assertThat(mavenCoordinates.getVersion(), is("2.0.10"));
+    assertThat(mavenCoordinates.getVersion(), is("2.0.11"));
     assertThat(mavenCoordinates.getType(), is("jar"));
     assertNull(mavenCoordinates.getClassifier());
     assertThat(libraryFile.getJavadocUri(),

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -37,7 +37,7 @@
         <mavenCoordinates
               artifactId="endpoints-framework"
               groupId="com.google.endpoints" 
-              version="2.0.10"/>
+              version="2.0.11"/>
         <exclusionFilter pattern="com/google/appengine/repackaged/**" />
       </libraryFile>
     </library>


### PR DESCRIPTION
Tests failing:
```
testEndpointsLibraryConfig(com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibrariesInPluginXmlTest)  Time elapsed: 0.007 sec  <<< FAILURE!
java.lang.AssertionError: 
Expected: is "2.0.10"
     but: was "2.0.11"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibrariesInPluginXmlTest.testEndpointsLibraryConfig(CloudLibrariesInPluginXmlTest.java:117)
```