### PR TITLE
Downgrade GCP Status logging severity

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
@@ -140,7 +140,7 @@ public class PollingStatusServiceImpl implements GcpStatusMonitoringService {
     } catch (IOException ex) {
       currentStatus = new GcpStatus(Severity.ERROR, ex.toString(), null);
     }
-    logger.info("current GCP status = " + currentStatus); //$NON-NLS-1$
+    logger.fine("current GCP status = " + currentStatus); //$NON-NLS-1$
     for (Consumer<GcpStatusMonitoringService> listener : listeners) {
       listener.accept(this);
     }

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
@@ -140,7 +140,6 @@ public class PollingStatusServiceImpl implements GcpStatusMonitoringService {
     } catch (IOException ex) {
       currentStatus = new GcpStatus(Severity.ERROR, ex.toString(), null);
     }
-    logger.fine("current GCP status = " + currentStatus); //$NON-NLS-1$
     for (Consumer<GcpStatusMonitoringService> listener : listeners) {
       listener.accept(this);
     }


### PR DESCRIPTION
This change dials down the logging severity level of the retrieved GCP status as INFO is too high.