### PR TITLE
Provide App Engine project wizard page directly

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
@@ -31,13 +31,13 @@ import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
 
 public abstract class AppEngineProjectWizard extends Wizard implements INewWizard {
 
-  private final AppEngineWizardPage wizardPage;
+  private final AppEngineWizardPage appEnginePage;
   protected final AppEngineProjectConfig config = new AppEngineProjectConfig();
   private IWorkbench workbench;
 
   public AppEngineProjectWizard(AppEngineWizardPage appEngineWizardPage) {
-    wizardPage = Preconditions.checkNotNull(appEngineWizardPage);
-    addPage(wizardPage);
+    appEnginePage = Preconditions.checkNotNull(appEngineWizardPage);
+    addPage(appEnginePage);
     setNeedsProgressMonitor(true);
   }
 
@@ -91,18 +91,19 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
   }
 
   private void retrieveConfigurationValues() {
-    config.setServiceName(wizardPage.getServiceName());
-    config.setPackageName(wizardPage.getPackageName());
-    config.setRuntimeId(wizardPage.getRuntimeId());
-    config.setProject(wizardPage.getProjectHandle());
-    if (!wizardPage.useDefaults()) {
-      config.setEclipseProjectLocationUri(wizardPage.getLocationURI());
+    config.setServiceName(appEnginePage.getServiceName());
+    config.setPackageName(appEnginePage.getPackageName());
+    config.setRuntimeId(appEnginePage.getRuntimeId());
+    config.setProject(appEnginePage.getProjectHandle());
+    if (!appEnginePage.useDefaults()) {
+      config.setEclipseProjectLocationUri(appEnginePage.getLocationURI());
     }
 
-    config.setAppEngineLibraries(wizardPage.getSelectedLibraries());
+    config.setAppEngineLibraries(appEnginePage.getSelectedLibraries());
 
-    if (wizardPage.asMavenProject()) {
-      config.setUseMaven(wizardPage.getMavenGroupId(), wizardPage.getMavenArtifactId(), wizardPage.getMavenVersion());
+    if (appEnginePage.asMavenProject()) {
+      config.setUseMaven(appEnginePage.getMavenGroupId(), appEnginePage.getMavenArtifactId(),
+          appEnginePage.getMavenVersion());
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
@@ -37,6 +37,7 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
 
   public AppEngineProjectWizard(AppEngineWizardPage appEngineWizardPage) {
     wizardPage = Preconditions.checkNotNull(appEngineWizardPage);
+    addPage(wizardPage);
     setNeedsProgressMonitor(true);
   }
 
@@ -54,7 +55,6 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     Thread.interrupted();
 
     sendAnalyticsPing();
-    addPage(wizardPage);
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
@@ -31,15 +31,16 @@ import org.eclipse.ui.ide.undo.WorkspaceUndoUtil;
 
 public abstract class AppEngineProjectWizard extends Wizard implements INewWizard {
 
-  protected AppEngineWizardPage page = null;
+  private final AppEngineWizardPage wizardPage;
   protected final AppEngineProjectConfig config = new AppEngineProjectConfig();
   private IWorkbench workbench;
 
-  public AppEngineProjectWizard() {
+  public AppEngineProjectWizard(AppEngineWizardPage appEngineWizardPage) {
+    wizardPage = Preconditions.checkNotNull(appEngineWizardPage);
     setNeedsProgressMonitor(true);
   }
 
-  public abstract AppEngineWizardPage createWizardPage();
+  public abstract void sendAnalyticsPing();
 
   public abstract IStatus validateDependencies();
 
@@ -52,14 +53,12 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     // (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2064)
     Thread.interrupted();
 
-    page = createWizardPage();
-    addPage(page);
+    sendAnalyticsPing();
+    addPage(wizardPage);
   }
 
   @Override
   public boolean performFinish() {
-    Preconditions.checkState(page != null);
-
     IStatus status = validateDependencies();
     if (!status.isOK()) {
       StatusUtil.setErrorStatus(this, status.getMessage(), status);
@@ -91,19 +90,19 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     }
   }
 
-  protected void retrieveConfigurationValues() {
-    config.setServiceName(page.getServiceName());
-    config.setPackageName(page.getPackageName());
-    config.setRuntimeId(page.getRuntimeId());
-    config.setProject(page.getProjectHandle());
-    if (!page.useDefaults()) {
-      config.setEclipseProjectLocationUri(page.getLocationURI());
+  private void retrieveConfigurationValues() {
+    config.setServiceName(wizardPage.getServiceName());
+    config.setPackageName(wizardPage.getPackageName());
+    config.setRuntimeId(wizardPage.getRuntimeId());
+    config.setProject(wizardPage.getProjectHandle());
+    if (!wizardPage.useDefaults()) {
+      config.setEclipseProjectLocationUri(wizardPage.getLocationURI());
     }
 
-    config.setAppEngineLibraries(page.getSelectedLibraries());
+    config.setAppEngineLibraries(wizardPage.getSelectedLibraries());
 
-    if (page.asMavenProject()) {
-      config.setUseMaven(page.getMavenGroupId(), page.getMavenArtifactId(), page.getMavenVersion());
+    if (wizardPage.asMavenProject()) {
+      config.setUseMaven(wizardPage.getMavenGroupId(), wizardPage.getMavenArtifactId(), wizardPage.getMavenVersion());
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
@@ -33,17 +33,16 @@ public class AppEngineFlexProjectWizard extends AppEngineProjectWizard {
   private ILibraryRepositoryService repositoryService;
 
   public AppEngineFlexProjectWizard() {
+    super(new AppEngineFlexWizardPage());
     setWindowTitle(Messages.getString("new.app.engine.flex.project"));
   }
 
   @Override
-  public AppEngineFlexWizardPage createWizardPage() {
+  public void sendAnalyticsPing() {
     AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_FLEX);
-
-    return new AppEngineFlexWizardPage();
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
@@ -43,17 +43,16 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
   private ILibraryRepositoryService repositoryService;
 
   public AppEngineStandardProjectWizard() {
+    super(new AppEngineStandardWizardPage());
     setWindowTitle(Messages.getString("new.app.engine.standard.project"));
   }
 
   @Override
-  public AppEngineStandardWizardPage createWizardPage() {
+  public void sendAnalyticsPing() {
     AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
         AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_STANDARD);
-
-    return new AppEngineStandardWizardPage();
   }
 
   @Override


### PR DESCRIPTION
(This doesn't fix #2906. Just the first refactoring step to fix it.)

I believe the reason we previously provided the wizard page through the abstract method was that we needed to dynamically create different pages, including the Cloud-SDK-not-found and Java-component-missing error pages.

The two wizards work as usual.