### PR TITLE
Extend MessageConsoleWriter listener

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/util/CloudSdkProcessWrapper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/util/CloudSdkProcessWrapper.java
@@ -25,7 +25,7 @@ import com.google.cloud.tools.eclipse.appengine.deploy.AppEngineProjectDeployer;
 import com.google.cloud.tools.eclipse.appengine.deploy.Messages;
 import com.google.cloud.tools.eclipse.appengine.deploy.standard.StandardStagingDelegate;
 import com.google.cloud.tools.eclipse.sdk.GcloudStructuredLogErrorMessageCollector;
-import com.google.cloud.tools.eclipse.sdk.MessageConsoleWriterOutputLineListener;
+import com.google.cloud.tools.eclipse.sdk.MessageConsoleWriterListener;
 import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import com.google.common.annotations.VisibleForTesting;
@@ -93,7 +93,7 @@ public class CloudSdkProcessWrapper {
     Preconditions.checkState(cloudSdk == null, "CloudSdk already set up");
 
     CloudSdk.Builder cloudSdkBuilder = getBaseCloudSdkBuilder(stderrOutputStream)
-        .addStdOutLineListener(new MessageConsoleWriterOutputLineListener(stdoutOutputStream));
+        .addStdOutLineListener(new MessageConsoleWriterListener(stdoutOutputStream));
     if (javaHome != null) {
       cloudSdkBuilder.javaHome(javaHome);
     }
@@ -102,7 +102,7 @@ public class CloudSdkProcessWrapper {
 
   private CloudSdk.Builder getBaseCloudSdkBuilder(MessageConsoleStream stdErrStream) {
     return new CloudSdk.Builder()
-        .addStdErrLineListener(new MessageConsoleWriterOutputLineListener(stdErrStream))
+        .addStdErrLineListener(new MessageConsoleWriterListener(stdErrStream))
         .startListener(new StoreProcessObjectListener())
         .exitListener(new ProcessExitRecorder())
         .appCommandMetricsEnvironment(CloudToolsInfo.METRICS_NAME)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -33,7 +33,7 @@ import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.localserver.Activator;
 import com.google.cloud.tools.eclipse.appengine.localserver.Messages;
-import com.google.cloud.tools.eclipse.sdk.MessageConsoleWriterOutputLineListener;
+import com.google.cloud.tools.eclipse.sdk.MessageConsoleWriterListener;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -414,10 +414,8 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
 
   private void initializeDevServer(MessageConsoleStream stdout, MessageConsoleStream stderr,
       Path javaHomePath) {
-    MessageConsoleWriterOutputLineListener stdoutListener =
-        new MessageConsoleWriterOutputLineListener(stdout);
-    MessageConsoleWriterOutputLineListener stderrListener =
-        new MessageConsoleWriterOutputLineListener(stderr);
+    MessageConsoleWriterListener stdoutListener = new MessageConsoleWriterListener(stdout);
+    MessageConsoleWriterListener stderrListener = new MessageConsoleWriterListener(stderr);
 
     // dev_appserver output goes to stderr
     cloudSdk = new CloudSdk.Builder()

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/MessageConsoleWriterListenerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/MessageConsoleWriterListenerTest.java
@@ -25,19 +25,20 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class MessageConsoleWriterOutputLineListenerTest {
+public class MessageConsoleWriterListenerTest {
   @Mock private MessageConsoleStream mockConsoleStream;
 
-  /**
-   * Tests that {@link MessageConsoleWriterOutputLineListener#onOutputLine(String)} appends the specified
-   * message to the console stream.
-   */
   @Test
   public void testOnOutputLine() {
-    String message = "a message";
-    MessageConsoleWriterOutputLineListener listener = new MessageConsoleWriterOutputLineListener(mockConsoleStream);
-    listener.onOutputLine(message);
-    verify(mockConsoleStream).println(message);
+    MessageConsoleWriterListener listener = new MessageConsoleWriterListener(mockConsoleStream);
+    listener.onOutputLine("a message");
+    verify(mockConsoleStream).println("a message");
   }
 
+  @Test
+  public void testMessage() {
+    MessageConsoleWriterListener listener = new MessageConsoleWriterListener(mockConsoleStream);
+    listener.message("a message");
+    verify(mockConsoleStream).print("a message");
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/MessageConsoleWriterListener.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/MessageConsoleWriterListener.java
@@ -17,20 +17,31 @@
 package com.google.cloud.tools.eclipse.sdk;
 
 import com.google.cloud.tools.appengine.cloudsdk.process.ProcessOutputLineListener;
+import com.google.cloud.tools.managedcloudsdk.MessageListener;
 import org.eclipse.ui.console.MessageConsoleStream;
 
-public class MessageConsoleWriterOutputLineListener implements ProcessOutputLineListener {
-  private MessageConsoleStream stream;
+public class MessageConsoleWriterListener implements ProcessOutputLineListener, MessageListener {
+  private final MessageConsoleStream stream;
 
-  public MessageConsoleWriterOutputLineListener(MessageConsoleStream stream) {
+  public MessageConsoleWriterListener(MessageConsoleStream stream) {
     this.stream = stream;
   }
 
   @Override
   public void onOutputLine(String line) {
     if (!stream.isClosed()) {
-      // there's still a small chance that the stream will be closed and the error will be logged by the ConsolePlugin
+      // there's still a small chance that the stream will be closed and the error will be logged by
+      // the ConsolePlugin
       stream.println(line);
+    }
+  }
+
+  @Override
+  public void message(String rawString) {
+    if (!stream.isClosed()) {
+      // there's still a small chance that the stream will be closed and the error will be logged by
+      // the ConsolePlugin
+      stream.print(rawString);
     }
   }
 }


### PR DESCRIPTION
Extending the existing listener for the managed Cloud SDK output. We'll redirect install output to the (deploy and local run) console too.