### PR TITLE
Add "Cloud" and "Google Cloud Platform" keywords, and minor reorg

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -14,7 +14,6 @@
          <description>%standard.wizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GAEKeyword"/>
@@ -62,7 +61,6 @@
          <description>%flex.wizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.FlexKeyword"/>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/plugin.xml
@@ -13,9 +13,11 @@
             category="com.google.cloud.tools.eclipse.wizards">
          <description>%standard.wizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GCPKeyword"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GAEKeyword"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GoogleKeyword"/>
          <keywordReference
              id="com.google.cloud.tools.eclipse.appengine.ui.AppEngineKeyword"/>
          <keywordReference
@@ -59,10 +61,12 @@
             category="com.google.cloud.tools.eclipse.wizards">
          <description>%flex.wizard.description</description>
          <selection class="org.eclipse.core.resources.IResource"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
+         <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.FlexKeyword"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GCPKeyword"/>
          <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GAEKeyword"/>
-         <keywordReference id="com.google.cloud.tools.eclipse.appengine.ui.GoogleKeyword"/>
          <keywordReference
              id="com.google.cloud.tools.eclipse.appengine.ui.AppEngineKeyword"/>
          <keywordReference

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.properties
@@ -1,10 +1,7 @@
 providerName=Google Inc.
 pluginName=Cloud Tools for Eclipse App Engine UI Support
 
-# Used for keywords
-googleCloudPlatformAcronym=GCP
 appEngineAcronym=GAE
-googleName=Google
 appEngineName=AppEngine   
 appEngineNameWithSpace=App Engine
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/plugin.xml
@@ -4,12 +4,8 @@
 
   <!-- TODO how can we test that the properties are defined? -->
   <extension point="org.eclipse.ui.keywords">
-    <keyword label="%googleCloudPlatformAcronym"
-             id="com.google.cloud.tools.eclipse.appengine.ui.GCPKeyword"/>
     <keyword label="%appEngineAcronym"
              id="com.google.cloud.tools.eclipse.appengine.ui.GAEKeyword"/>
-    <keyword label="%googleName"
-             id="com.google.cloud.tools.eclipse.appengine.ui.GoogleKeyword"/>
     <keyword label="%appEngineName"
              id="com.google.cloud.tools.eclipse.appengine.ui.AppEngineKeyword"/>
     <keyword label="%appEngineNameWithSpace"
@@ -19,7 +15,6 @@
   </extension>
   <extension
         point="org.eclipse.ui.menus">
-
      <menuContribution
            allPopups="false"
            locationURI="menu:com.google.cloud.tools.eclipse.ui.actions.new?after=appengine.standard">

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/plugin.xml
@@ -76,6 +76,10 @@
           name="%dataflowWizardName"
           project="true">
       <description>%dataflowWizardDescription</description>
+      <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
+      <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
+      <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
+      <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
     </wizard>
   </extension>
 

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/plugin.xml
@@ -77,7 +77,6 @@
           project="true">
       <description>%dataflowWizardDescription</description>
       <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
-      <keywordReference id="com.google.cloud.tools.eclipse.ui.GCPName"/>
       <keywordReference id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
       <keywordReference id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
     </wizard>

--- a/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/PluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.test/src/com/google/cloud/tools/eclipse/ui/PluginXmlTest.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.cloud.tools.eclipse.ui.util;
+package com.google.cloud.tools.eclipse.ui;
 
 import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.tools.eclipse.test.util.BasePluginXmlTest;
+import com.google.cloud.tools.eclipse.ui.util.OpenDropDownMenuHandler;
 import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -27,7 +28,7 @@ public class PluginXmlTest extends BasePluginXmlTest {
   @Test
   public void testExtensionPoint() {
     NodeList extensions = getDocument().getElementsByTagName("extension");
-    assertEquals(2, extensions.getLength());
+    assertEquals(3, extensions.getLength());
 
     // first element is the showPopup command
     Element extension = (Element) extensions.item(0);
@@ -58,6 +59,13 @@ public class PluginXmlTest extends BasePluginXmlTest {
     menuContribution = (Element) menuContributions.item(2);
     assertEquals("menu:com.google.cloud.tools.eclipse.ui.actions", //$NON-NLS-1$
         menuContribution.getAttribute("locationURI")); //$NON-NLS-1$
+
+    // last element is the keywords definition
+    extension = (Element) extensions.item(2);
+    assertEquals(
+        "org.eclipse.ui.keywords", extension.getAttribute("point")); // $NON-NLS-1$ //$NON-NLS-2$
+    NodeList keywords = extension.getElementsByTagName("keyword"); // $NON-NLS-1$
+    assertEquals(3, keywords.getLength());
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.ui/plugin.properties
+++ b/plugins/com.google.cloud.tools.eclipse.ui/plugin.properties
@@ -1,5 +1,10 @@
 providerName=Google Inc.
 pluginName=Cloud Tools for Eclipse Common UI
 
+# Used for keywords
+googleCloudPlatformAcronym=GCP
+googleName=Google
+cloudName=Cloud
+
 googleCloudPlatformName=Google Cloud Platform
 createNewProject = Create New Project

--- a/plugins/com.google.cloud.tools.eclipse.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.ui/plugin.xml
@@ -89,5 +89,16 @@
      </menuContribution>
      
    </extension>
+   <extension
+         point="org.eclipse.ui.keywords">
+    <keyword label="%googleCloudPlatformAcronym"
+             id="com.google.cloud.tools.eclipse.ui.GCPKeyword"/>
+    <keyword label="%googleName"
+             id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
+    <keyword label="%cloudName"
+             id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
+    <keyword label="%googleCloudPlatformName"
+             id="com.google.cloud.tools.eclipse.ui.GCPName"/>
+   </extension>
 
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.ui/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.ui/plugin.xml
@@ -97,8 +97,6 @@
              id="com.google.cloud.tools.eclipse.ui.GoogleKeyword"/>
     <keyword label="%cloudName"
              id="com.google.cloud.tools.eclipse.ui.CloudKeyword"/>
-    <keyword label="%googleCloudPlatformName"
-             id="com.google.cloud.tools.eclipse.ui.GCPName"/>
    </extension>
 
 </plugin>


### PR DESCRIPTION
- creates new "cloud" keyword
- moves non-appengine keywords into `com.google.cloud.tools.eclipse.ui`
- adds non-appengine keywords to dataflow wizards too

Fix #2905 