### PR TITLE
Prepare releasing 1.6.1

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.cloud.tools.eclipse.suite.feature"
       label="Google Cloud Platform for Eclipse"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="Google LLC"
       plugin="com.google.cloud.tools.eclipse.appengine.ui"
       license-feature="com.google.licenses.apache_v2">

--- a/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
@@ -8,7 +8,7 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.suite.feature</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <build>

--- a/gcp-repo/metadata.product
+++ b/gcp-repo/metadata.product
@@ -9,7 +9,7 @@
   .p2.inf).  p2 generates unique qualifiers for categories, so it would be
   best for our non-release builds to have unique versions too.
 -->
-<product uid="com.google.cloud.tools.eclipse.dist" version="1.6.0.qualifier" useFeatures="true" includeLaunchers="false">
+<product uid="com.google.cloud.tools.eclipse.dist" version="1.6.1.qualifier" useFeatures="true" includeLaunchers="false">
 
    <configIni use="default">
    </configIni>


### PR DESCRIPTION
It doesn't matter when we merge this, as long as we make a cut after this. (The actual cut we build against is determined at the time of tagging the repo.)