### PR TITLE
Remove unused library-related methods after #3040

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/ILibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/ILibraryClasspathContainerResolverService.java
@@ -17,13 +17,11 @@
 package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 
@@ -52,13 +50,4 @@ public interface ILibraryClasspathContainerResolverService {
    * asynchronously.
    */
   IStatus resolveContainer(IJavaProject javaProject, IPath containerPath, IProgressMonitor monitor);
-
-  /**
-   * Verifies that dependencies of a given runtime are available locally or can be downloaded.
-   *
-   * @return {@link Status#OK_STATUS} if all dependencies are available,
-   * {@link Status#CANCEL_STATUS} if the operation was cancelled via the <code>monitor</code>, or a
-   * {@link Status} object describing the error that happened while checking availability
-   */
-  IStatus checkRuntimeAvailability(AppEngineRuntime runtime, IProgressMonitor monitor);
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/ILibraryRepositoryService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/ILibraryRepositoryService.java
@@ -47,11 +47,4 @@ public interface ILibraryRepositoryService {
    */
   IPath resolveSourceArtifact(LibraryFile libraryFile, String versionHint, IProgressMonitor monitor)
       throws CoreException;
-
-  /**
-   * Checks if an artifact described by <code>libraryFile</code> is available. Throws a
-   * {@link CoreException} if the artifact is not available.
-   */
-  void makeArtifactAvailable(LibraryFile libraryFile, IProgressMonitor monitor)
-      throws CoreException;
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.eclipse.appengine.libraries.model.Filter;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.LibraryFile;
 import com.google.cloud.tools.eclipse.appengine.libraries.persistence.LibraryClasspathContainerSerializer;
-import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.cloud.tools.eclipse.util.MavenUtils;
 import com.google.cloud.tools.eclipse.util.jobs.FuturisticJob;
 import com.google.cloud.tools.eclipse.util.jobs.PluggableJob;
@@ -229,33 +228,6 @@ public class LibraryClasspathContainerResolverService
     } catch (CoreException | IOException ex) {
       return StatusUtil.error(
           this, Messages.getString("TaskResolveContainerError", containerPath), ex);
-    }
-  }
-
-  @Override
-  public IStatus checkRuntimeAvailability(AppEngineRuntime runtime, IProgressMonitor monitor) {
-    switch (runtime) {
-      case STANDARD_JAVA_7:
-        return checkAppEngineStandardJava7(monitor);
-      default:
-        throw new IllegalArgumentException("Unhandled runtime: " + runtime);
-    }
-  }
-
-  private IStatus checkAppEngineStandardJava7(IProgressMonitor monitor) {
-    try {
-      for (String libraryId : new String[] {"servlet-api-2.5", "jsp-api-2.1"}) {
-        Library library = CloudLibraries.getLibrary(libraryId);
-        for (LibraryFile libraryFile : library.getAllDependencies()) {
-          if (monitor.isCanceled()) {
-            return Status.CANCEL_STATUS;
-          }
-          repositoryService.makeArtifactAvailable(libraryFile, monitor);
-        }
-      }
-      return Status.OK_STATUS;
-    } catch (CoreException ex) {
-      return StatusUtil.error(this, Messages.getString("LibraryUnavailable"), ex);
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/M2RepositoryService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/M2RepositoryService.java
@@ -87,17 +87,4 @@ public class M2RepositoryService implements ILibraryRepositoryService {
   @Activate
   protected void activate() {  // Necessary to instantiate the class.
   }
-
-  /**
-   * First checks if the artifact is available locally. If not, then it tries to resolve it via
-   * Maven.
-   */
-  @Override
-  public void makeArtifactAvailable(LibraryFile libraryFile, IProgressMonitor monitor)
-      throws CoreException {
-    if (MavenHelper.isArtifactLocallyAvailable(libraryFile.getMavenCoordinates())) {
-      return;
-    }
-    MavenHelper.resolveArtifact(libraryFile.getMavenCoordinates(), monitor);
-  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/MavenHelper.java
@@ -103,13 +103,4 @@ public class MavenHelper {
             .toFile();
     return new Path(downloadedSources.getAbsolutePath());
   }
-
-  public static boolean isArtifactLocallyAvailable(MavenCoordinates mavenCoordinates) {
-    return MavenUtils.isArtifactAvailableLocally(
-        mavenCoordinates.getGroupId(),
-        mavenCoordinates.getArtifactId(),
-        mavenCoordinates.getVersion(),
-        mavenCoordinates.getType(),
-        mavenCoordinates.getClassifier());
-  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/AppEngineStandardProjectWizard.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject.standard;
 
-import com.google.cloud.tools.eclipse.appengine.libraries.ILibraryClasspathContainerResolverService;
 import com.google.cloud.tools.eclipse.appengine.libraries.repository.ILibraryRepositoryService;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectConfig;
 import com.google.cloud.tools.eclipse.appengine.newproject.AppEngineProjectWizard;
@@ -29,9 +28,6 @@ import javax.inject.Inject;
 import org.eclipse.core.runtime.IAdaptable;
 
 public class AppEngineStandardProjectWizard extends AppEngineProjectWizard {
-
-  @Inject
-  private ILibraryClasspathContainerResolverService resolverService;
 
   @Inject
   private ILibraryRepositoryService repositoryService;


### PR DESCRIPTION
We removed the seemingly useless dependency-validator from `AppEngineStandardProjectWizard` in #3040. We should have also removed the private field `resolverService` that is no longer used after that.

I also noticed there are unused methods after #3040, but I am not sure removing all of them is necessarily a good idea. Some of them might be a useful utility method. @briandealwis what do you think?