### PR TITLE
Incorporate XSDs for AES XML configuration files from App Engine SDK

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProviderTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.net.URI;
 import java.util.Map;
@@ -34,9 +33,14 @@ public class AppEngineConfigFileSchemaLocationProviderTest {
 
   @Test
   public void testAppEngineWebXml() {
-    assertSchemaLocation(
-        "http://appengine.google.com/ns/1.0 platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd",
-        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/appengine-web.xml")));
+    Map<String, String> locations =
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/appengine-web.xml"));
+    assertNotNull(locations);
+    assertEquals(2, locations.size());
+    assertEquals("platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd",
+        locations.get(IExternalSchemaLocationProvider.NO_NAMESPACE_SCHEMA_LOCATION));
+    assertEquals("http://appengine.google.com/ns/1.0 platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd",
+        locations.get(IExternalSchemaLocationProvider.SCHEMA_LOCATION));
   }
 
   @Test
@@ -75,8 +79,18 @@ public class AppEngineConfigFileSchemaLocationProviderTest {
   }
 
   @Test
+  public void testNoFile() {
+    Map<String, String> locations = fixture.getExternalSchemaLocation(URI.create("/"));
+    assertNotNull(locations);
+    assertEquals(0, locations.size());
+  }
+
+  @Test
   public void testUnknownFile() {
-    assertNull(fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/foobar.xml")));
+    Map<String, String> locations =
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/foobar.xml"));
+    assertNotNull(locations);
+    assertEquals(0, locations.size());
   }
 
   private void assertNoNamespaceSchemaLocation(String expected,
@@ -85,14 +99,5 @@ public class AppEngineConfigFileSchemaLocationProviderTest {
     assertEquals(1, externalSchemaLocationMap.size());
     assertEquals(expected, externalSchemaLocationMap
         .get(IExternalSchemaLocationProvider.NO_NAMESPACE_SCHEMA_LOCATION));
-  }
-
-  private void assertSchemaLocation(String expected,
-      Map<String, String> externalSchemaLocationMap) {
-    assertNotNull(externalSchemaLocationMap);
-    assertEquals(1, externalSchemaLocationMap.size());
-    assertEquals(expected,
-        externalSchemaLocationMap.get(IExternalSchemaLocationProvider.SCHEMA_LOCATION));
-
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.net.URI;
+import java.util.Map;
+import org.eclipse.wst.xml.core.contentmodel.modelquery.IExternalSchemaLocationProvider;
+import org.junit.Test;
+
+/**
+ * Test the generated schema locations.
+ */
+public class AppEngineConfigFileSchemaLocationProviderTest {
+  private final AppEngineConfigFileSchemaLocationProvider fixture =
+      new AppEngineConfigFileSchemaLocationProvider();
+
+  @Test
+  public void testAppEngineWebXml() {
+    assertSchemaLocation(
+        "http://appengine.google.com/ns/1.0 platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/appengine-web.xml")));
+  }
+
+  @Test
+  public void testQueueXml() {
+    assertNoNamespaceSchemaLocation(
+        "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/queue.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/queue.xml")));
+  }
+
+  @Test
+  public void testDispatchXml() {
+    assertNoNamespaceSchemaLocation(
+        "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/dispatch.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/dispatch.xml")));
+  }
+
+  @Test
+  public void testDatastoreIndexesXml() {
+    assertNoNamespaceSchemaLocation(
+        "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/datastore-indexes.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/datastore-indexes.xml")));
+  }
+
+  @Test
+  public void testDatastoreIndexesAutoXml() {
+    assertNoNamespaceSchemaLocation(
+        "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/datastore-indexes.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/datastore-indexes-auto.xml")));
+  }
+
+  @Test
+  public void testDosXml() {
+    assertNoNamespaceSchemaLocation(
+        "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/dos.xsd",
+        fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/dos.xml")));
+  }
+
+  @Test
+  public void testUnknownFile() {
+    assertNull(fixture.getExternalSchemaLocation(URI.create("/foo/WEB-INF/foobar.xml")));
+  }
+
+  private void assertNoNamespaceSchemaLocation(String expected,
+      Map<String, String> externalSchemaLocationMap) {
+    assertNotNull(externalSchemaLocationMap);
+    assertEquals(1, externalSchemaLocationMap.size());
+    assertEquals(expected, externalSchemaLocationMap
+        .get(IExternalSchemaLocationProvider.NO_NAMESPACE_SCHEMA_LOCATION));
+  }
+
+  private void assertSchemaLocation(String expected,
+      Map<String, String> externalSchemaLocationMap) {
+    assertNotNull(externalSchemaLocationMap);
+    assertEquals(1, externalSchemaLocationMap.size());
+    assertEquals(expected,
+        externalSchemaLocationMap.get(IExternalSchemaLocationProvider.SCHEMA_LOCATION));
+
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.resources,
-  org.eclipse.jdt.core
+ org.eclipse.jdt.core,
+ org.eclipse.wst.xml.core
 Import-Package: com.google.cloud.tools.eclipse.appengine.facets,
  com.google.cloud.tools.eclipse.util,
  com.google.cloud.tools.eclipse.util.status,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/plugin.xml
@@ -234,12 +234,10 @@
     </content-type>
   </extension>
   
-  <extension point="org.eclipse.wst.xml.core.catalogContributions">
-  	<catalogContribution>
-  	  <uri
-  	      name="http://appengine.google.com/ns/1.0"
-  	      uri="xsd/appengine-web.xsd"/>
-  	</catalogContribution>
+  <extension
+        point="org.eclipse.wst.xml.core.externalSchemaLocations">
+     <provider
+           class="com.google.cloud.tools.eclipse.appengine.validation.AppEngineConfigFileSchemaLocationProvider">
+     </provider>
   </extension>
-
 </plugin>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/plugin.xml
@@ -234,6 +234,14 @@
     </content-type>
   </extension>
   
+  <extension point="org.eclipse.wst.xml.core.catalogContributions">
+     <catalogContribution>
+        <uri
+              name="http://appengine.google.com/ns/1.0"
+              uri="xsd/appengine-web.xsd"/>
+     </catalogContribution>		
+  </extension>
+
   <extension
         point="org.eclipse.wst.xml.core.externalSchemaLocations">
      <provider

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
@@ -27,7 +27,7 @@ import org.eclipse.wst.xml.core.contentmodel.modelquery.IExternalSchemaLocationP
 
 /**
  * Associate schemas for App Engine standard environment configuration files. Configured from the
- * {@code org.eclipse.wst.xml.core.externalSchemaLocations} extension point
+ * {@code org.eclipse.wst.xml.core.externalSchemaLocations} extension point.
  */
 public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchemaLocationProvider {
   // Relevant XSDs are in this bundle
@@ -45,9 +45,11 @@ public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchem
     switch (basename) {
       // appengine-web.xml has a known namespace
       case "appengine-web.xml":
-        return ImmutableMap.of(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd", SCHEMA_LOCATION,
-            "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd");
+        return ImmutableMap.<String, String>builder()
+            .put(NO_NAMESPACE_SCHEMA_LOCATION, SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd")
+            .put(SCHEMA_LOCATION, "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX
+                + "appengine-web.xsd")
+            .build();
 
       case "datastore-indexes.xml":
       case "datastore-indexes-auto.xml":

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
@@ -34,6 +34,42 @@ public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchem
   private static final String SCHEMA_LOCATIONS_PREFIX =
       "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/";
 
+  private static final Map<String, Map<String, String>> schemaLocations =
+      ImmutableMap.<String, Map<String, String>>builder()
+          // appengine-web.xml has a known namespace
+          .put("appengine-web.xml",
+              ImmutableMap.<String, String>builder()
+                  .put(NO_NAMESPACE_SCHEMA_LOCATION, SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd")
+                  .put(SCHEMA_LOCATION,
+                      "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX
+                          + "appengine-web.xsd")
+                  .build())
+
+          .put("datastore-indexes.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "datastore-indexes.xsd"))
+          .put("datastore-indexes-auto.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "datastore-indexes.xsd"))
+
+          .put("cron.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "cron.xsd"))
+
+          .put("dispatch.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "dispatch.xsd"))
+
+          .put("queue.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "queue.xsd"))
+
+          .put("dos.xml",
+              Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+                  SCHEMA_LOCATIONS_PREFIX + "dos.xsd"))
+
+          .build();
+
   @Override
   public Map<String, String> getExternalSchemaLocation(URI fileURI) {
     Preconditions.checkNotNull(fileURI);
@@ -42,38 +78,6 @@ public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchem
       return Collections.emptyMap();
     }
     String basename = path.lastSegment();
-    switch (basename) {
-      // appengine-web.xml has a known namespace
-      case "appengine-web.xml":
-        return ImmutableMap.<String, String>builder()
-            .put(NO_NAMESPACE_SCHEMA_LOCATION, SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd")
-            .put(SCHEMA_LOCATION, "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX
-                + "appengine-web.xsd")
-            .build();
-
-      case "datastore-indexes.xml":
-      case "datastore-indexes-auto.xml":
-        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "datastore-indexes.xsd");
-
-      case "cron.xml":
-        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "cron.xsd");
-
-      case "dispatch.xml":
-        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "dispatch.xsd");
-
-      case "queue.xml":
-        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "queue.xsd");
-
-      case "dos.xml":
-        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
-            SCHEMA_LOCATIONS_PREFIX + "dos.xsd");
-
-      default:
-        return Collections.emptyMap();
-    }
+    return schemaLocations.getOrDefault(basename, Collections.emptyMap());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
@@ -1,16 +1,33 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.cloud.tools.eclipse.appengine.validation;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.wst.xml.core.contentmodel.modelquery.IExternalSchemaLocationProvider;
 
 /**
- * Associate schemas for App Engine standard environment configuration files.
- * 
- * @seealso the {@code org.eclipse.wst.xml.core.externalSchemaLocations} extension point
+ * Associate schemas for App Engine standard environment configuration files. Configured from the
+ * {@code org.eclipse.wst.xml.core.externalSchemaLocations} extension point
  */
 public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchemaLocationProvider {
   // Relevant XSDs are in this bundle
@@ -19,31 +36,42 @@ public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchem
 
   @Override
   public Map<String, String> getExternalSchemaLocation(URI fileURI) {
-    String basename = Path.fromPortableString(fileURI.getPath()).lastSegment();
+    Preconditions.checkNotNull(fileURI);
+    IPath path = Path.fromPortableString(fileURI.getPath());
+    if (path.segmentCount() == 0) {
+      return Collections.emptyMap();
+    }
+    String basename = path.lastSegment();
     switch (basename) {
+      // appengine-web.xml has a known namespace
       case "appengine-web.xml":
-        return Collections.singletonMap(SCHEMA_LOCATION,
+        return ImmutableMap.of(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd", SCHEMA_LOCATION,
             "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd");
+
       case "datastore-indexes.xml":
       case "datastore-indexes-auto.xml":
         return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
             SCHEMA_LOCATIONS_PREFIX + "datastore-indexes.xsd");
+
       case "cron.xml":
         return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
             SCHEMA_LOCATIONS_PREFIX + "cron.xsd");
+
       case "dispatch.xml":
         return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
             SCHEMA_LOCATIONS_PREFIX + "dispatch.xsd");
+
       case "queue.xml":
         return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
             SCHEMA_LOCATIONS_PREFIX + "queue.xsd");
+
       case "dos.xml":
         return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
             SCHEMA_LOCATIONS_PREFIX + "dos.xsd");
+
       default:
-        return null;
+        return Collections.emptyMap();
     }
   }
-
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineConfigFileSchemaLocationProvider.java
@@ -1,0 +1,49 @@
+
+package com.google.cloud.tools.eclipse.appengine.validation;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.wst.xml.core.contentmodel.modelquery.IExternalSchemaLocationProvider;
+
+/**
+ * Associate schemas for App Engine standard environment configuration files.
+ * 
+ * @seealso the {@code org.eclipse.wst.xml.core.externalSchemaLocations} extension point
+ */
+public class AppEngineConfigFileSchemaLocationProvider implements IExternalSchemaLocationProvider {
+  // Relevant XSDs are in this bundle
+  private static final String SCHEMA_LOCATIONS_PREFIX =
+      "platform:/plugin/com.google.cloud.tools.eclipse.appengine.validation/xsd/";
+
+  @Override
+  public Map<String, String> getExternalSchemaLocation(URI fileURI) {
+    String basename = Path.fromPortableString(fileURI.getPath()).lastSegment();
+    switch (basename) {
+      case "appengine-web.xml":
+        return Collections.singletonMap(SCHEMA_LOCATION,
+            "http://appengine.google.com/ns/1.0 " + SCHEMA_LOCATIONS_PREFIX + "appengine-web.xsd");
+      case "datastore-indexes.xml":
+      case "datastore-indexes-auto.xml":
+        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "datastore-indexes.xsd");
+      case "cron.xml":
+        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "cron.xsd");
+      case "dispatch.xml":
+        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "dispatch.xsd");
+      case "queue.xml":
+        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "queue.xsd");
+      case "dos.xml":
+        return Collections.singletonMap(NO_NAMESPACE_SCHEMA_LOCATION,
+            SCHEMA_LOCATIONS_PREFIX + "dos.xsd");
+      default:
+        return null;
+    }
+  }
+
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd
@@ -155,6 +155,7 @@
       <xs:element type="xs:positiveInteger" name="target-disk-read-ops-per-sec" minOccurs="0"/>
       <xs:element type="xs:positiveInteger" name="target-request-count-per-sec" minOccurs="0"/>
       <xs:element type="xs:positiveInteger" name="target-concurrent-requests" minOccurs="0"/>
+      <xs:element type="ns:flex-custom-metrics-array" name="custom-metrics" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
   <xs:complexType name="cpu-utilization-type">
@@ -168,6 +169,20 @@
         </xs:simpleType>
       </xs:element>
       <xs:element type="xs:positiveInteger" name="aggregation-window-length-sec" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="flex-custom-metrics-array">
+    <xs:sequence>
+      <xs:element type="ns:custom-metric-utilization-type" name="custom-metric" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="custom-metric-utilization-type">
+    <xs:all>
+      <xs:element type="xs:string" name="metric-name"  minOccurs="0"/>
+      <xs:element type="xs:string" name="target-type"  minOccurs="0"/>
+      <xs:element type="xs:double" name="target-utilization"  minOccurs="0"/>
+      <xs:element type="xs:double" name="single-instance-assignment"  minOccurs="0"/>
+      <xs:element type="xs:string" name="filter"  minOccurs="0"/>
     </xs:all>
   </xs:complexType>
   <xs:complexType name="vm-health-checkType">

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/cron.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/cron.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="cronentries" type="cronentries-Type"/>
+
+  <xs:complexType name="cronentries-Type">
+    <xs:sequence>
+      <xs:element type="cron-Type" name="cron" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="cron-Type">
+    <xs:all>
+      <xs:element type="xs:string" name="url"/>
+      <xs:element type="xs:string" name="description" minOccurs="0"/>
+      <xs:element type="xs:string" name="schedule"/>
+      <xs:element type="xs:string" name="timezone" minOccurs="0"/>
+      <xs:element type="target-Type" name="target" minOccurs="0"/>
+      <xs:element type="retry-parameters-Type" name="retry-parameters" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="retry-parameters-Type">
+    <xs:all>
+      <xs:element type="xs:nonNegativeInteger" name="job-retry-limit" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="job-age-limit-Type" name="job-age-limit" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="nonNegativeDouble" name="min-backoff-seconds" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="nonNegativeDouble" name="max-backoff-seconds" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="xs:nonNegativeInteger" name="max-doublings" maxOccurs="1" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:simpleType name="job-age-limit-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([0-9]+(\.?[0-9]*([eE][\-+]?[0-9]+)?)?)([smhd])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonNegativeDouble">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="target-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z\d\-]{1,100}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/datastore-indexes.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/datastore-indexes.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- CAUTION: the following files implement the parsing and validation of -->
+<!-- the index definition schema, and so they all must be kept in sync: -->
+
+<!--     apphosting/datastore/datastore_index.py -->
+<!--     apphosting/datastore/datastore_index_xml.py -->
+<!--     java/com/google/apphosting/utils/config/IndexesXmlReader.java -->
+<!--     java/com/google/apphosting/utils/config/IndexYamlReader.java -->
+<!--     java/com/google/appengine/tools/development/datastore-indexes.xsd -->
+<!--     java/com/google/appengine/tools/development/datastore-indexes.dtd -->
+<!--     java/com/google/appengine/api/datastore/dev/LocalCompositeIndexManager.java -->
+<!--     java/com/google/appengine/api/datastore/CompositeIndexManager.java -->
+
+<!-- TODO(flyboy): add to this list when we discover even more places -->
+<!-- that are sensitive to schema changes -->
+
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="datastore-indexes" type="datastore-indexesType" />
+  <xs:complexType name="propertyType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="directionType" name="direction" use="optional"/>
+        <xs:attribute type="modeType" name="mode" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="datastore-indexesType">
+    <xs:sequence>
+      <xs:element type="datastore-indexType" name="datastore-index" maxOccurs="unbounded" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Number of uses in query history</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute type="xs:boolean" name="autoGenerate" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="datastore-indexType">
+    <xs:sequence>
+      <xs:element type="propertyType" name="property" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="kind" use="required"/>
+    <xs:attribute type="xs:boolean" name="ancestor" use="optional"/>
+    <xs:attribute type="xs:string" name="source" use="optional"/>
+  </xs:complexType>
+
+  <xs:simpleType name="directionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="asc"/>
+      <xs:enumeration value="desc"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="modeType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="geospatial"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/dispatch.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/dispatch.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element type="dispatch-entries-Type" name="dispatch-entries"/>
+
+  <xs:complexType name="dispatch-entries-Type">
+    <xs:sequence>
+      <xs:element type="dispatch-Type" name="dispatch" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="dispatch-Type">
+    <xs:all>
+      <xs:element type="xs:string" name="url"/>
+      <xs:element type="xs:string" name="module"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/dos.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/dos.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="blacklistentries" type="blacklistentries-Type"/>
+
+  <xs:complexType name="blacklistentries-Type">
+    <xs:sequence>
+      <xs:element type="blacklist-Type" name="blacklist" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="blacklist-Type">
+    <xs:all>
+      <xs:element type="xs:string" name="subnet"/>
+      <xs:element type="xs:string" name="description" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+</xs:schema>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/queue.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/queue.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="queue-entries" type="queue-entries-Type"/>
+
+  <xs:complexType name="queue-entries-Type">
+    <xs:sequence>
+      <xs:element type="total-storage-limit-Type" name="total-storage-limit" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="queue-Type" name="queue" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="total-storage-limit-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([0-9]+(\.[0-9]*)?[BKMGT]?)"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="queue-Type">
+    <xs:all>
+      <xs:element type="name-Type" name="name"/>
+      <xs:element type="rate-Type" name="rate" minOccurs="0"/>
+      <xs:element type="xs:nonNegativeInteger" name="bucket-size" minOccurs="0"/>
+      <xs:element type="xs:nonNegativeInteger" name="max-concurrent-requests" minOccurs="0"/>
+      <xs:element type="retry-parameters-Type" name="retry-parameters" minOccurs="0"/>
+      <xs:element type="target-Type" name="target" minOccurs="0"/>
+      <xs:element type="queue-mode-Type" name="mode" minOccurs="0"/>
+      <xs:element type="acl-Type" name="acl" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:simpleType name="queue-mode-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="push|pull"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="acl-Type">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element type="xs:string" name="user-email" maxOccurs="unbounded" minOccurs="0"/>
+      <xs:element type="xs:string" name="writer-email" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:simpleType name="name-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-zA-Z\d\-]{1,100}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="rate-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="0"/>
+      <xs:pattern value="([0-9]+(\.[0-9]*)?)/([smhd])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="retry-parameters-Type">
+    <xs:all>
+      <xs:element type="xs:nonNegativeInteger" name="task-retry-limit" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="task-age-limit-Type" name="task-age-limit" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="nonNegativeDouble" name="min-backoff-seconds" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="nonNegativeDouble" name="max-backoff-seconds" maxOccurs="1" minOccurs="0"/>
+      <xs:element type="xs:nonNegativeInteger" name="max-doublings" maxOccurs="1" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:simpleType name="task-age-limit-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([0-9]+(\.?[0-9]*([eE][\-+]?[0-9]+)?)?)([smhd])"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="nonNegativeDouble">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="target-Type">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[a-z\d\-\.]{1,100}"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
Adds a WTP XML schema-location provider to associate schemas based on file name patterns.  This is sufficient to bring in validation and auto-complete on the associated elements.

For now, all but the `appengine-web.xsd` are brought in as `noNamespaceSchemaLocation` as they have no formal namespaces.

Fixes #1757, #1758, #1759, #1760, #1761