### PR TITLE
Indent Maven Coordinates box to clarify control structure

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/LibrarySelectorGroup.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/LibrarySelectorGroup.java
@@ -101,7 +101,7 @@ public class LibrarySelectorGroup implements ISelectionProvider {
       libraryButton.addSelectionListener(new ManualSelectionTracker());
       libraryButtons.put(library, libraryButton);
     }
-    GridLayoutFactory.fillDefaults().generateLayout(apiGroup);
+    GridLayoutFactory.swtDefaults().generateLayout(apiGroup);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/maven/MavenCoordinatesWizardUi.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.dialogs.DialogPage;
 import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyListener;
@@ -53,6 +54,7 @@ public class MavenCoordinatesWizardUi extends Composite {
 
     updateEnablement();
 
+    GridDataFactory.defaultsFor(mavenCoordinatesUi).indent(20, 0).applyTo(mavenCoordinatesUi);
     GridLayoutFactory.swtDefaults().generateLayout(this);
   }
 


### PR DESCRIPTION
As noted in #2865, the Maven Coordinates box is slight indented compared to the Libraries API section on the New App Engine Standard Environment wizard.  This patch indents the Maven Coordinates box by 20 pixels to make it clear that it is controlled by the checkbox:

<img width="606" alt="screen shot 2018-02-27 at 5 13 38 pm" src="https://user-images.githubusercontent.com/202851/36758296-0713030a-1be2-11e8-9fa3-007638c27ee6.PNG">

It will affect the App Engine Flexible Environment wizard too.