### PR TITLE
Use a browser-ID to reuse GCP status browser tab

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/ShowGcpStatusHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/ShowGcpStatusHandler.java
@@ -53,7 +53,12 @@ public class ShowGcpStatusHandler extends AbstractHandler implements IElementUpd
   public Object execute(ExecutionEvent event) throws ExecutionException {
     GcpStatusMonitoringService service = ServiceUtils.getService(event, GcpStatusMonitoringService.class);
     ((PollingStatusServiceImpl) service).refreshStatus();
-    WorkbenchUtil.openInBrowser(PlatformUI.getWorkbench(), STATUS_URL);
+    WorkbenchUtil.openInBrowser(
+        PlatformUI.getWorkbench(),
+        STATUS_URL,
+        "com.google.cloud.status" /* browser id */,
+        null /* title */,
+        null /* tooltip */);
     return null;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/ShowGcpStatusHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/ShowGcpStatusHandler.java
@@ -56,7 +56,7 @@ public class ShowGcpStatusHandler extends AbstractHandler implements IElementUpd
     WorkbenchUtil.openInBrowser(
         PlatformUI.getWorkbench(),
         STATUS_URL,
-        "com.google.cloud.status" /* browser id */,
+        "com.google.cloud.status" /* browser id */, //$NON-NLS-1$
         null /* title */,
         null /* tooltip */);
     return null;


### PR DESCRIPTION
Previously clicking on the status button opens new browser tabs.