### PR TITLE
Cause java.util.logging to shunt to slf4j

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -44,11 +44,11 @@
      Bind SLF4j to log over Logback
 
      Unfortunately m2e specifically pulls in Orbit's org.slf4j.api bundle
-     so we cannot use the SLF4j bundles from Maven Central.  Unfortunately
-     Orbit doesn't provide the java.util.logging binding.
+     so we cannot use the SLF4j bundles from Maven Central. 
    -->
    <bundle id="org.slf4j.api" version="0.0.0"/>
    <bundle id="org.slf4j.apis.jcl" version="0.0.0"/>
    <bundle id="org.slf4j.apis.log4j" version="0.0.0"/>
+   <bundle id="org.slf4j.bridge.jul" version="0.0.0"/>
    <bundle id="ch.qos.logback.slf4j" version="0.0.0"/>
 </site>

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1520023122">
+<target name="GCP for Eclipse Neon" sequenceNumber="1520958315">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
@@ -38,6 +38,7 @@
       <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
       <unit id="org.slf4j.apis.jcl" version="1.7.10.v20160208-0839"/>
       <unit id="org.slf4j.apis.log4j" version="1.7.10.v20160208-0839"/>
+      <unit id="org.slf4j.bridge.jul" version="1.7.10.v20160208-0839"/>
       <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
     </location>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -49,6 +49,7 @@ location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
     org.slf4j.api
     org.slf4j.apis.jcl
     org.slf4j.apis.log4j
+    org.slf4j.bridge.jul
     ch.qos.logback.slf4j
 }
 

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1520023081">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1520958331">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.2.v20171130-0906"/>
@@ -38,6 +38,7 @@
       <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
       <unit id="org.slf4j.apis.jcl" version="1.7.10.v20160208-0839"/>
       <unit id="org.slf4j.apis.log4j" version="1.7.10.v20160208-0839"/>
+      <unit id="org.slf4j.bridge.jul" version="1.7.10.v20160208-0839"/>
       <unit id="ch.qos.logback.slf4j" version="1.1.2.v20160301-0943"/>
       <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
     </location>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -49,6 +49,7 @@ location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
     org.slf4j.api
     org.slf4j.apis.jcl
     org.slf4j.apis.log4j
+    org.slf4j.bridge.jul
     ch.qos.logback.slf4j
 }
 

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/mockito-core-1.10.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/objenesis-2.2.jar"/>
+	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.dependencies;singleton:=true
 Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: %providerName
+Bundle-Activator: com.google.cloud.tools.eclipse.test.dependencies.LogConfigurator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
@@ -15,7 +16,8 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.eclipse.wst.xsd.core;bundle-version="[1.1,2.0)",
  org.slf4j.api;bundle-version="[1.7.10,2)",
  org.slf4j.apis.log4j;bundle-version="[1.7.10,2)",
- org.slf4j.apis.jcl;bundle-version="[1.7.10,2)"
+ org.slf4j.apis.jcl;bundle-version="[1.7.10,2)",
+ org.slf4j.bridge.jul;bundle-version="[1.7.10,2)"
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,
    org.mockito.verification,
@@ -107,4 +109,7 @@ Export-Package: org.mockito;provider=google;version="1.10.19";
  org.mockito.verification;provider=google;version="1.10.19";uses:="org.mockito.internal.verification.api,org.mockito.internal.util",
  org.objenesis;provider=google;version="2.2.0";uses:="org.objenesis.instantiator,org.objenesis.strategy"
 Bundle-Classpath: lib/mockito-core-1.10.19.jar,
- lib/objenesis-2.2.jar
+ lib/objenesis-2.2.jar,
+ .
+Import-Package: org.osgi.framework
+Bundle-ActivationPolicy: lazy

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -4,8 +4,9 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: com.google.cloud.tools.eclipse.test.dependencies;singleton:=true
 Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: %providerName
-Bundle-Activator: com.google.cloud.tools.eclipse.test.dependencies.LogConfigurator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Activator: com.google.cloud.tools.eclipse.test.dependencies.LogConfigurator
+Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.hamcrest.core;bundle-version="[1.3.0,1.3.1)";visibility:=reexport,
@@ -18,6 +19,7 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.slf4j.apis.log4j;bundle-version="[1.7.10,2)",
  org.slf4j.apis.jcl;bundle-version="[1.7.10,2)",
  org.slf4j.bridge.jul;bundle-version="[1.7.10,2)"
+Import-Package: org.osgi.framework
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,
    org.mockito.verification,
@@ -111,5 +113,3 @@ Export-Package: org.mockito;provider=google;version="1.10.19";
 Bundle-Classpath: lib/mockito-core-1.10.19.jar,
  lib/objenesis-2.2.jar,
  .
-Import-Package: org.osgi.framework
-Bundle-ActivationPolicy: lazy

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.slf4j.apis.log4j;bundle-version="[1.7.10,2)",
  org.slf4j.apis.jcl;bundle-version="[1.7.10,2)",
  org.slf4j.bridge.jul;bundle-version="[1.7.10,2)"
-Import-Package: org.osgi.framework
+Import-Package: org.osgi.framework,
+ org.slf4j.impl;version="[1.7.10,2)"
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,
    org.mockito.verification,

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
@@ -1,7 +1,11 @@
+source.. = src/
+output.. = target/classes/
 # NB: only include the lib/.jars actually required as lib/ will include referenced bundles
 # including broken hamcrest-1.1
 bin.includes = META-INF/,\
                lib/mockito-core-1.10.19.jar,\
                lib/objenesis-2.2.jar,\
                logback.xml,\
-               plugin.properties
+               plugin.properties,\
+               .
+source.. = src/

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
@@ -8,4 +8,3 @@ bin.includes = META-INF/,\
                logback.xml,\
                plugin.properties,\
                .
-source.. = src/

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/logback.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/logback.xml
@@ -1,4 +1,7 @@
 <configuration scan="true"> 
+  <!-- performance-related requirement for the java.util.logging to SLF4j bridge -->
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender"> 
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
@@ -27,13 +27,11 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public class LogConfigurator implements BundleActivator {
   @Override
   public void start(BundleContext context) throws Exception {
-    System.err.println(">>> INSTALLING JUL -> SLF4J BRIDGE <<<");
     SLF4JBridgeHandler.install();
   }
 
   @Override
   public void stop(BundleContext context) throws Exception {
-    System.err.println(">>> UNINSTALLING JUL -> SLF4J BRIDGE <<<");
     SLF4JBridgeHandler.uninstall();
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.test.dependencies;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Configures <tt>java.util.logging</tt> to redirect to SLF4j.
+ * Useful so that we can output thread details.
+ */
+public class LogConfigurator implements BundleActivator {
+  @Override
+  public void start(BundleContext context) throws Exception {
+    System.err.println(">>> INSTALLING JUL -> SLF4J BRIDGE <<<");
+    SLF4JBridgeHandler.install();
+  }
+
+  @Override
+  public void stop(BundleContext context) throws Exception {
+    System.err.println(">>> UNINSTALLING JUL -> SLF4J BRIDGE <<<");
+    SLF4JBridgeHandler.uninstall();
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LogConfigurator.java
@@ -27,6 +27,8 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 public class LogConfigurator implements BundleActivator {
   @Override
   public void start(BundleContext context) throws Exception {
+    // remove any existing handlers on root logger
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
     SLF4JBridgeHandler.install();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,15 @@
               -Xms40m -Xmx1G -XX:MaxPermSize=512m
               -Djava.awt.headless=true
               -Dlogback.configurationFile=platform:/plugin/com.google.cloud.tools.eclipse.test.dependencies/logback.xml
-              ${os-jvm-flags}</argLine>
+              ${os-jvm-flags}
+            </argLine>
+            <bundleStartLevel>
+              <bundle>
+                 <id>com.google.cloud.tools.eclipse.test.dependencies</id>
+                 <level>1</level>
+                 <autoStart>true</autoStart>
+              </bundle>
+           </bundleStartLevel>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
In debugging #2872, a key observation was that activities were happening on different threads.  `java.util.logging` doesn't log the thread name, [nor can it be configured to do so](https://stackoverflow.com/a/6889151/600339).  Whereas logback can output the thread, and [our logback configuration does so](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/master/plugins/com.google.cloud.tools.eclipse.test.dependencies/logback.xml#L4).  We already shunt log4j and commons-logging into SLF4j and thence into Logback in our tests.

This fix brings in the [java.util.logging → SLF4j bridge](https://www.slf4j.org/api/org/slf4j/bridge/SLF4JBridgeHandler.html) and causes it to be installed by a new bundle-activator for `com.google.cloud.tools.eclipse.test.dependencies`.

Another advantage is that this change will reduce our log size since `java.util.logging`'s default output takes two lines per log record. 