### PR TITLE
Add script to copy Kokoro-built repo

### DIFF
--- a/release/copy_repo_to_final_location.py
+++ b/release/copy_repo_to_final_location.py
@@ -22,7 +22,7 @@ def _AskRepoOrigin():
   print
   print "#"
   print "# Enter the GCS URL of the Kokoro-built repo."
-  print '# ("Artficat location" in the "jar_signing" success email.)'
+  print '# ("Artifact location" in the "jar_signing" success email.)'
   url = raw_input("URL? ")
 
   gcs_url = _FormatGcsUrl(url)

--- a/release/copy_repo_to_final_location.py
+++ b/release/copy_repo_to_final_location.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python2
+
+"""Copies a Kokoro-built CT4E release to a permenant location and makes it
+publicly available.
+
+The GCS location of a Kokoro-built repo is not suitable for direct release or
+repo management. An example location:
+
+    gs://kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/34/20180323-215548
+
+As a final step, we need to copy such a repo to a permanet location, e.g.:
+
+    gs://cloud-tools-for-eclipse/1.6.1
+"""
+
+import re
+import subprocess
+import sys
+
+
+def _AskRepoOrigin():
+  print
+  print "#"
+  print "# Enter the Cloud Console GCS URL of the Kokoro-built repo."
+  print '# ("Artficat location" in the "jar_signing" success email.)'
+  print "#"
+  gcs_url = raw_input("URL? ")
+
+  match_obj = re.search(
+      r'kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/\d+/[\d-]+$',
+      gcs_url)
+  if match_obj:
+    return "gs://" + match_obj.group()
+  else:
+    print "Wrong URL. Try again."
+    return _AskRepoOrigin()
+
+
+def _AskVersion():
+  print
+  print "#"
+  print "# Enter the CT4E version (e.g., 9.9.9)."
+  print '# (The name for a subdirectory of "gs://cloud-tools-for-eclipse/'
+  print "# where the Kokoro-built repo will be print copied into."
+  print "#"
+  version = raw_input("Version? ")
+
+  match_obj = re.search(r'^\d+\.\d+\.\d+$', version)
+  if match_obj:
+    return version
+  else:
+    print "Wrong format. Try again."
+    return _AskVersion()
+
+
+def _GcsLocationExists(gcs_location):
+  try:
+    subprocess.check_output(
+        ["gsutil", "ls", gcs_location], stderr=subprocess.STDOUT)
+    return True
+  except subprocess.CalledProcessError:
+    return False
+
+
+def main(argv):
+  gcs_origin = _AskRepoOrigin()
+  version = _AskVersion()
+  gcs_destination = "gs://cloud-tools-for-eclipse/" + version
+
+  if _GcsLocationExists(gcs_destination):
+    print
+    print "#"
+    print "# The destination directory already exists. If the version you"
+    print "# entered is correct, delete it first and try again."
+    print "#"
+    print "# Command to delete:"
+    print "# gsutil -m rm " + gcs_destination + "/**"
+    print "#"
+    exit(1)
+
+  # Copy the repo
+  subprocess.check_call(
+      ["gsutil", "-m", "cp", "-R", gcs_origin, gcs_destination])
+
+  # Make it publicly available
+  subprocess.check_call(
+      ["gsutil", "-m", "acl", "ch", "-R", "-u", "AllUsers:R", gcs_destination])
+
+  print
+  print "#"
+  print "# Copy done! The repo URL for installation:"
+  print "#"
+  print "# https://storage.googleapis.com/cloud-tools-for-eclipse/" + version
+  print "#"
+
+
+if __name__ == "__main__":
+   main(sys.argv[1:])

--- a/release/copy_repo_to_final_location.py
+++ b/release/copy_repo_to_final_location.py
@@ -21,9 +21,8 @@ import sys
 def _AskRepoOrigin():
   print
   print "#"
-  print "# Enter the Cloud Console GCS URL of the Kokoro-built repo."
+  print "# Enter the GCS URL of the Kokoro-built repo."
   print '# ("Artficat location" in the "jar_signing" success email.)'
-  print "#"
   gcs_url = raw_input("URL? ")
 
   match_obj = re.search(
@@ -40,9 +39,6 @@ def _AskVersion():
   print
   print "#"
   print "# Enter the CT4E version (e.g., 9.9.9)."
-  print '# (The name for a subdirectory of "gs://cloud-tools-for-eclipse/'
-  print "# where the Kokoro-built repo will be print copied into."
-  print "#"
   version = raw_input("Version? ")
 
   match_obj = re.search(r'^\d+\.\d+\.\d+$', version)
@@ -75,7 +71,6 @@ def main(argv):
     print "#"
     print "# Command to delete:"
     print "# gsutil -m rm " + gcs_destination + "/**"
-    print "#"
     exit(1)
 
   # Copy the repo
@@ -91,7 +86,6 @@ def main(argv):
   print "# Copy done! The repo URL for installation:"
   print "#"
   print "# https://storage.googleapis.com/cloud-tools-for-eclipse/" + version
-  print "#"
 
 
 if __name__ == "__main__":

--- a/release/copy_repo_to_final_location_test.py
+++ b/release/copy_repo_to_final_location_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python2
+
+import unittest
+from copy_repo_to_final_location import _IsVersionString
+from copy_repo_to_final_location import _FormatGcsUrl
+from copy_repo_to_final_location import _GcsLocationExists
+from copy_repo_to_final_location import _GetCopyCommand
+from copy_repo_to_final_location import _GetPublicAccessCommand
+
+
+class CopyRepoToFinalLocationTest(unittest.TestCase):
+
+  def testIsVersionString_WrongInput(self):
+    self.assertFalse(_IsVersionString("invalid version"))
+
+  def testIsVersionString(self):
+    self.assertTrue(_IsVersionString("1.6.0"));
+
+  def testIsVersionString_WholeString(self):
+    self.assertFalse(_IsVersionString(" 1.6.0"));
+    self.assertFalse(_IsVersionString("1.6.0 "));
+
+  def testIsVersionString_MultiDigit(self):
+    self.assertTrue(_IsVersionString("12.345.67"));
+
+  def testFormatGcsUrl_WrongInput(self):
+    self.assertFalse(_FormatGcsUrl("invalid URL"))
+
+  def testFormatGcsUrl_MinimalUrl(self):
+    self.assertEquals("gs://kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/34/20180323-215548",
+        _FormatGcsUrl("kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/34/20180323-215548"))
+
+  def testFormatGcsUrl_TrailingSlash(self):
+    self.assertFalse(_FormatGcsUrl("kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/34/20180323-215548/"))
+
+  def testFormatGcsUrl_InvalidJobNumber(self):
+    self.assertFalse(_FormatGcsUrl("kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/number/20180323-215548"))
+
+  def testFormatGcsUrl_InvalidTimestamp(self):
+    self.assertFalse(_FormatGcsUrl("kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/34/timestamp"))
+
+  def testFormatGcsUrl_GcslUrl(self):
+    self.assertEquals("gs://kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/13/20180322-160751",
+        _FormatGcsUrl("gs://kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/13/20180322-160751"))
+
+  def testFormatGcsUrl_CloudConsoleUrl(self):
+    self.assertEquals("gs://kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/21/20180323-101656",
+        _FormatGcsUrl("https://console.cloud.google.com/storage/browser/kokoro-ct4e-release/prod/google-cloud-eclipse/ubuntu/jar_signing/21/20180323-101656"))
+
+  def testGcsLocationExists_ExistingLocation(self):
+    self.assertTrue(_GcsLocationExists("gs://cloud-tools-for-eclipse/1.6.0"))
+
+  def testGcsLocationExists_NonExistingLocation(self):
+    self.assertEqual(False,
+        _GcsLocationExists("gs://cloud-tools-for-eclipse/non-existing"))
+
+  def testGetCopyCommand(self):
+    self.assertEquals(["gsutil", "-m", "cp", "-R", "origin", "destination"],
+        _GetCopyCommand("origin", "destination"))
+
+  def testGetPublicAccessCommand(self):
+    self.assertEquals(
+        ["gsutil", "-m", "acl", "ch", "-R", "-u", "AllUsers:R", "target"],
+        _GetPublicAccessCommand("target"))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
I tried Python this time. I'm completely new to Python.

This is a post-build script, to copy a Kokoro-built repo to a final, permanent GCS location (e.g., `gs://cloud-tools-for-eclipse/1.6.1`).

What it does is actually simple:
1. Asks the GCS URL of a Kokoro-built URL.
1. Asks the CT4E version (for the name of a final GCS location).
1. Halts if the destination directory already exists.
1. Copy the repo.
1. Make the repo publicly accessible.