### PR TITLE
Make AESv8-related tests work in Eclipse

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -29,6 +29,7 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.eclipse.wst.server.core.IRuntimeType;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +66,9 @@ public class AppEngineStandardFacetTest {
 
   @Test
   public void testDefaultFacetVersion() {
+    Assume.assumeTrue(
+        "Only valid if .standard.java8 not available",
+        AppEngineStandardFacet.FACET.getVersion("JRE8") == null);
     Assert.assertEquals(AppEngineStandardFacet.JRE7,
         AppEngineStandardFacet.FACET.getDefaultVersion());
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -29,7 +29,6 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 import org.eclipse.wst.server.core.IRuntimeType;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,15 +61,6 @@ public class AppEngineStandardFacetTest {
   public void testJre7StandardFacetVersion() {
     Assert.assertEquals("JRE7", AppEngineStandardFacet.JRE7.getVersionString());
     Assert.assertNull(AppEngineStandardFacet.JRE7.getProperty("appengine.runtime"));
-  }
-
-  @Test
-  public void testDefaultFacetVersion() {
-    Assume.assumeTrue(
-        "Only valid if .standard.java8 not available",
-        AppEngineStandardFacet.FACET.getVersion("JRE8") == null);
-    Assert.assertEquals(AppEngineStandardFacet.JRE7,
-        AppEngineStandardFacet.FACET.getDefaultVersion());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardFacetTest.java
@@ -52,10 +52,15 @@ public class AppEngineStandardFacetTest {
   public void testStandardFacetExists() {
     Assert.assertEquals("com.google.cloud.tools.eclipse.appengine.facets.standard",
         AppEngineStandardFacet.ID);
-    Assert.assertEquals("JRE7", AppEngineStandardFacet.JRE7.getVersionString());
     // see AppEngineStandardFacetVersionChangeTests for JRE8 test
     Assert.assertTrue(ProjectFacetsManager.isProjectFacetDefined(AppEngineStandardFacet.ID));
     Assert.assertEquals(AppEngineStandardFacet.ID, AppEngineStandardFacet.FACET.getId());
+  }
+
+  @Test
+  public void testJre7StandardFacetVersion() {
+    Assert.assertEquals("JRE7", AppEngineStandardFacet.JRE7.getVersionString());
+    Assert.assertNull(AppEngineStandardFacet.JRE7.getProperty("appengine.runtime"));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegateTest.java
@@ -16,10 +16,14 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
+import static org.junit.Assert.assertNull;
+
+import com.google.cloud.tools.appengine.AppEngineDescriptor;
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -30,13 +34,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
-
-import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
-import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 
 public class StandardFacetInstallDelegateTest {
 
@@ -53,14 +51,14 @@ public class StandardFacetInstallDelegateTest {
   
   @Test
   public void testCreateConfigFiles() throws CoreException, IOException, SAXException {
-    delegate.createConfigFiles(project, monitor);
-    
+    delegate.createConfigFiles(project, AppEngineStandardFacet.JRE7, monitor);
+
     IFile appengineWebXml = project.getFile("src/main/webapp/WEB-INF/appengine-web.xml");
     Assert.assertTrue(appengineWebXml.exists());
     
     try (InputStream in = appengineWebXml.getContents(true)) {
-      XMLReader parser = XMLReaderFactory.createXMLReader();
-      parser.parse(new InputSource(in));       
+      AppEngineDescriptor descriptor = AppEngineDescriptor.parse(in);
+      assertNull(descriptor.getRuntime());
     }
   }
   
@@ -74,9 +72,9 @@ public class StandardFacetInstallDelegateTest {
     appengineWebXml.create(new ByteArrayInputStream(new byte[0]), true, monitor);
 
     Assert.assertTrue(appengineWebXml.exists());
-    
-    delegate.createConfigFiles(project, monitor);
-    
+
+    delegate.createConfigFiles(project, AppEngineStandardFacet.JRE7, monitor);
+
     // Make sure createConfigFiles did not write any data into appengine-web.xml
     try (InputStream in = appengineWebXml.getContents(true)) {
       Assert.assertEquals("appengine-web.xml is not empty", -1, in.read());       

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -10,7 +10,6 @@
        <version-comparator
              class="com.google.cloud.tools.eclipse.appengine.facets.StringVersionComparator">
        </version-comparator>
-       <default-version version="JRE8" />
     </project-facet>
     <project-facet-version facet="com.google.cloud.tools.eclipse.appengine.facets.standard" version="JRE7">
        <constraint>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -48,7 +48,7 @@ public class StandardFacetInstallDelegate implements IDelegate {
                       IProjectFacetVersion version,
                       Object config,
                       IProgressMonitor monitor) throws CoreException {
-    createConfigFiles(project, monitor);
+    createConfigFiles(project, version, monitor);
     installAppEngineRuntimes(project);
   }
 
@@ -123,11 +123,10 @@ public class StandardFacetInstallDelegate implements IDelegate {
     }
   }
 
-  /**
-   * Creates an appengine-web.xml file in the WEB-INF folder if it doesn't exist.
-   */
+  /** Creates an appengine-web.xml file in the WEB-INF folder if it doesn't exist. */
   @VisibleForTesting
-  void createConfigFiles(IProject project, IProgressMonitor monitor)
+  void createConfigFiles(
+      IProject project, IProjectFacetVersion facetVersion, IProgressMonitor monitor)
       throws CoreException {
     SubMonitor progress = SubMonitor.convert(monitor, 10);
 
@@ -141,9 +140,12 @@ public class StandardFacetInstallDelegate implements IDelegate {
         new ByteArrayInputStream(new byte[0]), progress.newChild(2));
     String configFileLocation = appEngineWebXml.getLocation().toString();
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("runtime", "java8");
-    Templates.createFileContent(configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE,
-        parameters);
+    Object appEngineRuntime = facetVersion.getProperty("appengine.runtime");
+    if (appEngineRuntime instanceof String) {
+      parameters.put("runtime", (String) appEngineRuntime);
+    }
+    Templates.createFileContent(
+        configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE, parameters);
     progress.worked(4);
     appEngineWebXml.refreshLocal(IFile.DEPTH_ZERO, progress.newChild(1));
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineJre8StandardFacetVersionTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineJre8StandardFacetVersionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.standard.java8;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Tests of the AppEngineStandardFacet JRE8 facet version definition. */
+public class AppEngineJre8StandardFacetVersionTest {
+  @Test
+  public void testId() {
+    assertEquals(
+        "JRE8", AppEngineStandardFacetChangeListener.APP_ENGINE_STANDARD_JRE8.getVersionString());
+  }
+
+  @Test
+  public void testAppEngineRuntimeProperty() {
+    assertEquals(
+        "java8",
+        AppEngineStandardFacetChangeListener.APP_ENGINE_STANDARD_JRE8.getProperty(
+            "appengine.runtime"));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTest.java
@@ -46,7 +46,7 @@ import org.xml.sax.SAXException;
  * Tests that changing the App Engine Standard Facet results in appropriate {@code <runtime>}
  * changes in the {@code appengine-web.xml}.
  */
-public class AppEngineStandardFacetVersionChangeTests {
+public class AppEngineStandardFacetVersionChangeTest {
   @Rule
   public TestProjectCreator jre7Project = new TestProjectCreator()
       .withFacetVersions(JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineStandardFacet.JRE7);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTests.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.io.IOException;
 import java.io.InputStream;
@@ -96,7 +97,10 @@ public class AppEngineStandardFacetVersionChangeTests {
     }
   }
 
-  /** Changing AppEngine Standard JRE8 to JRE7+Java7 facet should succeed. */
+  /**
+   * Changing AppEngine Standard JRE8 to JRE7+Java7 facet should be reverted: we only accept changes
+   * via the appengine-web.xml.
+   */
   @Test
   public void testChange_AESJ8_AESJ7andJava7() throws CoreException, IOException, SAXException {
     IFacetedProject project = jre8Project.getFacetedProject();
@@ -107,7 +111,13 @@ public class AppEngineStandardFacetVersionChangeTests {
     actions.add(new Action(Action.Type.VERSION_CHANGE, JavaFacet.VERSION_1_7, null));
     project.modify(actions, null);
 
-    assertDescriptorRuntimeIsJre7(project);
+    // the autobuilder should revert the change
+    ProjectUtils.waitForProjects(project.getProject());
+    assertEquals(
+        AppEngineStandardFacetChangeListener.APP_ENGINE_STANDARD_JRE8,
+        project.getProjectFacetVersion(AppEngineStandardFacet.FACET));
+    assertEquals(JavaFacet.VERSION_1_8, project.getProjectFacetVersion(JavaFacet.FACET));
+    assertDescriptorRuntimeIsJre8(project);
   }
 
   private static AppEngineDescriptor parseDescriptor(IFacetedProject project)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/plugin.xml
@@ -28,6 +28,10 @@
              </requires>
           </and>
         </constraint>
+       <property
+             name="appengine.runtime"
+             value="java8">
+       </property>
     </project-facet-version>
    </extension>
 


### PR DESCRIPTION
- adds a facet version property `appengine.runtime` to the AES JRE8 facet version to ensure the `<runtime>` value
- use the `appengine.runtime` property to set the `<runtime>` value as required
- rename `AppEngineStandardFacetVersionChangeTests` to ensure they are run by Tycho surefire tests
- fix up tests to reflect the current reality from #2591 

Fixes #2868