### PR TITLE
Configure tycho-surefire to set SWT_GTK3=0 for Mars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ env:
   matrix:
     # ECLIPSE_TARGET is the targeted platform: mars is the default target
     # JAVA_RUNTIME specifies the execution runtime for tests; must match an <id> in .travisci/toolchains.xml
-    # SWT_GTK3=0 to force GTK2 on Mars as its GTK3 support is buggy
-    - JAVA_RUNTIME=JavaSE-1.7 SWT_GTK3=0
+    - JAVA_RUNTIME=JavaSE-1.7
     - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=neon
     - JAVA_RUNTIME=JavaSE-1.8 ECLIPSE_TARGET=oxygen MAVEN_FLAGS=-Pjacoco
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
 
+    <!-- by default enable GTK3 support -->
+    <swt.gtk3>1</swt.gtk3>
+
     <!-- log surefire tests to stdout -->
     <tycho.showEclipseLog>true</tycho.showEclipseLog>
 
@@ -371,6 +374,9 @@
               - maven.artifact.threads=1 to workaround repository corruption seen in
                 https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2284
             -->
+            <environmentVariables>
+              <SWT_GTK3>${swt.gtk3}</SWT_GTK3>
+            </environmentVariables>
             <argLine>${jacoco.agentArgLine} -Dmaven.artifact.threads=1
               -Dorg.eclipse.swtbot.search.timeout=${org.eclipse.swtbot.search.timeout}
               -Xms40m -Xmx1G -XX:MaxPermSize=512m
@@ -433,6 +439,7 @@
         </property>
       </activation>
       <properties>
+         <swt.gtk3>0</swt.gtk3> <!-- disable GTK3 support for Mars -->
          <jettyMinVersion>9.1</jettyMinVersion>
          <jettyMaxVersion>9.3</jettyMaxVersion>
       </properties>


### PR DESCRIPTION
Instead of configuring Travis to set `SWT_GTK3=0` on Mars, configure _tycho-surefire_ on Maven to set `SWT_GTK3=0` when running Mars.  This should make `mvn verify` more robust for Linux and Mars.