### PR TITLE
Disable library list check listener in test

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
@@ -52,6 +52,9 @@ public class BuildPathTest {
 
   @Before
   public void setUp() throws JavaModelException {
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2758
+    Activator.removeLibraryListCheckListener();
+
     project = projectCreator.getJavaProject();
     initialClasspathSize = project.getRawClasspath().length;
     assertNull(BuildPath.findMasterContainer(project));
@@ -90,8 +93,6 @@ public class BuildPathTest {
 
   @Test
   public void testCheckLibraries() throws CoreException {
-    Activator.removeLibraryListCheckListener();
-
     IPath librariesIdPath = new Path(
         ".settings/com.google.cloud.tools.eclipse.appengine.libraries/_libraries.container");
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/BuildPathTest.java
@@ -90,9 +90,10 @@ public class BuildPathTest {
 
   @Test
   public void testCheckLibraries() throws CoreException {
-    IPath librariesIdPath =
-        new Path(".settings").append(LibraryClasspathContainer.CONTAINER_PATH_PREFIX)
-            .append("_libraries.container");
+    Activator.removeLibraryListCheckListener();
+
+    IPath librariesIdPath = new Path(
+        ".settings/com.google.cloud.tools.eclipse.appengine.libraries/_libraries.container");
 
     // original classpath without our master-library container
     IClasspathEntry[] originalClasspath = project.getRawClasspath();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Activator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Activator.java
@@ -85,7 +85,7 @@ public class Activator implements BundleActivator {
   }
 
   @VisibleForTesting
-  static void removeLibraryListCheckListener() {
+  public static void removeLibraryListCheckListener() {
     JavaCore.removeElementChangedListener(listener);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Activator.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/Activator.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -36,7 +37,7 @@ public class Activator implements BundleActivator {
    * Listen for changes to Java project classpath containers. If our Google Cloud Libraries
    * container has been removed, then clean up any definition files.
    */
-  private IElementChangedListener listener = new IElementChangedListener() {
+  private static final IElementChangedListener listener = new IElementChangedListener() {
     @Override
     public void elementChanged(ElementChangedEvent event) {
       visit(event.getDelta());
@@ -80,6 +81,11 @@ public class Activator implements BundleActivator {
 
   @Override
   public void stop(BundleContext context) {
+    removeLibraryListCheckListener();
+  }
+
+  @VisibleForTesting
+  static void removeLibraryListCheckListener() {
     JavaCore.removeElementChangedListener(listener);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CreateAppEngineWtpProjectTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.Activator;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.MavenCoordinates;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
@@ -82,6 +83,9 @@ public abstract class CreateAppEngineWtpProjectTest {
 
   @Before
   public void setUp() throws CoreException {
+    // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2996
+    Activator.removeLibraryListCheckListener();
+
     IWorkspace workspace = ResourcesPlugin.getWorkspace();
     project = workspace.getRoot().getProject("testproject" + Math.random());
     config.setProject(project);


### PR DESCRIPTION
Fixes #2758.

The listener spawns a workspace job that calls `BuildPath.checkLibraryList()`, which is the method of interest in this test. Removing the listener seems to fix it. Running `testCheckLibraries()` thousand times in a loop doesn't seem to fail after this change.

Also attempts to fix the flakyness in #2996 (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2996#issuecomment-379330728).