### PR TITLE
Show Analytics opt-in dialog on correct shells

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
@@ -41,8 +41,6 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     setNeedsProgressMonitor(true);
   }
 
-  public abstract void sendAnalyticsPing();
-
   public abstract IStatus validateDependencies();
 
   public abstract CreateAppEngineWtpProject getAppEngineProjectCreationOperation(
@@ -53,8 +51,6 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     // Clear interrupted state
     // (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2064)
     Thread.interrupted();
-
-    sendAnalyticsPing();
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
@@ -38,14 +38,6 @@ public class AppEngineFlexProjectWizard extends AppEngineProjectWizard {
   }
 
   @Override
-  public void sendAnalyticsPing() {
-    AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_FLEX);
-  }
-
-  @Override
   public IStatus validateDependencies() {
     return Status.OK_STATUS;
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexWizardPage.java
@@ -18,6 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.newproject.flex;
 
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineWizardPage;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.PlatformUI;
 
@@ -35,4 +37,13 @@ public class AppEngineFlexWizardPage extends AppEngineWizardPage {
         "com.google.cloud.tools.eclipse.appengine.newproject.NewFlexProjectContext"); //$NON-NLS-1$
   }
 
+  @Override
+  public void createControl(Composite parent) {
+    super.createControl(parent);
+
+    AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_FLEX);
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
@@ -48,14 +48,6 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
   }
 
   @Override
-  public void sendAnalyticsPing() {
-    AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
-        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_STANDARD);
-  }
-
-  @Override
   public IStatus validateDependencies() {
     try {
       boolean fork = true;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardWizardPage.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineWizardPage;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -48,6 +50,16 @@ public class AppEngineStandardWizardPage extends AppEngineWizardPage {
   public void setHelp(Composite container) {
     PlatformUI.getWorkbench().getHelpSystem().setHelp(container,
         "com.google.cloud.tools.eclipse.appengine.newproject.NewStandardProjectContext"); //$NON-NLS-1$
+  }
+
+  @Override
+  public void createControl(Composite parent) {
+    super.createControl(parent);
+
+    AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD,
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE,
+        AnalyticsEvents.APP_ENGINE_NEW_PROJECT_WIZARD_TYPE_STANDARD);
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardLandingPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/page/NewDataflowProjectWizardLandingPage.java
@@ -23,6 +23,8 @@ import com.google.cloud.tools.eclipse.dataflow.core.project.DataflowProjectValid
 import com.google.cloud.tools.eclipse.dataflow.core.project.MajorVersion;
 import com.google.cloud.tools.eclipse.dataflow.ui.Messages;
 import com.google.cloud.tools.eclipse.dataflow.ui.util.ButtonFactory;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
+import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import com.google.cloud.tools.eclipse.util.ArtifactRetriever;
 import com.google.common.base.Strings;
 import java.io.File;
@@ -174,8 +176,7 @@ public class NewDataflowProjectWizardLandingPage extends WizardPage  {
     locationBrowse.setEnabled(false);
 
     projectNameTemplate = addCombo(formComposite, Messages.getString("name.template"), false); //$NON-NLS-1$
-    projectNameTemplate.setToolTipText(
-        Messages.getString("name.template.tooltip")); //$NON-NLS-1$
+    projectNameTemplate.setToolTipText(Messages.getString("name.template.tooltip")); //$NON-NLS-1$
     projectNameTemplate.add("[artifactId]"); //$NON-NLS-1$
     projectNameTemplate.add("[groupId]-[artifactId]"); //$NON-NLS-1$
     projectNameTemplate.setLayoutData(gridSpan(GridData.FILL_HORIZONTAL, 1));
@@ -185,8 +186,10 @@ public class NewDataflowProjectWizardLandingPage extends WizardPage  {
 
     formComposite.layout();
     parent.layout();
+
+    AnalyticsPingManager.getInstance().sendPingOnShell(parent.getShell(),
+        AnalyticsEvents.DATAFLOW_NEW_PROJECT_WIZARD);
   }
-  
 
   private void setHelp(Composite container) {
     PlatformUI.getWorkbench().getHelpSystem().setHelp(container,

--- a/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/wizard/NewDataflowProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.dataflow.ui/src/com/google/cloud/tools/eclipse/dataflow/ui/wizard/NewDataflowProjectWizard.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import java.lang.reflect.InvocationTargetException;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
 
@@ -35,7 +36,6 @@ import org.eclipse.ui.IWorkbench;
 public class NewDataflowProjectWizard extends Wizard implements INewWizard {
   private DataflowProjectCreator creator = DataflowProjectCreator.create();
 
-  private NewDataflowProjectWizardLandingPage landingPage;
   private NewDataflowProjectWizardDefaultRunOptionsPage defaultRunOptionsPage;
 
   @Override
@@ -69,10 +69,7 @@ public class NewDataflowProjectWizard extends Wizard implements INewWizard {
 
   @Override
   public void addPages() {
-    AnalyticsPingManager.getInstance().sendPingOnShell(getShell(),
-        AnalyticsEvents.DATAFLOW_NEW_PROJECT_WIZARD);
-
-    landingPage = new NewDataflowProjectWizardLandingPage(creator);
+    WizardPage landingPage = new NewDataflowProjectWizardLandingPage(creator);
     addPage(landingPage);
 
     defaultRunOptionsPage = new NewDataflowProjectWizardDefaultRunOptionsPage();


### PR DESCRIPTION
Fixes #2906.

@briandealwis can you check if all the three wizards (including the Dataflow one) work on Mac? You can merge with `analytics-dialog-test` as before for testing. They work for me on Linux.