### PR TITLE
Secure scheduling rule for CreateAppEngineStandardWtpProjectTest

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizardTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizardTest.java
@@ -29,11 +29,6 @@ public class AppEngineFlexProjectWizardTest {
   }
 
   @Test
-  public void testValidateDependencies() {
-    Assert.assertTrue(wizard.validateDependencies().isOK());
-  }
-
-  @Test
   public void testAddPages() {
     wizard.addPages();
     Assert.assertFalse(wizard.canFinish());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
@@ -80,6 +80,8 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
     ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot();
     try {
+      // CreateAppEngineWtpProject/WorkspaceModificationOperation normally acquires the
+      // workspace lock in `run()`
       Job.getJobManager().beginRule(rule, null);
       creator.execute(monitor);
     } finally {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
@@ -78,11 +78,12 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
     libraries.add(library);
     config.setAppEngineLibraries(libraries);
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
+    
+    // CreateAppEngineWtpProject/WorkspaceModificationOperation normally acquires the
+    // workspace lock in `run()`
     ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot();
+    Job.getJobManager().beginRule(rule, null);
     try {
-      // CreateAppEngineWtpProject/WorkspaceModificationOperation normally acquires the
-      // workspace lock in `run()`
-      Job.getJobManager().beginRule(rule, null);
       creator.execute(monitor);
     } finally {
       Job.getJobManager().endRule(rule);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
@@ -32,8 +32,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -75,7 +78,13 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
     libraries.add(library);
     config.setAppEngineLibraries(libraries);
     CreateAppEngineWtpProject creator = newCreateAppEngineWtpProject();
-    creator.execute(monitor);
+    ISchedulingRule rule = ResourcesPlugin.getWorkspace().getRoot();
+    try {
+      Job.getJobManager().beginRule(rule, null);
+      creator.execute(monitor);
+    } finally {
+      Job.getJobManager().endRule(rule);
+    }
 
     assertTrue(project.hasNature(JavaCore.NATURE_ID));
     assertAppEngineApiSdkOnClasspath();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/AppEngineProjectWizard.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.lang.reflect.InvocationTargetException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.ui.INewWizard;
@@ -41,8 +40,6 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
     setNeedsProgressMonitor(true);
   }
 
-  public abstract IStatus validateDependencies();
-
   public abstract CreateAppEngineWtpProject getAppEngineProjectCreationOperation(
       AppEngineProjectConfig config, IAdaptable uiInfoAdapter);
 
@@ -55,12 +52,6 @@ public abstract class AppEngineProjectWizard extends Wizard implements INewWizar
 
   @Override
   public boolean performFinish() {
-    IStatus status = validateDependencies();
-    if (!status.isOK()) {
-      StatusUtil.setErrorStatus(this, status.getMessage(), status);
-      return false;
-    }
-
     retrieveConfigurationValues();
 
     // todo set up

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexProjectWizard.java
@@ -26,8 +26,6 @@ import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
 import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 
 public class AppEngineFlexProjectWizard extends AppEngineProjectWizard {
   @Inject
@@ -36,11 +34,6 @@ public class AppEngineFlexProjectWizard extends AppEngineProjectWizard {
   public AppEngineFlexProjectWizard() {
     super(new AppEngineFlexWizardPage());
     setWindowTitle(Messages.getString("new.app.engine.flex.project"));
-  }
-
-  @Override
-  public IStatus validateDependencies() {
-    return Status.OK_STATUS;
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
@@ -22,18 +22,11 @@ import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfi
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectWizard;
 import com.google.cloud.tools.eclipse.appengine.newproject.CreateAppEngineWtpProject;
 import com.google.cloud.tools.eclipse.appengine.newproject.Messages;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.cloud.tools.eclipse.usagetracker.AnalyticsEvents;
 import com.google.cloud.tools.eclipse.usagetracker.AnalyticsPingManager;
-import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import com.google.common.collect.ImmutableMap;
-import java.lang.reflect.InvocationTargetException;
 import javax.inject.Inject;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.jface.operation.IRunnableWithProgress;
 
 public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
 
@@ -46,27 +39,6 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
   public AppEngineStandardProjectWizard() {
     super(new AppEngineStandardWizardPage());
     setWindowTitle(Messages.getString("new.app.engine.standard.project"));
-  }
-
-  @Override
-  public IStatus validateDependencies() {
-    try {
-      boolean fork = true;
-      boolean cancelable = true;
-      DependencyValidator dependencyValidator = new DependencyValidator();
-      getContainer().run(fork, cancelable, dependencyValidator);
-      if (dependencyValidator.result.isOK()) {
-        return Status.OK_STATUS;
-      } else {
-        return StatusUtil.setErrorStatus(this, Messages.getString("project.creation.failed"),
-            dependencyValidator.result);
-      }
-    } catch (InvocationTargetException ex) {
-      return StatusUtil.setErrorStatus(this, Messages.getString("project.creation.failed"),
-          ex.getCause());
-    } catch (InterruptedException ex) {
-      return Status.CANCEL_STATUS;
-    }
   }
 
   @Override
@@ -91,17 +63,4 @@ public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
     }
     return accepted;
   }
-
-
-  private class DependencyValidator implements IRunnableWithProgress {
-
-    private IStatus result;
-
-    @Override
-    public void run(IProgressMonitor monitor)
-        throws InvocationTargetException, InterruptedException {
-      result = resolverService.checkRuntimeAvailability(AppEngineRuntime.STANDARD_JAVA_7, monitor);
-    }
-  }
-
 }


### PR DESCRIPTION
Fixes #2996
- ensure `CreateAppEngineStandardWtpProjectTest.testAppEngineLibrariesAdded()` runs with the workspace root scheduling rule
- remove seemingly useless dependency-validator as it's hard-coded to check requirements for App Engine Standard for Java 7 apps