### PR TITLE
Fix .e45 feature p2-metadata generation and add tests

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.feature/p2.inf
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/p2.inf
@@ -6,7 +6,7 @@ update.matchExp = providedCapabilities.exists(pc | \
   pc.namespace == 'org.eclipse.equinox.p2.iu' && \
     (pc.name == 'com.google.cloud.tools.eclipse.suite.e45.feature.feature.group' || \
       (pc.name == 'com.google.cloud.tools.eclipse.suite.feature.feature.group' && \
-        pc.version ~= '[0.0.0,$version$)')))
+        pc.version ~= range('[0.0.0,$version$)'))))
 
 # Anti-requisites to prevent being installed in conjuction with GPE
  requires.0.namespace = org.eclipse.equinox.p2.iu

--- a/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
@@ -10,4 +10,32 @@
   <artifactId>com.google.cloud.tools.eclipse.suite.feature</artifactId>
   <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
-</project>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-update-metadata</id>
+            <phase>package</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target description="verify p2 metadata for updating from old .e45 feature">
+                <fail message="p2 metadata missing com.google.cloud.tools.eclipse.suite.e45.feature update information">
+                  <condition>
+                    <not>
+                      <resourcecontains resource="${project.build.directory}/p2content.xml"
+                        substring="com.google.cloud.tools.eclipse.suite.e45.feature.feature.group"/>
+                    </not>
+                  </condition>
+                </fail>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  </project>

--- a/gcp-repo/pom.xml
+++ b/gcp-repo/pom.xml
@@ -55,6 +55,29 @@
           <pomDependencies>consider</pomDependencies>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>verify-update-metadata</id>
+            <phase>package</phase>
+            <goals><goal>run</goal></goals>
+            <configuration>
+              <target description="verify p2 metadata for updating from old .e45 feature">
+                <fail message="p2 metadata missing com.google.cloud.tools.eclipse.suite.e45.feature update information">
+                  <condition>
+                    <not>
+                      <resourcecontains resource="${project.build.directory}/targetPlatformRepository/content.xml"
+                        substring="com.google.cloud.tools.eclipse.suite.e45.feature.feature.group"/>
+                    </not>
+                  </condition>
+                </fail>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,12 @@
           <version>3.0.2</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.eclipse.scout</groupId>
           <artifactId>eclipse-settings-maven-plugin</artifactId>
           <version>3.0.2</version>


### PR DESCRIPTION
I get inconsistent results with #2893 where the p2 update metadata wasn't always being picked up.  It turns out I had a missing `range()` in the p2ql expression, and fixing that now ensures the metadata is always generated.  I realized that I can can use ant to test that the metadata was generated.

Fixes #2890