### PR TITLE
Mirror p2 metadata from unsigned repo instead of creating new metadata

### DIFF
--- a/kokoro/ubuntu/jar_signing.sh
+++ b/kokoro/ubuntu/jar_signing.sh
@@ -52,18 +52,11 @@ cp "${KOKORO_GFILE_DIR}/index.html" "${NEW_REPO}"
 ls -lR "${NEW_REPO}"
 
 ###############################################################################
-# Add additional p2 metadata to the new repo.
+# Mirror (copy) p2 metadata from the unsigned repo.
 
-# Renaming required for the p2 ProductPublisher
-mv "${KOKORO_GFILE_DIR}/metadata/metadata.p2.inf" \
-   "${KOKORO_GFILE_DIR}/metadata/p2.inf"
-
-"${ECLIPSE_BIN}" -nosplash -console -consolelog \
-  -application org.eclipse.equinox.p2.publisher.ProductPublisher \
-  -metadataRepository file:"${NEW_REPO}" \
-  -productFile "${KOKORO_GFILE_DIR}/metadata/metadata.product" \
-  -flavor tooling \
-  -append \
-  -compress
+"${ECLIPSE_BIN}" -nosplash -consolelog \
+  -application org.eclipse.equinox.p2.metadata.repository.mirrorApplication \
+  -source file:"${KOKORO_GFILE_DIR}" \
+  -destination file:"${NEW_REPO}"
 
 ls -lR "${NEW_REPO}"

--- a/kokoro/ubuntu/new_release.cfg
+++ b/kokoro/ubuntu/new_release.cfg
@@ -6,7 +6,6 @@ build_file: "google-cloud-eclipse/kokoro/ubuntu/new_release.sh"
 action {
   # Save the p2 repo built by the release script.
   define_artifacts {
-    regex: "git/google-cloud-eclipse/gcp-repo/target/repository/metadata/*"
     regex: "git/google-cloud-eclipse/gcp-repo/target/repository/**/*.jar"
     regex: "git/google-cloud-eclipse/gcp-repo/target/repository/**/*.xml"
     regex: "git/google-cloud-eclipse/gcp-repo/target/repository/**/*.xz"

--- a/kokoro/ubuntu/new_release.sh
+++ b/kokoro/ubuntu/new_release.sh
@@ -8,6 +8,9 @@ set -e
 # Display commands being run.
 set -x
 
+gsutil -q cp "gs://ct4e-m2-repositories/m2-oxygen.tar" - \
+  | tar -C "${HOME}" -xf -
+
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
 gcloud components update --quiet
 gcloud components install app-engine-java --quiet
@@ -36,8 +39,3 @@ TMPDIR= xvfb-run \
       -Dga.tracking.id="${ANALYTICS_TRACKING_ID}" \
       ${PRODUCT_VERSION_SUFFIX:+-Dproduct.version.qualifier.suffix="'${PRODUCT_VERSION_SUFFIX}'"} \
     clean verify
-
-# Also export `metadata.product` and `metadata.p2.inf` to the second Kokoro job.
-readonly METADATA_DIR=gcp-repo/target/repository/metadata
-mkdir "${METADATA_DIR}"
-cp gcp-repo/metadata.p2.inf gcp-repo/metadata.product "${METADATA_DIR}"


### PR DESCRIPTION
Fixes the problem that the current signing step reconstructs the p2 metadata, which reverts the timestamp (and the optional suffix) of the product version  (https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/3016#issuecomment-385432805).

Extra: unpack an M2 repo cache to speed up builds.