### PR TITLE
Change importProjects to return a map of name -> project

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeClassicMigratorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeClassicMigratorTest.java
@@ -20,10 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.tools.eclipse.appengine.compat.gpe.GpeMigrator;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -46,10 +45,14 @@ public class GpeClassicMigratorTest {
 
   @Before
   public void setUp() throws IOException, CoreException {
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "test-projects/GPE-classic-project.zip", false /* checkBuildErrors */, monitor);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(),
+            "test-projects/GPE-classic-project.zip",
+            false /* checkBuildErrors */,
+            monitor);
     assertEquals(1, projects.size());
-    gpeProject = projects.get(0);
+    gpeProject = projects.values().iterator().next();
   }
 
   @After

--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeFacetedMigratorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeFacetedMigratorTest.java
@@ -21,10 +21,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.google.cloud.tools.eclipse.appengine.compat.gpe.GpeMigrator;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -51,10 +50,14 @@ public class GpeFacetedMigratorTest {
 
   @Before
   public void setUp() throws IOException, CoreException {
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "test-projects/GPE-faceted-project.zip", false /* checkBuildErrors */, monitor);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(),
+            "test-projects/GPE-faceted-project.zip",
+            false /* checkBuildErrors */,
+            monitor);
     assertEquals(1, projects.size());
-    gpeProject = projects.get(0);
+    gpeProject = projects.values().iterator().next();
   }
 
   @After

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallationTest.java
@@ -27,7 +27,7 @@ import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -49,14 +49,14 @@ public class StandardFacetInstallationTest {
 
   public final ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
-  private List<IProject> projects;
+  private Map<String, IProject> projects;
 
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator().withFacets();
 
   @After
   public void tearDown() throws CoreException {
     if (projects != null) {
-      for (IProject project : projects) {
+      for (IProject project : projects.values()) {
         try {
           project.delete(true, null);
         } catch (IllegalArgumentException ex) {
@@ -75,7 +75,7 @@ public class StandardFacetInstallationTest {
     projects = ProjectUtils.importProjects(getClass(),
         "projects/test-dynamic-web-project.zip", true /* checkBuildErrors */, null);
     assertEquals(1, projects.size());
-    IProject project = projects.get(0);
+    IProject project = projects.values().iterator().next();
     IFacetedProject facetedProject = ProjectFacetsManager.create(project);
     // verify that the appengine-web.xml is installed in the dynamic web root folder
     AppEngineStandardFacet.installAppEngineFacet(facetedProject, true, null);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/WebProjectUtilTest.java
@@ -29,7 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.resources.IFile;
@@ -277,10 +277,11 @@ public class WebProjectUtilTest {
       throws CoreException, IOException {
     // WTP's Dynamic Web Project with multiple <wb-resource> elements
     // - looking up a file should look in the wb-resource in order
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(), "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
     assertEquals(1, projects.size());
-    importedProject = projects.get(0);
+    importedProject = projects.values().iterator().next();
 
     createFile(importedProject, new Path("target/m2e-wtp/web-resources/WEB-INF/foo.txt"),
         asInputStream("m2e-wtp"));
@@ -310,10 +311,11 @@ public class WebProjectUtilTest {
       throws CoreException, IOException {
     // WTP's Dynamic Web Project with multiple <wb-resource> elements
     // - creating a file should be put in the defaultRootSource
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(), "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
     assertEquals(1, projects.size());
-    importedProject = projects.get(0);
+    importedProject = projects.values().iterator().next();
 
     IFile fooTxt =
         WebProjectUtil.createFileInWebInf(importedProject, new Path("foo.txt"), asInputStream("foo"),
@@ -331,10 +333,11 @@ public class WebProjectUtilTest {
       throws CoreException, IOException {
     // WTP's Dynamic Web Project with multiple <wb-resource> elements
     // - creating a file should be put in the defaultRootSource
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(), "projects/test-dynamic-web-project-dynamicrootsource.zip", true, null);
     assertEquals(1, projects.size());
-    importedProject = projects.get(0);
+    importedProject = projects.values().iterator().next();
     IFolder libFolder = WebProjectUtil.createFolderInWebInf(importedProject, new Path("lib"), null);
 
     // lib should be created in the <wb-resource> tagged with `defaultRootSource`

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -26,7 +26,7 @@ import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.common.base.Stopwatch;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import org.eclipse.core.resources.IProject;
@@ -50,7 +50,7 @@ public class LocalAppEnginePublishOperationTest {
   @Rule
   public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
-  private List<IProject> projects;
+  private Map<String, IProject> projects;
   private IProject serverProject;
   private IProject sharedProject;
   private IModule serverModule;
@@ -64,8 +64,8 @@ public class LocalAppEnginePublishOperationTest {
     assertEquals(2, projects.size());
     Predicate<IProject> isServerProject = project -> "sox-server".equals(project.getName());
     Predicate<IProject> isSharedProject = project -> "sox-shared".equals(project.getName());
-    serverProject = projects.stream().filter(isServerProject).findFirst().get();
-    sharedProject = projects.stream().filter(isSharedProject).findFirst().get();
+    serverProject = projects.get("sox-server");
+    sharedProject = projects.get("sox-shared");
 
     // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/1798
     Stopwatch stopwatch = Stopwatch.createStarted();
@@ -94,7 +94,7 @@ public class LocalAppEnginePublishOperationTest {
   @After
   public void tearDown() throws CoreException {
     if (projects != null) {
-      for (IProject project : projects) {
+      for (IProject project : projects.values()) {
         project.delete(true, null);
       }
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -62,8 +61,6 @@ public class LocalAppEnginePublishOperationTest {
     projects = ProjectUtils.importProjects(getClass(),
         "projects/test-submodules.zip", true /* checkBuildErrors */, null);
     assertEquals(2, projects.size());
-    Predicate<IProject> isServerProject = project -> "sox-server".equals(project.getName());
-    Predicate<IProject> isSharedProject = project -> "sox-shared".equals(project.getName());
     serverProject = projects.get("sox-server");
     sharedProject = projects.get("sox-shared");
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/GpeConversionTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/GpeConversionTest.java
@@ -24,7 +24,7 @@ import com.google.cloud.tools.eclipse.appengine.facets.convert.AppEngineStandard
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
+import java.util.Map;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.jobs.Job;
@@ -63,11 +63,10 @@ public class GpeConversionTest {
 
   private void convertGpeProject(URL zipFile)
       throws CoreException, IOException, InterruptedException {
-    List<IProject> projects =
-        ProjectUtils.importProjects(zipFile,
-        false /* checkBuildErrors */, null);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(zipFile, false /* checkBuildErrors */, null);
     assertEquals(1, projects.size());
-    project = projects.get(0);
+    project = projects.values().iterator().next();
     IFacetedProject facetedProject = ProjectFacetsManager.create(project,
         true /* convert to faceted project if necessary */, null /* no monitor here */);
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.eclipse.test.util.ZipUtil;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -45,7 +46,7 @@ public abstract class ChildModuleWarPublishTest {
   public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   private static final IProgressMonitor monitor = new NullProgressMonitor();
-  private static List<IProject> allProjects;
+  private static Map<String, IProject> allProjects;
   private static IProject project;
 
   protected abstract List<String> getExpectedChildModuleNames();
@@ -54,18 +55,14 @@ public abstract class ChildModuleWarPublishTest {
       throws IOException, CoreException {
     allProjects = ProjectUtils.importProjects(ChildModuleWarPublishTest.class,
         testZip, false /* checkBuildErrors */, monitor);
-    for (IProject loaded : allProjects) {
-      if (loaded.getName().equals(mainProject)) {
-        project = loaded;
-      }
-    }
+    project = allProjects.get(mainProject);
     assertNotNull(project);
   }
 
   @AfterClass
   public static void tearDown() {
-    ProjectUtils.waitForProjects(allProjects);
-    for (IProject project : allProjects) {
+    ProjectUtils.waitForProjects(allProjects.values());
+    for (IProject project : allProjects.values()) {
       try {
         project.delete(true, null);
       } catch (CoreException | RuntimeException ex) {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/FlexMavenPackagedProjectStagingDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/FlexMavenPackagedProjectStagingDelegateTest.java
@@ -24,7 +24,7 @@ import com.google.cloud.tools.eclipse.appengine.deploy.flex.FlexMavenPackagedPro
 import com.google.cloud.tools.eclipse.test.util.project.JavaRuntimeUtils;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -43,11 +43,12 @@ public class FlexMavenPackagedProjectStagingDelegateTest {
   public void testStage_springBoot() throws IOException, CoreException {
     Assume.assumeTrue("Only for JavaSE-8", JavaRuntimeUtils.hasJavaSE8());
 
-    List<IProject> projects = ProjectUtils.importProjects(getClass(),
-        "test-projects/spring-boot-test.zip", false /* checkBuildErrors */, null);
+    Map<String, IProject> projects =
+        ProjectUtils.importProjects(
+            getClass(), "test-projects/spring-boot-test.zip", false /* checkBuildErrors */, null);
     assertEquals(1, projects.size());
 
-    IProject project = projects.get(0);
+    IProject project = projects.values().iterator().next();
     IPath safeWorkDirectory = project.getFolder("safe-work-directory").getLocation();
     IPath stagingDirectory = project.getFolder("staging-result").getLocation();
     IPath appEngineDirectory = project.getFolder("src/main/appengine").getLocation();

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -25,7 +25,6 @@ import com.google.cloud.tools.eclipse.test.util.ZipUtil;
 import com.google.cloud.tools.eclipse.test.util.reflection.ReflectionUtil;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -34,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +128,7 @@ public class ProjectUtils {
 
     // import the projects
     progress.setWorkRemaining(10 * projectFiles.size() + 10);
-    Map<String, IProject> projects = Maps.newLinkedHashMap();
+    Map<String, IProject> projects = new LinkedHashMap<>();
     System.out.printf("Importing %d projects:\n", projectFiles.size());
     for (IPath projectFile : projectFiles) {
       System.out.println("    " + projectFile);


### PR DESCRIPTION
Change `ProjectUtils.importProject()` to return a map of _project-name_ → _project, since we have this information.  Simplifies `LocalAppEnginePublishOperationTest`.