### PR TITLE
Forcibly terminate server on error from quit-request

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerBehaviour.java
@@ -154,17 +154,22 @@ public class LocalAppEngineServerBehaviour extends ServerBehaviourDelegate
         devServer.stop(stopConfig);
       } catch (AppEngineException ex) {
         logger.log(Level.WARNING, "Error terminating server: " + ex.getMessage(), ex); //$NON-NLS-1$
+        terminate();
       }
     } else {
       // we've already given it a chance
-      logger.info("forced stop: destroying associated processes"); //$NON-NLS-1$
-      if (devProcess != null) {
-        devProcess.destroy();
-        devProcess = null;
-      }
-      devServer = null;
-      setServerState(IServer.STATE_STOPPED);
+      terminate();
     }
+  }
+
+  private void terminate() {
+    logger.info("forced stop: destroying associated processes"); //$NON-NLS-1$
+    if (devProcess != null) {
+      devProcess.destroy();
+      devProcess = null;
+    }
+    devServer = null;
+    setServerState(IServer.STATE_STOPPED);
   }
 
 


### PR DESCRIPTION
`appengine-plugins-core`'s `CloudSdkDevAppServer1#stop()` raises an `AppEngineException` if the `/_ah/admin/quit` request returns a non-2XX result.  In such a case, we forcibly terminate the devappserver process.

Fixes #1964 
Fixes #2771
Filed https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/530 to move this up