### PR TITLE
Configurable build version

### DIFF
--- a/gcp-repo/pom.xml
+++ b/gcp-repo/pom.xml
@@ -13,8 +13,19 @@
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 
+  <properties>
+	<product.version.qualifier.prefix/>  <!-- 0-length string by default -->
+  </properties>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <configuration>
+          <format>${product.version.qualifier.prefix}yyyyMMddHHmm</format>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-repository-plugin</artifactId>

--- a/gcp-repo/pom.xml
+++ b/gcp-repo/pom.xml
@@ -13,19 +13,8 @@
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
 
-  <properties>
-	<product.version.qualifier.prefix/>  <!-- 0-length string by default -->
-  </properties>
-
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-packaging-plugin</artifactId>
-        <configuration>
-          <format>${product.version.qualifier.prefix}yyyyMMddHHmm</format>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-repository-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
   <properties>
     <tycho.version>1.1.0</tycho.version>
     <tycho-extras.version>1.0.0</tycho-extras.version>
+    <product.version.qualifier.postfix/>  <!-- 0-length string by default -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>oxygen</eclipse.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -259,6 +260,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <format>yyyyMMddHHmm${product.version.qualifier.postfix}</format>
           <timestampProvider>${tycho.buildtimestamp.provider}</timestampProvider>
           <jgit.dirtyWorkingTree>${jgit.dirtyWorkingTree}</jgit.dirtyWorkingTree>
           <jgit.ignore>


### PR DESCRIPTION
Regarding #3016.

Initially I put the format configuration only in `gcp-repo/pom.xml`, which added the a postfix only to the display (product) version. I plan to add `-post-release-nightly` so that it would look like `1.6.1.201804251802-post-release-nightly`. However, I thought it is actually nice to put such a postfix to the feature version too, which will clearly show us if the installed version is a nightly build, e.g., in the bug reported from our menu. So I added it to the top-level `pom.xml`.

Things work naturally and properly when it comes to upgrading, as the postfix is the last item to compare. In terms of comparing versions, `1.6.1.201804251802-post-release-nightly` comes after `1.6.1.201804251802`, which matches my plan to build `1.6.1.201804251802-post-release-nightly` after releasing `1.6.1.201804251802`.

When not providing the postfix property, there would be no change to the current version scheme.