### PR TITLE
Trigger installation of the Managed Cloud SDK on selection

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployJob.java
@@ -88,7 +88,7 @@ public class DeployJob extends WorkspaceJob {
     try {
       progress.subTask("Checking for Google Cloud SDK");
       IStatus installStatus =
-          CloudSdkManager.getDefault().installManagedSdk(stdoutOutputStream, progress.newChild(20));
+          CloudSdkManager.getInstance().installManagedSdk(stdoutOutputStream, progress.newChild(20));
       if (installStatus != Status.OK_STATUS) {
         return StatusUtil.error(
             this,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/DeployJob.java
@@ -88,7 +88,7 @@ public class DeployJob extends WorkspaceJob {
     try {
       progress.subTask("Checking for Google Cloud SDK");
       IStatus installStatus =
-          CloudSdkManager.installManagedSdk(stdoutOutputStream, progress.newChild(20));
+          CloudSdkManager.getDefault().installManagedSdk(stdoutOutputStream, progress.newChild(20));
       if (installStatus != Status.OK_STATUS) {
         return StatusUtil.error(
             this,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -124,7 +124,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
 
   private static IStatus validateCloudSdk(IProgressMonitor monitor) {
     // ensure we have a Cloud SDK; no-op if not configured to use managed sdk
-    IStatus status = CloudSdkManager.installManagedSdk(null, monitor);
+    IStatus status = CloudSdkManager.getDefault().installManagedSdk(null, monitor);
     if (!status.isOK()) {
       return status;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -124,7 +124,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
 
   private static IStatus validateCloudSdk(IProgressMonitor monitor) {
     // ensure we have a Cloud SDK; no-op if not configured to use managed sdk
-    IStatus status = CloudSdkManager.getDefault().installManagedSdk(null, monitor);
+    IStatus status = CloudSdkManager.getInstance().installManagedSdk(null, monitor);
     if (!status.isOK()) {
       return status;
     }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
@@ -44,7 +44,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class CloudSdkManagerTest {
 
   @Mock private ManagedCloudSdk managedCloudSdk;
-  private CloudSdkManager fixture = new CloudSdkManager();
+  private final CloudSdkManager fixture = new CloudSdkManager();
 
   @Before
   public void setUp() throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException {
@@ -55,7 +55,7 @@ public class CloudSdkManagerTest {
   @After
   public void tearDown() {
     assertTrue("write lock not available", fixture.modifyLock.writeLock().tryLock());
-    CloudSdkManager.singleton = null;
+    CloudSdkManager.instance = null;
     CloudSdkManager.forceManagedSdkFeature = false;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
@@ -44,7 +44,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class CloudSdkManagerTest {
 
   @Mock private ManagedCloudSdk managedCloudSdk;
-  @Mock private IProgressMonitor monitor;
   private CloudSdkManager fixture = new CloudSdkManager();
 
   @Before
@@ -74,7 +73,7 @@ public class CloudSdkManagerTest {
   @Test
   public void testRunInstallJob_blocking() {
     CloudSdkModifyJob okJob = new FakeModifyJob(Status.OK_STATUS);
-    IStatus result = CloudSdkManager.runInstallJob(null, okJob, monitor);
+    IStatus result = CloudSdkManager.runInstallJob(null, okJob, null);
     // Incomplete test, but if it ever fails, something is surely broken.
     assertEquals(Job.NONE, okJob.getState());
     assertTrue(result.isOK());
@@ -83,7 +82,7 @@ public class CloudSdkManagerTest {
   @Test
   public void testRunInstallJob_canceled() {
     CloudSdkModifyJob cancelJob = new FakeModifyJob(Status.CANCEL_STATUS);
-    IStatus result = CloudSdkManager.runInstallJob(null, cancelJob, monitor);
+    IStatus result = CloudSdkManager.runInstallJob(null, cancelJob, null);
     assertEquals(Job.NONE, cancelJob.getState());
     assertEquals(Status.CANCEL, result.getSeverity());
   }
@@ -92,7 +91,7 @@ public class CloudSdkManagerTest {
   public void testRunInstallJob_installError() {
     IStatus error = StatusUtil.error(this, "awesome install error in unit test");
     CloudSdkModifyJob errorJob = new FakeModifyJob(error);
-    IStatus result = CloudSdkManager.runInstallJob(null, errorJob, monitor);
+    IStatus result = CloudSdkManager.runInstallJob(null, errorJob, null);
     assertEquals(Job.NONE, errorJob.getState());
     assertEquals(Status.ERROR, result.getSeverity());
     assertEquals("awesome install error in unit test", result.getMessage());
@@ -171,7 +170,7 @@ public class CloudSdkManagerTest {
             @Override
             public IStatus run(IProgressMonitor monitor) {
               // Should block until we allow SDK modification below.
-              fixture.runInstallJob(null, installJob, monitor);
+              CloudSdkManager.runInstallJob(null, installJob, monitor);
               return Status.OK_STATUS;
             }
           };

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceAreaTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceAreaTest.java
@@ -72,7 +72,7 @@ public class CloudSdkPreferenceAreaTest {
   @After
   public void tearDown() {
     CloudSdkManager.forceManagedSdkFeature = false;
-    CloudSdkManager.singleton = null;
+    CloudSdkManager.instance = null;
   }
 
   @Test
@@ -207,7 +207,7 @@ public class CloudSdkPreferenceAreaTest {
     CloudSdkManager mockManager = mock(CloudSdkManager.class);
     doNothing().when(mockManager).installManagedSdkAsync();
     doReturn(true).when(mockManager).isManagedSdkFeatureEnabled();
-    CloudSdkManager.singleton = mockManager;
+    CloudSdkManager.instance = mockManager;
 
     when(preferences.getString(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT)).thenReturn("MANUAL");
     when(preferences.getString(CloudSdkPreferences.CLOUD_SDK_PATH))

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceAreaTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceAreaTest.java
@@ -21,7 +21,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.sdk.CloudSdkManager;
@@ -67,6 +72,7 @@ public class CloudSdkPreferenceAreaTest {
   @After
   public void tearDown() {
     CloudSdkManager.forceManagedSdkFeature = false;
+    CloudSdkManager.singleton = null;
   }
 
   @Test
@@ -194,5 +200,26 @@ public class CloudSdkPreferenceAreaTest {
 
     new SWTBotCheckBox(chooseSdk).click();
     assertEquals(IStatus.ERROR, area.getStatus().getSeverity());
+  }
+
+  @Test
+  public void testApply_automatic() {
+    CloudSdkManager mockManager = mock(CloudSdkManager.class);
+    doNothing().when(mockManager).installManagedSdkAsync();
+    doReturn(true).when(mockManager).isManagedSdkFeatureEnabled();
+    CloudSdkManager.singleton = mockManager;
+
+    when(preferences.getString(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT)).thenReturn("MANUAL");
+    when(preferences.getString(CloudSdkPreferences.CLOUD_SDK_PATH))
+        .thenReturn("/non-existing/directory");
+
+    createPreferenceArea();
+    new SWTBotCheckBox(chooseSdk).click();
+    assertTrue(area.getStatus().isOK());
+
+    area.performApply();
+    verify(mockManager).installManagedSdkAsync();
+    verify(mockManager, atLeastOnce()).isManagedSdkFeatureEnabled();
+    verifyNoMoreInteractions(mockManager);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/InstallManagedCloudSdkStartup.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/InstallManagedCloudSdkStartup.java
@@ -41,7 +41,7 @@ public class InstallManagedCloudSdkStartup implements IStartup {
         new WorkbenchJob("Check Google Cloud SDK") {
           @Override
           public IStatus runInUIThread(IProgressMonitor monitor) {
-            CloudSdkManager.getDefault().installManagedSdkAsync();
+            CloudSdkManager.getInstance().installManagedSdkAsync();
             return Status.OK_STATUS;
           }
         };

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/InstallManagedCloudSdkStartup.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/InstallManagedCloudSdkStartup.java
@@ -41,7 +41,7 @@ public class InstallManagedCloudSdkStartup implements IStartup {
         new WorkbenchJob("Check Google Cloud SDK") {
           @Override
           public IStatus runInUIThread(IProgressMonitor monitor) {
-            CloudSdkManager.installManagedSdkAsync();
+            CloudSdkManager.getDefault().installManagedSdkAsync();
             return Status.OK_STATUS;
           }
         };

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/UpdateManagedCloudSdkHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/UpdateManagedCloudSdkHandler.java
@@ -10,7 +10,7 @@ import org.eclipse.core.commands.ExecutionException;
 public class UpdateManagedCloudSdkHandler extends AbstractHandler {
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {
-    CloudSdkManager.updateManagedSdkAsync();
+    CloudSdkManager.getDefault().updateManagedSdkAsync();
     return null;
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/UpdateManagedCloudSdkHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/UpdateManagedCloudSdkHandler.java
@@ -10,7 +10,7 @@ import org.eclipse.core.commands.ExecutionException;
 public class UpdateManagedCloudSdkHandler extends AbstractHandler {
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {
-    CloudSdkManager.getDefault().updateManagedSdkAsync();
+    CloudSdkManager.getInstance().updateManagedSdkAsync();
     return null;
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
@@ -60,7 +60,6 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
       "com.google.cloud.tools.eclipse.preferences.main"; //$NON-NLS-1$
 
   private Button chooseSdk;
-  private Button updateSdk;
   private Composite chooseSdkArea;
   private CloudSdkDirectoryFieldEditor sdkLocation;
   private Label sdkVersionLabel;
@@ -83,7 +82,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     Composite contents = new Composite(parent, SWT.NONE);
     Link instructions = new Link(contents, SWT.WRAP);
     instructions.setText(
-        CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()
+        CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()
             ? Messages.getString("CloudSdkRequiredWithManagedSdk") // $NON-NLS-1$
             : Messages.getString("CloudSdkRequired")); // $NON-NLS-1$
     instructions.setFont(contents.getFont());
@@ -98,7 +97,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     sdkVersionLabel.setFont(contents.getFont());
     sdkVersionLabel.setText(Messages.getString("SdkVersion", "Unset")); //$NON-NLS-1$ //$NON-NLS-2$
 
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       chooseSdk = new Button(parent, SWT.CHECK);
       chooseSdk.setText(Messages.getString("UseLocalSdk")); //$NON-NLS-1$
       chooseSdk.addSelectionListener(new SelectionAdapter() {
@@ -128,7 +127,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     sdkLocation.setPreferenceStore(getPreferenceStore());
     sdkLocation.setPropertyChangeListener(wrappedPropertyChangeListener);
 
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       GridLayoutFactory.fillDefaults().numColumns(sdkLocation.getNumberOfControls())
           .extendedMargins(IDialogConstants.LEFT_MARGIN, 0, 0, 0)
           .generateLayout(chooseSdkArea);
@@ -144,10 +143,10 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
   
   private void updateSelectedVersion() {
     String version = Messages.getString("UnknownVersion"); //$NON-NLS-1$
-    if (!CloudSdkManager.getDefault().isManagedSdkFeatureEnabled() || chooseSdk.getSelection()) {
+    if (!CloudSdkManager.getInstance().isManagedSdkFeatureEnabled() || chooseSdk.getSelection()) {
       Path path = Paths.get(sdkLocation.getStringValue());
       version = getSdkVersion(path);
-    } else if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    } else if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       try {
         Path home = ManagedCloudSdk.newManagedSdk().getSdkHome();
         version = getSdkVersion(home);
@@ -193,7 +192,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void load() {
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       loadSdkManagement(false /* loadDefault */);
       updateControlEnablement();
     }
@@ -204,7 +203,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void loadDefault() {
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       loadSdkManagement(true /* loadDefault */);
       updateControlEnablement();
     }
@@ -218,14 +217,14 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void performApply() {
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       if (chooseSdk.getSelection()) {
         getPreferenceStore().putValue(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT,
             CloudSdkManagementOption.MANUAL.name());
       } else {
         getPreferenceStore().putValue(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT,
             CloudSdkManagementOption.AUTOMATIC.name());
-        CloudSdkManager.getDefault().installManagedSdkAsync();
+        CloudSdkManager.getInstance().installManagedSdkAsync();
       }
     }
     sdkLocation.store();
@@ -290,7 +289,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
     @Override
     protected boolean doCheckState() {
-      if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled() && !chooseSdk.getSelection()) {
+      if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled() && !chooseSdk.getSelection()) {
         // return early if we're not using a local SDK
         return true;
       }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
@@ -60,6 +60,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
       "com.google.cloud.tools.eclipse.preferences.main"; //$NON-NLS-1$
 
   private Button chooseSdk;
+  private Button updateSdk;
   private Composite chooseSdkArea;
   private CloudSdkDirectoryFieldEditor sdkLocation;
   private Label sdkVersionLabel;
@@ -82,7 +83,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     Composite contents = new Composite(parent, SWT.NONE);
     Link instructions = new Link(contents, SWT.WRAP);
     instructions.setText(
-        CloudSdkManager.getDefault().getDefault().isManagedSdkFeatureEnabled()
+        CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()
             ? Messages.getString("CloudSdkRequiredWithManagedSdk") // $NON-NLS-1$
             : Messages.getString("CloudSdkRequired")); // $NON-NLS-1$
     instructions.setFont(contents.getFont());

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/preferences/CloudSdkPreferenceArea.java
@@ -81,9 +81,10 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
   public Control createContents(Composite parent) {
     Composite contents = new Composite(parent, SWT.NONE);
     Link instructions = new Link(contents, SWT.WRAP);
-    instructions.setText(CloudSdkManager.isManagedSdkFeatureEnabled()
-        ? Messages.getString("CloudSdkRequiredWithManagedSdk") //$NON-NLS-1$
-        : Messages.getString("CloudSdkRequired")); //$NON-NLS-1$
+    instructions.setText(
+        CloudSdkManager.getDefault().getDefault().isManagedSdkFeatureEnabled()
+            ? Messages.getString("CloudSdkRequiredWithManagedSdk") // $NON-NLS-1$
+            : Messages.getString("CloudSdkRequired")); // $NON-NLS-1$
     instructions.setFont(contents.getFont());
     instructions.addSelectionListener(new SelectionAdapter() {
       @Override
@@ -95,8 +96,8 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     sdkVersionLabel = new Label(parent, SWT.LEAD);
     sdkVersionLabel.setFont(contents.getFont());
     sdkVersionLabel.setText(Messages.getString("SdkVersion", "Unset")); //$NON-NLS-1$ //$NON-NLS-2$
-    
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       chooseSdk = new Button(parent, SWT.CHECK);
       chooseSdk.setText(Messages.getString("UseLocalSdk")); //$NON-NLS-1$
       chooseSdk.addSelectionListener(new SelectionAdapter() {
@@ -126,7 +127,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
     sdkLocation.setPreferenceStore(getPreferenceStore());
     sdkLocation.setPropertyChangeListener(wrappedPropertyChangeListener);
 
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       GridLayoutFactory.fillDefaults().numColumns(sdkLocation.getNumberOfControls())
           .extendedMargins(IDialogConstants.LEFT_MARGIN, 0, 0, 0)
           .generateLayout(chooseSdkArea);
@@ -142,10 +143,10 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
   
   private void updateSelectedVersion() {
     String version = Messages.getString("UnknownVersion"); //$NON-NLS-1$
-    if (!CloudSdkManager.isManagedSdkFeatureEnabled() || chooseSdk.getSelection()) {
+    if (!CloudSdkManager.getDefault().isManagedSdkFeatureEnabled() || chooseSdk.getSelection()) {
       Path path = Paths.get(sdkLocation.getStringValue());
       version = getSdkVersion(path);
-    } else if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    } else if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       try {
         Path home = ManagedCloudSdk.newManagedSdk().getSdkHome();
         version = getSdkVersion(home);
@@ -191,7 +192,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void load() {
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       loadSdkManagement(false /* loadDefault */);
       updateControlEnablement();
     }
@@ -202,7 +203,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void loadDefault() {
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       loadSdkManagement(true /* loadDefault */);
       updateControlEnablement();
     }
@@ -216,13 +217,14 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
   @Override
   public void performApply() {
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       if (chooseSdk.getSelection()) {
         getPreferenceStore().putValue(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT,
             CloudSdkManagementOption.MANUAL.name());
       } else {
         getPreferenceStore().putValue(CloudSdkPreferences.CLOUD_SDK_MANAGEMENT,
             CloudSdkManagementOption.AUTOMATIC.name());
+        CloudSdkManager.getDefault().installManagedSdkAsync();
       }
     }
     sdkLocation.store();
@@ -287,7 +289,7 @@ public class CloudSdkPreferenceArea extends PreferenceArea {
 
     @Override
     protected boolean doCheckState() {
-      if (CloudSdkManager.isManagedSdkFeatureEnabled() && !chooseSdk.getSelection()) {
+      if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled() && !chooseSdk.getSelection()) {
         // return early if we're not using a local SDK
         return true;
       }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
@@ -43,14 +43,17 @@ public class CloudSdkManager {
   // To be able to write tests for the managed Cloud SDK feature, which is disabled at the moment.
   @VisibleForTesting public static boolean forceManagedSdkFeature;
 
-  @VisibleForTesting public static CloudSdkManager singleton;
+  @VisibleForTesting public static CloudSdkManager instance;
 
-  public static synchronized CloudSdkManager getDefault() {
-    if (singleton == null) {
-      singleton = new CloudSdkManager();
+  public static synchronized CloudSdkManager getInstance() {
+    if (instance == null) {
+      instance = new CloudSdkManager();
     }
-    return singleton;
+    return instance;
   }
+
+  @VisibleForTesting
+  CloudSdkManager() {}
 
   // readers = using SDK, writers = modifying SDK
   @VisibleForTesting final ReadWriteLock modifyLock = new ReentrantReadWriteLock();

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
@@ -41,10 +41,21 @@ public class CloudSdkManager {
       "com.google.cloud.tools.eclipse.sdk/enable.managed.cloud.sdk";
 
   // To be able to write tests for the managed Cloud SDK feature, which is disabled at the moment.
-  @VisibleForTesting
-  public static boolean forceManagedSdkFeature;
+  @VisibleForTesting public static boolean forceManagedSdkFeature;
 
-  public static boolean isManagedSdkFeatureEnabled() {
+  @VisibleForTesting public static CloudSdkManager singleton;
+
+  public static synchronized CloudSdkManager getDefault() {
+    if (singleton == null) {
+      singleton = new CloudSdkManager();
+    }
+    return singleton;
+  }
+
+  // readers = using SDK, writers = modifying SDK
+  @VisibleForTesting final ReadWriteLock modifyLock = new ReentrantReadWriteLock();
+
+  public boolean isManagedSdkFeatureEnabled() {
     if (forceManagedSdkFeature) {
       return true;
     }
@@ -57,10 +68,6 @@ public class CloudSdkManager {
     return false;
   }
 
-  // readers = using SDK, writers = modifying SDK
-  @VisibleForTesting
-  static final ReadWriteLock modifyLock = new ReentrantReadWriteLock();
-
   /**
    * Prevents potential future SDK auto-install or auto-update functionality to allow safely using
    * the managed Cloud SDK for some period of time. Blocks if an install or update is in progress.
@@ -72,7 +79,7 @@ public class CloudSdkManager {
    *
    * @see CloudSdkManager#allowModifyingSdk
    */
-  public static void preventModifyingSdk() throws InterruptedException {
+  public void preventModifyingSdk() throws InterruptedException {
     do {
       IJobManager jobManager = Job.getJobManager();
       // The join is to improve UI reporting of blocked jobs. Most of the waiting should be here.
@@ -88,7 +95,7 @@ public class CloudSdkManager {
    *
    * @see CloudSdkManager#preventModifyingSdk
    */
-  public static void allowModifyingSdk() {
+  public void allowModifyingSdk() {
     modifyLock.readLock().unlock();
   }
 
@@ -96,7 +103,7 @@ public class CloudSdkManager {
    * Triggers the installation of a Cloud SDK, if the preferences are configured to auto-manage the
    * SDK.
    */
-  public static void installManagedSdkAsync() {
+  public void installManagedSdkAsync() {
     if (isManagedSdkFeatureEnabled()) {
       if (CloudSdkPreferences.isAutoManaging()) {
         // Keep installation failure as ERROR so that failures are reported
@@ -115,8 +122,7 @@ public class CloudSdkManager {
    * @param consoleStream stream to which the install output is written
    * @param monitor the progress monitor that can also be used to cancel the installation
    */
-  public static IStatus installManagedSdk(
-      MessageConsoleStream consoleStream, IProgressMonitor monitor) {
+  public IStatus installManagedSdk(MessageConsoleStream consoleStream, IProgressMonitor monitor) {
     if (isManagedSdkFeatureEnabled()) {
       if (CloudSdkPreferences.isAutoManaging()) {
         // We don't check if the Cloud SDK installed but always schedule the install job; such check
@@ -145,7 +151,7 @@ public class CloudSdkManager {
    * Triggers the update of a managed Cloud SDK, if the preferences are configured to auto-manage
    * the SDK.
    */
-  public static void updateManagedSdkAsync() {
+  public void updateManagedSdkAsync() {
     if (isManagedSdkFeatureEnabled()) {
       if (CloudSdkPreferences.isAutoManaging()) {
         // Keep installation failure as ERROR so that failures are reported

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
@@ -84,7 +84,7 @@ public final class CloudSdkPreferences extends AbstractPreferenceInitializer {
 
   @VisibleForTesting
   static void initializeDefaultPreferences(IPreferenceStore preferences) {
-    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getInstance().isManagedSdkFeatureEnabled()) {
       if (!preferences.contains(CLOUD_SDK_MANAGEMENT)) {
         // If the CLOUD_SDK_MANAGEMENT preference has not been set, then determine the
         // appropriate setting. Note that CloudSdkPreferenceResolver only checks for

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkPreferences.java
@@ -84,7 +84,7 @@ public final class CloudSdkPreferences extends AbstractPreferenceInitializer {
 
   @VisibleForTesting
   static void initializeDefaultPreferences(IPreferenceStore preferences) {
-    if (CloudSdkManager.isManagedSdkFeatureEnabled()) {
+    if (CloudSdkManager.getDefault().isManagedSdkFeatureEnabled()) {
       if (!preferences.contains(CLOUD_SDK_MANAGEMENT)) {
         // If the CLOUD_SDK_MANAGEMENT preference has not been set, then determine the
         // appropriate setting. Note that CloudSdkPreferenceResolver only checks for


### PR DESCRIPTION
Required making `CloudSdkManager` mockable.

Fixes #2808 