### PR TITLE
Add logging.properties template

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegateTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegateTest.java
@@ -41,8 +41,8 @@ public class StandardFacetInstallDelegateTest {
 
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
   
-  private StandardFacetInstallDelegate delegate = new StandardFacetInstallDelegate();
-  private IProgressMonitor monitor = new NullProgressMonitor(); 
+  private final StandardFacetInstallDelegate delegate = new StandardFacetInstallDelegate();
+  private final IProgressMonitor monitor = new NullProgressMonitor();
   private IProject project;
   
   @Before 
@@ -56,8 +56,10 @@ public class StandardFacetInstallDelegateTest {
     delegate.createConfigFiles(project, AppEngineStandardFacet.JRE7, monitor);
 
     IFile appengineWebXml = project.getFile("src/main/webapp/WEB-INF/appengine-web.xml");
+    IFile loggingProperties = project.getFile("src/main/webapp/WEB-INF/logging.properties");
     Assert.assertTrue(appengineWebXml.exists());
-    
+    Assert.assertTrue(loggingProperties.exists());
+
     try (InputStream in = appengineWebXml.getContents(true)) {
       AppEngineDescriptor descriptor = AppEngineDescriptor.parse(in);
       assertNull(descriptor.getRuntime());
@@ -65,23 +67,25 @@ public class StandardFacetInstallDelegateTest {
   }
   
   @Test
-  public void testCreateConfigFiles_dontOverwrite() 
-      throws CoreException, IOException {
-    
+  public void testCreateConfigFiles_dontOverwrite() throws CoreException, IOException {
     IFolder webInfDir = project.getFolder("src/main/webapp/WEB-INF");
     ResourceUtils.createFolders(webInfDir, monitor);
-    IFile appengineWebXml = project.getFile("src/main/webapp/WEB-INF/appengine-web.xml");
+    IFile appengineWebXml = webInfDir.getFile("appengine-web.xml");
+    IFile loggingProperties = project.getFile("logging.properties");
     appengineWebXml.create(new ByteArrayInputStream(new byte[0]), true, monitor);
+    loggingProperties.create(new ByteArrayInputStream(new byte[0]), true, monitor);
 
     Assert.assertTrue(appengineWebXml.exists());
+    Assert.assertTrue(loggingProperties.exists());
 
     delegate.createConfigFiles(project, AppEngineStandardFacet.JRE7, monitor);
 
-    // Make sure createConfigFiles did not write any data into appengine-web.xml
-    try (InputStream in = appengineWebXml.getContents(true)) {
-      Assert.assertEquals("appengine-web.xml is not empty", -1, in.read());       
+    // Make sure createConfigFiles did not overwrite appengine-web.xml or logging.properties
+    try (InputStream appengineXmlIn = appengineWebXml.getContents(true);
+        InputStream loggingPropertiesIn = loggingProperties.getContents(true)) {
+      Assert.assertEquals("appengine-web.xml is not empty", -1, appengineXmlIn.read());
+      Assert.assertEquals("logging.properties is not empty", -1, loggingPropertiesIn.read());
     }
-
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallationTest.java
@@ -90,6 +90,18 @@ public class StandardFacetInstallationTest {
   }
 
   @Test
+  public void testStandardFacetInstallation_createsLoggingProperties() throws CoreException {
+    IProject project = projectCreator.getProject();
+    assertFalse(project.getFile("src/main/webapp/WEB-INF/logging.properties").exists());
+
+    IFacetedProject facetedProject = projectCreator.getFacetedProject();
+    AppEngineStandardFacet.installAppEngineFacet(facetedProject, true, null);
+    ProjectUtils.waitForProjects(project); // App Engine runtime is added via a Job, so wait.
+
+    assertTrue(project.getFile("src/main/webapp/WEB-INF/logging.properties").exists());
+  }
+
+  @Test
   public void testStandardFacetInstallation_createsWebXml() throws CoreException {
     IProject project = projectCreator.getProject();
     assertFalse(project.getFile("src/main/webapp/WEB-INF/web.xml").exists());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -137,7 +137,7 @@ public class StandardFacetInstallDelegate implements IDelegate {
     SubMonitor progress = SubMonitor.convert(monitor, 10);
 
     createFileInWebInf(project, "logging.properties", Templates.LOGGING_PROPERTIES_TEMPLATE,
-        Collections.emptyMap(), progress.newChild(5));
+        Collections.emptyMap(), progress.split(5));
 
     Map<String, String> parameters = new HashMap<>();
     Object appEngineRuntime = facetVersion.getProperty("appengine.runtime");
@@ -145,7 +145,7 @@ public class StandardFacetInstallDelegate implements IDelegate {
       parameters.put("runtime", (String) appEngineRuntime);
     }
     createFileInWebInf(project, "appengine-web.xml", Templates.APPENGINE_WEB_XML_TEMPLATE,
-        parameters, progress.newChild(5));
+        parameters, progress.split(5));
   }
 
   /** Creates a file in the WEB-INF folder if it doesn't exist. */
@@ -160,10 +160,10 @@ public class StandardFacetInstallDelegate implements IDelegate {
 
     // Use the virtual component model to decide where to create the file
     targetFile = WebProjectUtil.createFileInWebInf(project, new Path(filename),
-        new ByteArrayInputStream(new byte[0]), progress.newChild(2));
+        new ByteArrayInputStream(new byte[0]), progress.split(2));
     String fileLocation = targetFile.getLocation().toString();
     Templates.createFileContent(fileLocation, templateName, templateParameters);
     progress.worked(4);
-    targetFile.refreshLocal(IFile.DEPTH_ZERO, progress.newChild(1));
+    targetFile.refreshLocal(IFile.DEPTH_ZERO, progress.split(1));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.facets;
 
 import com.google.cloud.tools.eclipse.util.CloudToolsInfo;
 import com.google.cloud.tools.eclipse.util.Templates;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.core.resources.IFile;
@@ -39,8 +39,6 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 public class StandardFacetInstallDelegate implements IDelegate {
-  private static final String APPENGINE_WEB_XML = "appengine-web.xml";
-
   private static final String JSDT_FACET_ID = "wst.jsdt.web";
   private static final int MAX_JSDT_CHECK_RETRIES = 100;
 
@@ -134,30 +132,38 @@ public class StandardFacetInstallDelegate implements IDelegate {
     }
   }
 
-  /** Creates an appengine-web.xml file in the WEB-INF folder if it doesn't exist. */
-  @VisibleForTesting
-  void createConfigFiles(
-      IProject project, IProjectFacetVersion facetVersion, IProgressMonitor monitor)
-      throws CoreException {
+  void createConfigFiles(IProject project, IProjectFacetVersion facetVersion,
+      IProgressMonitor monitor) throws CoreException {
     SubMonitor progress = SubMonitor.convert(monitor, 10);
 
-    IFile appEngineWebXml = WebProjectUtil.findInWebInf(project, new Path(APPENGINE_WEB_XML));
-    if (appEngineWebXml != null && appEngineWebXml.exists()) {
-      return;
-    }
+    createFileInWebInf(project, "logging.properties", Templates.LOGGING_PROPERTIES_TEMPLATE,
+        Collections.emptyMap(), progress.newChild(5));
 
-    // Use the virtual component model decide where to create the appengine-web.xml
-    appEngineWebXml = WebProjectUtil.createFileInWebInf(project, new Path(APPENGINE_WEB_XML),
-        new ByteArrayInputStream(new byte[0]), progress.newChild(2));
-    String configFileLocation = appEngineWebXml.getLocation().toString();
     Map<String, String> parameters = new HashMap<>();
     Object appEngineRuntime = facetVersion.getProperty("appengine.runtime");
     if (appEngineRuntime instanceof String) {
       parameters.put("runtime", (String) appEngineRuntime);
     }
-    Templates.createFileContent(
-        configFileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE, parameters);
+    createFileInWebInf(project, "appengine-web.xml", Templates.APPENGINE_WEB_XML_TEMPLATE,
+        parameters, progress.newChild(5));
+  }
+
+  /** Creates a file in the WEB-INF folder if it doesn't exist. */
+  private void createFileInWebInf(IProject project, String filename, String templateName,
+      Map<String, String> templateParameters, IProgressMonitor monitor) throws CoreException {
+    SubMonitor progress = SubMonitor.convert(monitor, 7);
+
+    IFile targetFile = WebProjectUtil.findInWebInf(project, new Path(filename));
+    if (targetFile != null && targetFile.exists()) {
+      return;
+    }
+
+    // Use the virtual component model to decide where to create the file
+    targetFile = WebProjectUtil.createFileInWebInf(project, new Path(filename),
+        new ByteArrayInputStream(new byte[0]), progress.newChild(2));
+    String fileLocation = targetFile.getLocation().toString();
+    Templates.createFileContent(fileLocation, templateName, templateParameters);
     progress.worked(4);
-    appEngineWebXml.refreshLocal(IFile.DEPTH_ZERO, progress.newChild(1));
+    targetFile.refreshLocal(IFile.DEPTH_ZERO, progress.newChild(1));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -23,12 +23,17 @@ import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.util.MappedNamespaceContext;
 import com.google.cloud.tools.eclipse.util.Templates;
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -75,6 +80,7 @@ public class CodeTemplatesTest {
     validateNonConfigFiles(mostImportant, "http://java.sun.com/xml/ns/javaee",
         "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd", "2.5");
     validateAppEngineWebXml(AppEngineRuntime.STANDARD_JAVA_7);
+    validateLoggingProperties();
   }
 
   @Test
@@ -86,6 +92,7 @@ public class CodeTemplatesTest {
     validateNonConfigFiles(mostImportant, "http://xmlns.jcp.org/xml/ns/javaee",
         "http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd", "3.1");
     validateAppEngineWebXml(AppEngineRuntime.STANDARD_JAVA_8);
+    validateLoggingProperties();
   }
 
   @Test
@@ -207,6 +214,18 @@ public class CodeTemplatesTest {
         new InputStreamReader(appYaml.getContents(), StandardCharsets.UTF_8))) {
       Assert.assertEquals("runtime: java", reader.readLine());
       Assert.assertEquals("env: flex", reader.readLine());
+    }
+  }
+
+  private void validateLoggingProperties() throws FileNotFoundException, IOException {
+    IFolder loggingProperties = project.getFolder("src/main/webapp/WEB-INF/logging.properties");
+    Path path = Paths.get(loggingProperties.getLocation().toString());
+    try (InputStream in = Files.newInputStream(path)) {
+      Properties properties = new Properties();
+      properties.load(in);
+
+      Assert.assertEquals(1, properties.keySet().size());
+      Assert.assertEquals("WARNING", properties.getProperty(".level"));
     }
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -26,7 +26,6 @@ import com.google.common.base.Strings;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -84,7 +83,7 @@ public class CodeTemplates {
     IFile hello =
         createJavaSourceFiles(project, config, isStandardProject, subMonitor.newChild(15));
 
-    createAppEngineWebXmlOrAppYaml(project, config, isStandardProject, subMonitor.newChild(5));
+    createAppEngineConfigFiles(project, config, isStandardProject, subMonitor.newChild(5));
 
     createWebXml(project, config, isStandardProject, subMonitor.newChild(5));
 
@@ -131,7 +130,7 @@ public class CodeTemplates {
     return hello;
   }
 
-  private static void createAppEngineWebXmlOrAppYaml(IProject project,
+  private static void createAppEngineConfigFiles(IProject project,
       AppEngineProjectConfig config, boolean isStandardProject, IProgressMonitor monitor)
       throws CoreException {
     Map<String, String> properties = new HashMap<>();
@@ -148,6 +147,9 @@ public class CodeTemplates {
       IFolder webInf = project.getFolder("src/main/webapp/WEB-INF"); //$NON-NLS-1$
       createChildFile("appengine-web.xml", //$NON-NLS-1$
           Templates.APPENGINE_WEB_XML_TEMPLATE,
+          webInf, properties, monitor);
+      createChildFile("logging.properties", //$NON-NLS-1$
+          Templates.LOGGING_PROPERTIES_TEMPLATE,
           webInf, properties, monitor);
     } else {
       IFolder appengine = project.getFolder("src/main/appengine"); //$NON-NLS-1$

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.eclipse.util;
 
-import com.google.cloud.tools.eclipse.util.Templates;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -171,6 +170,13 @@ public class TemplatesTest {
     compareToFile("helloAppEngineJava8.txt");
   }
 
+  @Test
+  public void testCreateFileContent_loggingProperties() throws CoreException, IOException {
+    Templates.createFileContent(fileLocation, Templates.LOGGING_PROPERTIES_TEMPLATE, dataMap);
+
+    compareToFile("loggingProperties.txt");
+  }
+
   private static InputStream getDataFile(String fileName) throws IOException {
     Bundle bundle = FrameworkUtil.getBundle(TemplatesTest.class);
     URL expectedFileUrl = bundle.getResource("/testData/templates/appengine/" + fileName);
@@ -182,7 +188,7 @@ public class TemplatesTest {
 
   private void compareToFile(String expected) throws IOException {
 
-    try (InputStream testFileStream = Files.newInputStream(Paths.get((fileLocation)));
+    try (InputStream testFileStream = Files.newInputStream(Paths.get(fileLocation));
         InputStream expectedFileStream = getDataFile(expected);
         Scanner expectedScanner = new Scanner(expectedFileStream);
         Scanner actualScanner = new Scanner(testFileStream)) {

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appEngineWebXmlWithRuntime.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appEngineWebXmlWithRuntime.txt
@@ -5,4 +5,8 @@
   <sessions-enabled>false</sessions-enabled>
   <runtime>java8</runtime>
 
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+  </system-properties>
+
 </appengine-web-app>

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appengineWebXml.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appengineWebXml.txt
@@ -4,4 +4,8 @@
   <threadsafe>true</threadsafe>
   <sessions-enabled>false</sessions-enabled>
 
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+  </system-properties>
+
 </appengine-web-app>

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appengineWebXmlWithService.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/appengineWebXmlWithService.txt
@@ -5,4 +5,8 @@
   <sessions-enabled>false</sessions-enabled>
   <service>foobar</service>
 
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+  </system-properties>
+
 </appengine-web-app>

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/loggingProperties.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/loggingProperties.txt
@@ -1,0 +1,13 @@
+# A default java.util.logging configuration.
+# (All App Engine logging is through java.util.logging by default).
+#
+# To use this configuration, copy it into your application's WEB-INF
+# folder and add the following to your appengine-web.xml:
+# 
+# <system-properties>
+#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+# </system-properties>
+#
+
+# Set the default logging level for all loggers to WARNING
+.level = WARNING

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/loggingProperties.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/loggingProperties.txt
@@ -1,13 +1,4 @@
-# A default java.util.logging configuration.
-# (All App Engine logging is through java.util.logging by default).
-#
-# To use this configuration, copy it into your application's WEB-INF
-# folder and add the following to your appengine-web.xml:
-# 
-# <system-properties>
-#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
-# </system-properties>
-#
+# https://cloud.google.com/appengine/docs/standard/java/logs/
 
 # Set the default logging level for all loggers to WARNING
 .level = WARNING

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
@@ -45,6 +45,7 @@ public class Templates {
   public static final String APP_YAML_TEMPLATE = "app.yaml.ftl";
   public static final String POM_XML_STANDARD_TEMPLATE = "pom.xml.standard.ftl";
   public static final String POM_XML_FLEX_TEMPLATE = "pom.xml.flex.ftl";
+  public static final String LOGGING_PROPERTIES_TEMPLATE = "logging.properties.ftl";
 
   private static Configuration configuration;
 

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/appengine-web.xml.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/appengine-web.xml.ftl
@@ -8,4 +8,8 @@
 <#if runtime??>  <runtime>${runtime}</runtime>
 </#if>
 
+  <system-properties>
+    <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+  </system-properties>
+
 </appengine-web-app>

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/logging.properties.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/logging.properties.ftl
@@ -1,0 +1,13 @@
+# A default java.util.logging configuration.
+# (All App Engine logging is through java.util.logging by default).
+#
+# To use this configuration, copy it into your application's WEB-INF
+# folder and add the following to your appengine-web.xml:
+# 
+# <system-properties>
+#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
+# </system-properties>
+#
+
+# Set the default logging level for all loggers to WARNING
+.level = WARNING

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/logging.properties.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/logging.properties.ftl
@@ -1,13 +1,4 @@
-# A default java.util.logging configuration.
-# (All App Engine logging is through java.util.logging by default).
-#
-# To use this configuration, copy it into your application's WEB-INF
-# folder and add the following to your appengine-web.xml:
-# 
-# <system-properties>
-#   <property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>
-# </system-properties>
-#
+# https://cloud.google.com/appengine/docs/standard/java/logs/
 
 # Set the default logging level for all loggers to WARNING
 .level = WARNING


### PR DESCRIPTION
Fixes #3051.
Fixes #2541.

There are two execution paths where we add `appengine-web.xml` and (now) `logging.properties`:
   - Through the project wizard.
   - When adding the App Engine Standard facet.

With the [sample code here](https://cloud.google.com/appengine/docs/standard/java/how-requests-are-handled#logging), only WARNING and ERROR are logged because `.level = WARNING` in `logging.properties`.

![selection_001](https://user-images.githubusercontent.com/10523105/39891069-aa3084fc-546a-11e8-952c-b6bd1c959f9c.png)