### PR TITLE
Annotate Maven build log with elapsed time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ env:
   global:
     - CLOUD_SDK_HOME=$HOME/google-cloud-sdk
     - PATH=$CLOUD_SDK_HOME/bin:$PATH
-    # Our maven build typically reports about 512m
-    - MAVEN_OPTS=-Xmx700m
+    # -Xmx700m: Our maven build typically reports about 512m required
+    # -DshowDateTime: show milliseconds since start
+    - MAVEN_OPTS=-Xmx700m -Dorg.slf4j.simpleLogger.showDateTime=true
     - CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
     - DISPLAY=:99.0
     - GCS_BUILD_BUCKET=gs://travis_artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - PATH=$CLOUD_SDK_HOME/bin:$PATH
     # -Xmx700m: Our maven build typically reports about 512m required
     # -DshowDateTime: show milliseconds since start
-    - MAVEN_OPTS=-Xmx700m -Dorg.slf4j.simpleLogger.showDateTime=true
+    - MAVEN_OPTS='-Xmx700m -Dorg.slf4j.simpleLogger.showDateTime=true'
     - CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
     - DISPLAY=:99.0
     - GCS_BUILD_BUCKET=gs://travis_artifacts


### PR DESCRIPTION
Uh, wow: 2 minutes to fetch from Orbit, and 2 minutes to fail fetching from docker-editor.openanalytics.eu
```
25726 [INFO] Adding repository http://download.eclipse.org/tools/orbit/downloads/latest-R
26240 [INFO] Fetching p2.index from http://download.eclipse.org/tools/orbit/downloads/drops2/R20170307180635/repository/
26244 [INFO] Fetching p2.index from http://download.eclipse.org/tools/orbit/downloads/drops2/R20170307180635/repository/
148246 [INFO] Adding repository http://docker-editor.openanalytics.eu/update
269492 [WARNING] Failed to access p2 repository http://docker-editor.openanalytics.eu/update, use local cache. Communication with repository at http://docker-editor.openanalytics.eu/update failed.
269689 [INFO] Adding repository http://dadacoalition.org/yedit
281378 [INFO] Resolving dependencies of MavenProject: com.google.cloud.tools.eclipse:google-cloud-plugin-eclipse.repo:0.1.0-SNAPSHOT @ /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/gcp-repo/pom.xml
```