### PR TITLE
Rename Cloud SDK modify job

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/CloudSdkManagerTest.java
@@ -187,7 +187,7 @@ public class CloudSdkManagerTest {
     private final IStatus result;
 
     private FakeModifyJob(IStatus result) {
-      super("fake job", mock(MessageConsoleStream.class), modifyLock);
+      super(mock(MessageConsoleStream.class), modifyLock);
       this.result = result;
     }
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.test/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJobTest.java
@@ -184,12 +184,12 @@ public class CloudSdkModifyJobTest {
     private boolean modifiedSdk;
 
     private FakeModifyJob(boolean blockOnStart) {
-      super("fake job", mock(MessageConsoleStream.class), readWriteLock);
+      super(mock(MessageConsoleStream.class), readWriteLock);
       this.blockOnStart = blockOnStart;
     }
 
     private FakeModifyJob(MessageConsoleStream consoleStream) {
-      super("fake job", consoleStream, readWriteLock);
+      super(consoleStream, readWriteLock);
       blockOnStart = false;
     }
 

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkInstallJob.java
@@ -44,7 +44,7 @@ public class CloudSdkInstallJob extends CloudSdkModifyJob {
   private static final Logger logger = Logger.getLogger(CloudSdkInstallJob.class.getName());
 
   public CloudSdkInstallJob(MessageConsoleStream consoleStream, ReadWriteLock cloudSdkLock) {
-    super(Messages.getString("installing.cloud.sdk"), consoleStream, cloudSdkLock); // $NON-NLS-1$
+    super(consoleStream, cloudSdkLock);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkModifyJob.java
@@ -54,9 +54,8 @@ public abstract class CloudSdkModifyJob extends Job {
   /** The severity reported on installation failure. */
   protected int failureSeverity = IStatus.ERROR;
 
-  public CloudSdkModifyJob(String jobName, MessageConsoleStream consoleStream,
-      ReadWriteLock cloudSdkLock) {
-    super(jobName);
+  public CloudSdkModifyJob(MessageConsoleStream consoleStream, ReadWriteLock cloudSdkLock) {
+    super(Messages.getString("configuring.cloud.sdk")); // $NON-NLS-1$
     this.consoleStream = consoleStream != null ? consoleStream : createNewMessageConsole();
     this.cloudSdkLock = cloudSdkLock;
     setRule(MUTEX_RULE);

--- a/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkUpdateJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk/src/com/google/cloud/tools/eclipse/sdk/internal/CloudSdkUpdateJob.java
@@ -39,7 +39,7 @@ public class CloudSdkUpdateJob extends CloudSdkModifyJob {
   private static final Logger logger = Logger.getLogger(CloudSdkUpdateJob.class.getName());
 
   public CloudSdkUpdateJob(MessageConsoleStream consoleStream, ReadWriteLock cloudSdkLock) {
-    super(Messages.getString("updating.cloud.sdk"), consoleStream, cloudSdkLock); //$NON-NLS-1$
+    super(consoleStream, cloudSdkLock);
   }
 
   /**


### PR DESCRIPTION
The name will be "Configuring Google Cloud SDK...".

The externalized strings are still used, so they have not been removed from `messages.properties`.