### PR TITLE
Suspend ConvertJob only on Neon

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
+import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.cloud.tools.eclipse.util.Templates;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
@@ -61,10 +62,16 @@ public class StandardFacetInstallDelegate implements IDelegate {
     // Schedule immediately so that it doesn't go into the SLEEPING state. Ensuring the job is
     // active is necessary for unit testing.
     installJob.schedule();
-    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
-    // The first ConvertJob has already been scheduled (which installs JSDT facet), and
-    // this is to suspend the second ConvertJob temporarily.
-    ConvertJobSuspender.suspendFutureConvertJobs();
+    if (isEclipseNeon()) {
+      // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
+      // The first ConvertJob has already been scheduled (which installs JSDT facet), and
+      // this is to suspend the second ConvertJob temporarily.
+      ConvertJobSuspender.suspendFutureConvertJobs();
+    }
+  }
+
+  private static boolean isEclipseNeon() {
+    return CloudToolsInfo.getEclipseVersion().startsWith("4.6");
   }
 
   private static class AppEngineRuntimeInstallJob extends Job {
@@ -103,11 +110,13 @@ public class StandardFacetInstallDelegate implements IDelegate {
     @Override
     protected IStatus run(IProgressMonitor monitor) {
       try {
-        // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
-        // Wait until the first ConvertJob installs the JSDT facet.
-        waitUntilJsdtIsFixedFacet(monitor);
-        if (monitor.isCanceled()) {
-          return Status.CANCEL_STATUS;
+        if (isEclipseNeon()) {
+          // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1155
+          // Wait until the first ConvertJob installs the JSDT facet.
+          waitUntilJsdtIsFixedFacet(monitor);
+          if (monitor.isCanceled()) {
+            return Status.CANCEL_STATUS;
+          }
         }
         AppEngineStandardFacet.installAllAppEngineRuntimes(facetedProject, monitor);
         return Status.OK_STATUS;
@@ -117,8 +126,10 @@ public class StandardFacetInstallDelegate implements IDelegate {
       } catch (InterruptedException ex) {
         return Status.CANCEL_STATUS;
       } finally {
-        // Now resume the second ConvertJob.
-        ConvertJobSuspender.resume();
+        if (isEclipseNeon()) {
+          // Now resume the second ConvertJob.
+          ConvertJobSuspender.resume();
+        }
       }
     }
   }


### PR DESCRIPTION
I believe #1155 affects only Neon: https://bugs.eclipse.org/bugs/show_bug.cgi?id=510377. With this change, creating a new App Engine standard project will be slightly faster on Oyxgen or later.