### PR TITLE
Persist one-time managed Cloud SDK preferences setup

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferencesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferencesTest.java
@@ -19,14 +19,18 @@ package com.google.cloud.tools.eclipse.sdk.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.google.cloud.tools.eclipse.sdk.CloudSdkManager;
 import com.google.cloud.tools.eclipse.test.util.TestPreferencesRule;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.osgi.service.prefs.BackingStoreException;
 
 public class CloudSdkPreferencesTest {
   @Rule public TestPreferencesRule preferencesCreator = new TestPreferencesRule();
@@ -103,5 +107,12 @@ public class CloudSdkPreferencesTest {
     CloudSdkPreferences.configureManagementPreferences(preferences, false /*cloudSdkAvailable*/);
     assertFalse(preferences.isDefault(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT));
     assertEquals("MANUAL", preferences.getString(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT));
+  }
+
+  @Test
+  public void testFlushPreferences() throws BackingStoreException {
+    IEclipsePreferences preferencesNode = mock(IEclipsePreferences.class);
+    CloudSdkPreferences.flushPreferences(preferencesNode);
+    verify(preferencesNode).flush();
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Import-Package: com.google.cloud.tools.eclipse.util.jobs,
  org.eclipse.ui.console,
  org.eclipse.ui.preferences,
  org.osgi.framework;version="[1.8.0,2.0.0)",
- org.osgi.service.prefs;version="1.1.1"
+ org.osgi.service.prefs
 Eclipse-RegisterBuddy: com.google.cloud.tools.appengine
 Export-Package: com.google.cloud.tools.eclipse.sdk,
  com.google.cloud.tools.eclipse.sdk.internal;x-friends:="com.google.cloud.tools.eclipse.sdk.ui"

--- a/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Import-Package: com.google.cloud.tools.eclipse.util.jobs,
  org.eclipse.osgi.service.debug,
  org.eclipse.ui.console,
  org.eclipse.ui.preferences,
- org.osgi.framework;version="[1.8.0,2.0.0)"
+ org.osgi.framework;version="[1.8.0,2.0.0)",
+ org.osgi.service.prefs;version="1.1.1"
 Eclipse-RegisterBuddy: com.google.cloud.tools.appengine
 Export-Package: com.google.cloud.tools.eclipse.sdk,
  com.google.cloud.tools.eclipse.sdk.internal;x-friends:="com.google.cloud.tools.eclipse.sdk.ui"

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
@@ -106,9 +106,13 @@ public final class CloudSdkPreferences extends AbstractPreferenceInitializer {
     } else {
       preferences.setValue(CLOUD_SDK_MANAGEMENT, CloudSdkManagementOption.AUTOMATIC.name());
     }
+    flushPreferences(getPreferenceNode());
+  }
 
+  @VisibleForTesting
+  static void flushPreferences(IEclipsePreferences preferenceNode) {
     try {
-      getPreferenceNode().flush();
+      preferenceNode.flush();
     } catch (BackingStoreException ex) {
       logger.log(Level.WARNING, "could not save preferences", ex);
     }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
@@ -21,17 +21,23 @@ import com.google.cloud.tools.appengine.cloudsdk.CloudSdkNotFoundException;
 import com.google.cloud.tools.eclipse.sdk.CloudSdkManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.osgi.service.prefs.BackingStoreException;
 
 /**
  * Class for Cloud SDK preferences: defining constants, accessing their preference store and node,
  * initializing default values, etc.
  */
 public final class CloudSdkPreferences extends AbstractPreferenceInitializer {
+
+  private static final Logger logger = Logger.getLogger(CloudSdkPreferences.class.getName());
+
   // host bundle for the preference
   static final String BUNDLEID = "com.google.cloud.tools.eclipse.sdk";
 
@@ -99,6 +105,12 @@ public final class CloudSdkPreferences extends AbstractPreferenceInitializer {
       preferences.setValue(CLOUD_SDK_MANAGEMENT, CloudSdkManagementOption.MANUAL.name());
     } else {
       preferences.setValue(CLOUD_SDK_MANAGEMENT, CloudSdkManagementOption.AUTOMATIC.name());
+    }
+
+    try {
+      getPreferenceNode().flush();
+    } catch (BackingStoreException ex) {
+      logger.log(Level.WARNING, "could not save preferences", ex);
     }
   }
 


### PR DESCRIPTION
Fixes #2839.

I noticed `IPreferencesStore` does not have `flush()`, maybe because it is a general abstraction of the preference notion? I think the only way to persist is to actually get the preference node.