### PR TITLE
Ensure checksum errors result in error

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/DependencyResolver.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/DependencyResolver.java
@@ -20,14 +20,15 @@ import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
@@ -72,7 +73,11 @@ public class DependencyResolver {
         collectRequest.setRoot(new Dependency(artifact, JavaScopes.RUNTIME));
         collectRequest.setRepositories(centralRepository(system));
         DependencyRequest request = new DependencyRequest(collectRequest, filter);
-        RepositorySystemSession session = context.getRepositorySession();
+
+        // ensure checksum errors result in failure
+        DefaultRepositorySystemSession session =
+            new DefaultRepositorySystemSession(context.getRepositorySession());
+        session.setChecksumPolicy(RepositoryPolicy.CHECKSUM_POLICY_FAIL);
 
         try {
           List<ArtifactResult> artifacts =


### PR DESCRIPTION
Maven's default [`checksumPolicy` appears to be `warn`](https://github.com/apache/maven/blob/master/maven-artifact/src/main/java/org/apache/maven/artifact/repository/ArtifactRepositoryPolicy.java#L74).  This patch sets the checksum policy in our `DependencyResolver` to fail.

Unfortunately I can't figure out how to inject a `RepositoryConnector` or `Transporter` (or one of their providers or factories) to try to inject a transfer failure to test, but I did verify with a breakpoint that the checksum policy was set to `error`.