### PR TITLE
Create and show SDK install/update console for background jobs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.sdk.internal.CloudSdkModifyJob;
@@ -33,6 +34,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.console.MessageConsoleStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -201,7 +203,7 @@ public class CloudSdkManagerTest {
     private final IStatus result;
 
     private FakeModifyJob(IStatus result) {
-      super("fake job", null, fixture.modifyLock);
+      super("fake job", mock(MessageConsoleStream.class), fixture.modifyLock);
       this.result = result;
     }
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJobTest.java
@@ -65,19 +65,21 @@ public class CloudSdkInstallJobTest {
 
   @Test
   public void testBelongsTo() {
-    Job installJob = new CloudSdkInstallJob(null, new ReentrantReadWriteLock());
+    Job installJob = newCloudSdkInstallJob();
     assertTrue(installJob.belongsTo(CloudSdkInstallJob.CLOUD_SDK_MODIFY_JOB_FAMILY));
   }
 
   @Test
   public void testMutexRuleSet() {
-    Job installJob = new CloudSdkInstallJob(null, new ReentrantReadWriteLock());
+    Job installJob = newCloudSdkInstallJob();
     assertEquals(CloudSdkInstallJob.MUTEX_RULE, installJob.getRule());
   }
 
   @Test
   public void testGetManagedCloudSdk() throws UnsupportedOsException {
-    assertNotNull(new CloudSdkInstallJob(null, new ReentrantReadWriteLock()).getManagedCloudSdk());
+    // Don't use "newCloudSdkInstallJob()", as it overrides "getManagedCloudSdk()".
+    assertNotNull(new CloudSdkInstallJob(consoleStream, new ReentrantReadWriteLock())
+        .getManagedCloudSdk());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJobTest.java
@@ -93,8 +93,7 @@ public class CloudSdkInstallJobTest {
     job.schedule();
     job.join();
 
-    verify(consoleStream)
-        .println("Installing/upgrading the Cloud SDK... (may take several minutes)");
+    verify(consoleStream).println("[Installing Google Cloud SDK]");
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.eclipse.sdk.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -32,36 +34,37 @@ import org.eclipse.core.runtime.IProgressMonitorWithBlocking;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
+import org.eclipse.ui.progress.IProgressConstants;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class CloudSdkModifyJobTest {
 
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-  private CloudSdkModifyJob installJob;
-
-  @Before
-  public void setUp() {
-    installJob = new FakeModifyJob(false /* blockOnStart */);
-  }
 
   @After
   public void tearDown() {
-    assertEquals(Job.NONE, installJob.getState());
-
     assertTrue(readWriteLock.writeLock().tryLock());
     readWriteLock.writeLock().unlock();
+
+    IConsole console = findAutoCreatedConsole();
+    if (console != null) {
+      ConsolePlugin.getDefault().getConsoleManager().removeConsoles(new IConsole[] {console});
+    }
   }
 
   @Test
   public void testBelongsTo() {
+    Job installJob = new FakeModifyJob(false /* blockOnStart */);
     assertTrue(installJob.belongsTo(CloudSdkModifyJob.CLOUD_SDK_MODIFY_JOB_FAMILY));
   }
 
   @Test
   public void testMutexRuleSet() {
+    Job installJob = new FakeModifyJob(false /* blockOnStart */);
     assertEquals(CloudSdkModifyJob.MUTEX_RULE, installJob.getRule());
   }
 
@@ -80,7 +83,46 @@ public class CloudSdkModifyJobTest {
   }
 
   @Test
+  public void testConsoleNotCreatedIfGiven() {
+    new FakeModifyJob(mock(MessageConsoleStream.class));
+    assertNull(findAutoCreatedConsole());
+  }
+
+  @Test
+  public void testConsoleCreatedIfNotGiven() {
+    assertNull(findAutoCreatedConsole());
+
+    new FakeModifyJob(null /* no console stream given */);
+    assertNotNull(findAutoCreatedConsole());
+  }
+
+  private static IConsole findAutoCreatedConsole() {
+    IConsole[] consoles = ConsolePlugin.getDefault().getConsoleManager().getConsoles();
+    for (IConsole console : consoles) {
+      if ("Configuring Google Cloud SDK".equals(console.getName())) {
+        return console;
+      }
+    }
+    return null;
+  }
+
+  @Test
+  public void testNoActionPropertyIfConsoleGiven() {
+    Job job = new FakeModifyJob(mock(MessageConsoleStream.class));
+    Object actionProperty = job.getProperty(IProgressConstants.ACTION_PROPERTY);
+    assertNull(actionProperty);
+  }
+
+  @Test
+  public void testShowConsoleActionPropertyIfConsoleCreated() {
+    Job job = new FakeModifyJob(null /* no console stream given */);
+    Object actionProperty = job.getProperty(IProgressConstants.ACTION_PROPERTY);
+    assertTrue(actionProperty instanceof ShowConsoleViewAction);
+  }
+
+  @Test
   public void testRun_unlocksAfterReturn() throws InterruptedException {
+    Job installJob = new FakeModifyJob(false /* blockOnStart */);
     installJob.schedule();
     installJob.join();
 
@@ -144,6 +186,11 @@ public class CloudSdkModifyJobTest {
     private FakeModifyJob(boolean blockOnStart) {
       super("fake job", mock(MessageConsoleStream.class), readWriteLock);
       this.blockOnStart = blockOnStart;
+    }
+
+    private FakeModifyJob(MessageConsoleStream consoleStream) {
+      super("fake job", consoleStream, readWriteLock);
+      blockOnStart = false;
     }
 
     @Override

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
@@ -17,12 +17,11 @@
 package com.google.cloud.tools.eclipse.sdk.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.Semaphore;
@@ -37,21 +36,15 @@ import org.eclipse.ui.console.MessageConsoleStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CloudSdkModifyJobTest {
-
-  @Mock private MessageConsoleStream consoleStream;
 
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private CloudSdkModifyJob installJob;
 
   @Before
   public void setUp() {
-    installJob = new FakeModifyJob(consoleStream, false /* blockOnStart */);
+    installJob = new FakeModifyJob(false /* blockOnStart */);
   }
 
   @After
@@ -99,8 +92,8 @@ public class CloudSdkModifyJobTest {
 
   @Test
   public void testRun_mutualExclusion() throws InterruptedException {
-    FakeModifyJob job1 = new FakeModifyJob(consoleStream, true /* blockOnStart */);
-    FakeModifyJob job2 = new FakeModifyJob(consoleStream, true /* blockOnStart */);
+    FakeModifyJob job1 = new FakeModifyJob(true /* blockOnStart */);
+    FakeModifyJob job2 = new FakeModifyJob(true /* blockOnStart */);
 
     job1.schedule();
     while (job1.getState() != Job.RUNNING) {
@@ -123,13 +116,13 @@ public class CloudSdkModifyJobTest {
     boolean locked = true;
 
     try {
-      FakeModifyJob job = new FakeModifyJob(consoleStream, true /* blockOnStart */);
+      FakeModifyJob job = new FakeModifyJob(true /* blockOnStart */);
       job.schedule();
       while (job.getState() != Job.RUNNING) {
         Thread.sleep(50);
       }
       // Incomplete test, but if it ever fails, something is surely broken.
-      verify(consoleStream, never()).println(anyString());
+      assertFalse(job.modifiedSdk);
 
       readWriteLock.readLock().unlock();
       locked = false;
@@ -146,14 +139,16 @@ public class CloudSdkModifyJobTest {
 
     private final Semaphore blocker = new Semaphore(0);
     private final boolean blockOnStart;
+    private boolean modifiedSdk;
 
-    private FakeModifyJob(MessageConsoleStream consoleStream, boolean blockOnStart) {
-      super("fake job", consoleStream, readWriteLock);
+    private FakeModifyJob(boolean blockOnStart) {
+      super("fake job", mock(MessageConsoleStream.class), readWriteLock);
       this.blockOnStart = blockOnStart;
     }
 
     @Override
     protected IStatus modifySdk(IProgressMonitor monitor) {
+      modifiedSdk = true;
       try {
         if (blockOnStart) {
           blocker.acquire();

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
@@ -99,8 +99,8 @@ public class CloudSdkModifyJobTest {
 
   @Test
   public void testRun_mutualExclusion() throws InterruptedException {
-    FakeModifyJob job1 = new FakeModifyJob(null, true /* blockOnStart */);
-    FakeModifyJob job2 = new FakeModifyJob(null, true /* blockOnStart */);
+    FakeModifyJob job1 = new FakeModifyJob(consoleStream, true /* blockOnStart */);
+    FakeModifyJob job2 = new FakeModifyJob(consoleStream, true /* blockOnStart */);
 
     job1.schedule();
     while (job1.getState() != Job.RUNNING) {

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/ShowConsoleViewActionTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/ShowConsoleViewActionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.sdk.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleManager;
+import org.junit.Test;
+
+public class ShowConsoleViewActionTest {
+
+  @Test
+  public void testShowConsole() {
+    IConsole console = mock(IConsole.class);
+    IConsoleManager consoleManager = mock(IConsoleManager.class);
+    Action action = new ShowConsoleViewAction(console, () -> consoleManager);
+    action.run();
+
+    verify(consoleManager).showConsoleView(console);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/META-INF/MANIFEST.MF
@@ -9,17 +9,21 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.appengine;bundle-version="0.5.0"
-Import-Package: com.google.cloud.tools.eclipse.util.jobs,
+Import-Package: com.google.cloud.tools.eclipse.ui.util,
+ com.google.cloud.tools.eclipse.util.jobs,
  com.google.cloud.tools.eclipse.util.status,
  com.google.common.annotations;version="[21.0.0,22.0.0)",
  com.google.common.base;version="[21.0.0,22.0.0)",
  org.eclipse.core.runtime;version="3.5.0",
  org.eclipse.core.runtime.jobs,
  org.eclipse.core.runtime.preferences,
+ org.eclipse.jface.action,
  org.eclipse.jface.preference,
  org.eclipse.osgi.service.debug,
+ org.eclipse.swt.events,
  org.eclipse.ui.console,
  org.eclipse.ui.preferences,
+ org.eclipse.ui.progress,
  org.osgi.framework;version="[1.8.0,2.0.0)",
  org.osgi.service.prefs
 Eclipse-RegisterBuddy: com.google.cloud.tools.appengine

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManager.java
@@ -158,7 +158,7 @@ public class CloudSdkManager {
     if (isManagedSdkFeatureEnabled()) {
       if (CloudSdkPreferences.isAutoManaging()) {
         // Keep installation failure as ERROR so that failures are reported
-        Job updateJob = new CloudSdkUpdateJob(null /* no console output */, modifyLock);
+        Job updateJob = new CloudSdkUpdateJob(null /* create new message console */, modifyLock);
         updateJob.setUser(false);
         updateJob.schedule();
       }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
@@ -57,10 +57,6 @@ public class CloudSdkInstallJob extends CloudSdkModifyJob {
     SubMonitor progress =
         SubMonitor.convert(monitor, Messages.getString("configuring.cloud.sdk"), 30); // $NON-NLS-1$
 
-    if (progress.isCanceled()) {
-      return Status.CANCEL_STATUS;
-    }
-
     try {
       ManagedCloudSdk managedSdk = getManagedCloudSdk();
       if (!managedSdk.isInstalled()) {

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
@@ -59,12 +59,11 @@ public class CloudSdkInstallJob extends CloudSdkModifyJob {
   protected IStatus modifySdk(IProgressMonitor monitor) {
     SubMonitor progress =
         SubMonitor.convert(monitor, Messages.getString("configuring.cloud.sdk"), 30); // $NON-NLS-1$
+
     if (progress.isCanceled()) {
       return Status.CANCEL_STATUS;
     }
-    if (consoleStream != null) {
-      consoleStream.println(Messages.getString("startModifying"));
-    }
+
     try {
       ManagedCloudSdk managedSdk = getManagedCloudSdk();
       if (!managedSdk.isInstalled()) {

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
@@ -31,9 +31,6 @@ import org.eclipse.core.runtime.IProgressMonitorWithBlocking;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jface.action.Action;
-import org.eclipse.ui.console.ConsolePlugin;
-import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
 import org.eclipse.ui.progress.IProgressConstants;
@@ -65,18 +62,13 @@ public abstract class CloudSdkModifyJob extends Job {
     setRule(MUTEX_RULE);
   }
 
-  private MessageConsoleStream createNewMessageConsole() {
+  @VisibleForTesting
+  MessageConsoleStream createNewMessageConsole() {
     final MessageConsole console = MessageConsoleUtilities.findOrCreateConsole(
         Messages.getString("configuring.cloud.sdk"), // $NON-NLS-1$
         name -> new MessageConsole(name, null));
 
-    setProperty(IProgressConstants.ACTION_PROPERTY, new Action(null) {
-      @Override
-      public void run() {
-        IConsoleManager consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-        consoleManager.showConsoleView(console);
-      }
-    });
+    setProperty(IProgressConstants.ACTION_PROPERTY, new ShowConsoleViewAction(console));
 
     return console.newMessageStream();
   }

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
@@ -64,9 +64,9 @@ public abstract class CloudSdkModifyJob extends Job {
 
   @VisibleForTesting
   MessageConsoleStream createNewMessageConsole() {
-    final MessageConsole console = MessageConsoleUtilities.findOrCreateConsole(
+    MessageConsole console = MessageConsoleUtilities.findOrCreateConsole(
         Messages.getString("configuring.cloud.sdk"), // $NON-NLS-1$
-        name -> new MessageConsole(name, null));
+        name -> new MessageConsole(name, null /* imageDescriptor */));
 
     setProperty(IProgressConstants.ACTION_PROPERTY, new ShowConsoleViewAction(console));
 
@@ -128,7 +128,7 @@ public abstract class CloudSdkModifyJob extends Job {
   protected void subTask(IProgressMonitor monitor, String description) {
     monitor.subTask(description);
     // make output headers distinguishable on the console
-    String section = String.format("[%s]", description); // $NON-NLS-1$
+    String section = "[" + description + "]"; // $NON-NLS-1$ // $NON-NLS-2$
     consoleStream.println(section);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
@@ -64,9 +64,9 @@ public abstract class CloudSdkModifyJob extends Job {
 
   @VisibleForTesting
   MessageConsoleStream createNewMessageConsole() {
-    MessageConsole console = MessageConsoleUtilities.findOrCreateConsole(
+    MessageConsole console = MessageConsoleUtilities.getMessageConsole(
         Messages.getString("configuring.cloud.sdk"), // $NON-NLS-1$
-        name -> new MessageConsole(name, null /* imageDescriptor */));
+        null /* imageDescriptor */);
 
     setProperty(IProgressConstants.ACTION_PROPERTY, new ShowConsoleViewAction(console));
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
@@ -46,7 +46,7 @@ public abstract class CloudSdkModifyJob extends Job {
 
   public static final Object CLOUD_SDK_MODIFY_JOB_FAMILY = new Object();
 
-  /** Scheduling rule to prevent running {@code CloudSdkModifyJob} concurrently. */
+  /** Scheduling rule to prevent running {@link CloudSdkModifyJob} concurrently. */
   @VisibleForTesting
   static final MutexRule MUTEX_RULE =
       new MutexRule("for " + CloudSdkModifyJob.class); // $NON-NLS-1$
@@ -102,9 +102,6 @@ public abstract class CloudSdkModifyJob extends Job {
     }
 
     try {
-      if (consoleStream != null) {
-        consoleStream.println(Messages.getString("startModifying"));
-      }
       return modifySdk(monitor);
     } finally {
       cloudSdkLock.writeLock().unlock();

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/ShowConsoleViewAction.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/ShowConsoleViewAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.sdk.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Supplier;
+import org.eclipse.jface.action.Action;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsoleManager;
+
+class ShowConsoleViewAction extends Action {
+
+  private final IConsole console;
+  private final Supplier<IConsoleManager> consoleManagerSupplier;
+
+  ShowConsoleViewAction(IConsole console) {
+    this(console, () -> ConsolePlugin.getDefault().getConsoleManager());
+  }
+
+  @VisibleForTesting
+  ShowConsoleViewAction(IConsole console, Supplier<IConsoleManager> consoleManagerSupplier) {
+    this.console = console;
+    this.consoleManagerSupplier = consoleManagerSupplier;
+  }
+
+  @Override
+  public void run() {
+    consoleManagerSupplier.get().showConsoleView(console);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/messages.properties
@@ -4,6 +4,5 @@ updating.cloud.sdk=Updating Google Cloud SDK
 installing.cloud.sdk.app.engine.java=Installing Google Cloud SDK app extensions for Java
 installing.cloud.sdk.failed=Failed to install the Google Cloud SDK.
 unsupported.os.installation=Google Cloud SDK installation only supported on Windows, Linux, and MacOS.
-startModifying=Installing/upgrading the Cloud SDK... (may take several minutes)
 cloud.sdk.in.use=Google Cloud SDK is in use
 cloud.sdk.not.installed=Google Cloud SDK is not installed


### PR DESCRIPTION
Fixes #2838.

Currently, we see the detailed SDK install/update output only when deploying, for which we have a deploy console. For the background install/update jobs, only shown are the brief monitor task names.

This PR creates a new message console for those jobs. The console is created when the job is instantiated. There will be only one console which will be reused across multiple (sequential) install/update jobs.

When users open the job progress view, they will see task names as hyperlinks:

![selection_005](https://user-images.githubusercontent.com/10523105/36984616-4e28c6b4-2063-11e8-9a1f-05d501c39bce.png)

When clicking on the link, it will bring the console to the front.

![selection_006](https://user-images.githubusercontent.com/10523105/36984623-5042aabe-2063-11e8-9f8f-235f55368066.png)