### PR TITLE
Do not show exception toString() in status menu

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
@@ -26,9 +26,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
 import java.net.Proxy;
 import java.net.Proxy.Type;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URLConnection;
 import java.net.UnknownHostException;
@@ -140,13 +140,14 @@ public class PollingStatusServiceImpl implements GcpStatusMonitoringService {
               new GcpStatus(highestSeverity, Joiner.on(", ").join(affectedServices), activeIncidents); //$NON-NLS-1$
         }
       }
-    } catch (UnknownHostException | NoRouteToHostException ex) {
-      logger.log(Level.WARNING, "Cannot connect to GCP", ex); //$NON-NLS1$
+    } catch (UnknownHostException | SocketException ex) {
+      logger.log(Level.WARNING, "Cannot connect to GCP: " + ex); // $NON-NLS1$
       currentStatus =
           new GcpStatus(
               Severity.ERROR, Messages.getString("cannot.connect.to.gcp"), null); //$NON-NLS1$
     } catch (IOException ex) {
-      logger.log(Level.WARNING, "Failure to retrieve GCP status", ex); //$NON-NLS1$
+      // Could be a JSON error
+      logger.log(Level.WARNING, "Failure retrieving GCP status", ex); // $NON-NLS1$
       currentStatus =
           new GcpStatus(
               Severity.ERROR, Messages.getString("failure.retrieving.status"), null); //$NON-NLS1$

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
@@ -138,7 +139,10 @@ public class PollingStatusServiceImpl implements GcpStatusMonitoringService {
         }
       }
     } catch (IOException ex) {
-      currentStatus = new GcpStatus(Severity.ERROR, ex.toString(), null);
+      logger.log(Level.WARNING, "Unable to retrieve GCP status", ex); //$NON-NLS1$
+      currentStatus =
+          new GcpStatus(
+              Severity.ERROR, Messages.getString("failure.retrieving.status"), null); //$NON-NLS1$
     }
     for (Consumer<GcpStatusMonitoringService> listener : listeners) {
       listener.accept(this);

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/PollingStatusServiceImpl.java
@@ -26,10 +26,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
 import java.net.Proxy;
 import java.net.Proxy.Type;
 import java.net.URI;
 import java.net.URLConnection;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -138,8 +140,13 @@ public class PollingStatusServiceImpl implements GcpStatusMonitoringService {
               new GcpStatus(highestSeverity, Joiner.on(", ").join(affectedServices), activeIncidents); //$NON-NLS-1$
         }
       }
+    } catch (UnknownHostException | NoRouteToHostException ex) {
+      logger.log(Level.WARNING, "Cannot connect to GCP", ex); //$NON-NLS1$
+      currentStatus =
+          new GcpStatus(
+              Severity.ERROR, Messages.getString("cannot.connect.to.gcp"), null); //$NON-NLS1$
     } catch (IOException ex) {
-      logger.log(Level.WARNING, "Unable to retrieve GCP status", ex); //$NON-NLS1$
+      logger.log(Level.WARNING, "Failure to retrieve GCP status", ex); //$NON-NLS1$
       currentStatus =
           new GcpStatus(
               Severity.ERROR, Messages.getString("failure.retrieving.status"), null); //$NON-NLS1$

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/messages.properties
@@ -1,2 +1,3 @@
 poll.job.name=Retrieve Google Cloud Platform status
+cannot.connect.to.gcp=Cannot connect to Google Cloud Platform
 failure.retrieving.status=Failure retrieving GCP status

--- a/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/src/com/google/cloud/tools/eclipse/ui/status/messages.properties
@@ -1,1 +1,2 @@
 poll.job.name=Retrieve Google Cloud Platform status
+failure.retrieving.status=Failure retrieving GCP status


### PR DESCRIPTION
fix #3006 Shows _Cannot connect to Google Cloud Platform_ on connection errors (e.g., UnknownHostException or NoRouteToHostException), and _Failure retrieving GCP status_ on any other IOExceptions (e.g., JSON parsing error or HTTP non-2XX code.