### PR TITLE
Remove Eclipse Public License feature

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="org.eclipse.license" version="0.0.0"/>
    <feature id="org.eclipse.sdk" version="0.0.0"/>
    <feature id="org.eclipse.jdt" version="0.0.0"/>
    <feature id="org.eclipse.m2e.feature" version="0.0.0"/>

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1519744381">
+<target name="GCP for Eclipse Neon" sequenceNumber="1519746459">
   <locations>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="2.0.0.v20180130-0820"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
-    </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
       <unit id="org.eclipse.jdt.feature.group" version="3.12.3.v20170301-0400"/>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -11,10 +11,6 @@
  */
 target "GCP for Eclipse Neon" with source requirements
 
-location "http://download.eclipse.org/cbi/updates/license/" {
-    org.eclipse.license.feature.group
-}
-
 location "http://download.eclipse.org/releases/neon/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1519744361">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1519746463">
   <locations>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="2.0.0.v20180130-0820"/>
-      <repository location="http://download.eclipse.org/cbi/updates/license/"/>
-    </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.2.v20171130-0906"/>
       <unit id="org.eclipse.jdt.feature.group" version="3.13.2.v20171130-0906"/>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -11,10 +11,6 @@
  */
 target "GCP for Eclipse Oxygen" with source requirements
 
-location "http://download.eclipse.org/cbi/updates/license/" {
-    org.eclipse.license.feature.group
-}
-
 location "http://download.eclipse.org/releases/oxygen/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group


### PR DESCRIPTION
We pull in the `org.eclipse.license` feature, a vestige from GPE.  But since CT4E is under the ASL, it's unnecessary.

Note: this patch builds on #2860 since it requires regenerating the .target files.