### PR TITLE
Change update notification to install by default

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.test.util,
+Import-Package: com.google.cloud.tools.appengine.cloudsdk.serialization;version="0.6.0",
+ com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.ui,
  org.eclipse.swtbot.swt.finder.widgets

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
@@ -61,22 +61,22 @@ public class CloudSdkUpdateNotificationTest {
   }
 
   @Test
-  public void testNotTriggeredOnCancelLink() {
+  public void testTriggeredOnSkipLink() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
         new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
-    notification.linkSelected("cancel");
+    notification.linkSelected("skip");
     verify(trigger, never()).run();
   }
 
   @Test
-  public void testNoTriggerOnCloseButton() {
+  public void testTriggerOnCloseButton() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
         new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
     notification.open();
     notification.close();
-    verify(trigger, never()).run();
+    verify(trigger).run();
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
@@ -19,22 +19,31 @@ package com.google.cloud.tools.eclipse.sdk.ui;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbench;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkUpdateNotificationTest {
+  @Mock private IWorkbench workbench;
+
+  @Before
+  public void setUp() {
+    when(workbench.getDisplay()).thenReturn(Display.getCurrent());
+  }
 
   @Test
   public void testTriggeredOnUpdateLink() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
-        new CloudSdkUpdateNotification(
-            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
     notification.linkSelected("install");
     verify(trigger).run();
   }
@@ -43,8 +52,7 @@ public class CloudSdkUpdateNotificationTest {
   public void testTriggeredOnFade() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
-        new CloudSdkUpdateNotification(
-            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
     // simulate fade away
     notification.open();
     notification.getShell().setAlpha(0);
@@ -56,8 +64,7 @@ public class CloudSdkUpdateNotificationTest {
   public void testNotTriggeredOnCancelLink() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
-        new CloudSdkUpdateNotification(
-            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
     notification.linkSelected("cancel");
     verify(trigger, never()).run();
   }
@@ -66,8 +73,7 @@ public class CloudSdkUpdateNotificationTest {
   public void testNoTriggerOnCloseButton() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkUpdateNotification notification =
-        new CloudSdkUpdateNotification(
-            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
     notification.open();
     notification.close();
     verify(trigger, never()).run();

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.sdk.ui;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
+import org.eclipse.ui.PlatformUI;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkUpdateNotificationTest {
+
+  @Test
+  public void testTriggeredOnUpdateLink() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(
+            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+    notification.linkSelected("install");
+    verify(trigger).run();
+  }
+
+  @Test
+  public void testTriggeredOnFade() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(
+            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+    // simulate fade away
+    notification.open();
+    notification.getShell().setAlpha(0);
+    notification.close();
+    verify(trigger).run();
+  }
+
+  @Test
+  public void testNotTriggeredOnCancelLink() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(
+            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+    notification.linkSelected("cancel");
+    verify(trigger, never()).run();
+  }
+
+  @Test
+  public void testNoTriggerOnCloseButton() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(
+            PlatformUI.getWorkbench(), new CloudSdkVersion("178.0.0"), trigger);
+    notification.open();
+    notification.close();
+    verify(trigger, never()).run();
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/MessagesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/MessagesTest.java
@@ -30,13 +30,14 @@ public class MessagesTest {
   @Test
   public void testCloudSdkUpdateNotificationTitle() {
     Assert.assertEquals(
-        "Google Cloud SDK Update Available", Messages.getString("CloudSdkUpdateNotificationTitle"));
+        "Google Cloud SDK Update Installation",
+        Messages.getString("CloudSdkUpdateNotificationTitle"));
   }
 
   @Test
   public void testCloudSdkUpdateNotificationMessage() {
     Assert.assertEquals(
-        "<a href=\"update\">Update now</a> or from the Google Cloud Tools preference page.\n"
+        "Installation will begin momentarily, or <a href=\"skip\">skip for now</a>.\n"
             + "See the <a href=\"https://cloud.google.com/sdk/docs/release-notes\">release notes</a> for changes since 1.9.0.",
         Messages.getString("CloudSdkUpdateNotificationMessage", new CloudSdkVersion("1.9.0")));
   }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/META-INF/MANIFEST.MF
@@ -10,9 +10,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.107.0",
  com.google.cloud.tools.appengine;bundle-version="0.6.0",
- org.eclipse.equinox.preferences;bundle-version="3.5.300",
  org.eclipse.equinox.common;bundle-version="3.7.0",
- org.eclipse.e4.core.contexts;bundle-version="1.4.0",
  com.google.cloud.tools.eclipse.sdk,
  com.google.cloud.tools.eclipse.preferences
 Import-Package: com.google.cloud.tools.eclipse.ui.util,
@@ -20,8 +18,5 @@ Import-Package: com.google.cloud.tools.eclipse.ui.util,
  com.google.common.annotations;version="[21.0.0,22.0.0)",
  com.google.common.base;version="[21.0.0,22.0.0)",
  org.eclipse.core.runtime.jobs,
- org.eclipse.mylyn.commons.ui.dialogs,
- org.eclipse.osgi.util;version="1.1.0",
- org.eclipse.ui.console,
- org.osgi.framework;version="1.8.0"
+ org.eclipse.mylyn.commons.ui.dialogs
 Export-Package: com.google.cloud.tools.eclipse.sdk.ui.preferences

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
@@ -72,7 +72,7 @@ public class ManagedCloudSdkStartup implements IStartup {
       return;
     }
 
-    Job checkInstallationJob = new Job("Check Google Cloud SDK") {
+    Job checkInstallationJob = new Job(Messages.getString("CheckUpToDateJobTitle")) { //$NON-NLS-1$
       @Override
       protected IStatus run(IProgressMonitor monitor) {
         try {
@@ -80,12 +80,12 @@ public class ManagedCloudSdkStartup implements IStartup {
           ManagedCloudSdk installer = ManagedCloudSdk.newManagedSdk();
           checkInstallation(sdkManager, installer, monitor);
         } catch (UnsupportedOsException ex) {
-          logger.log(Level.FINE, "Unable to check Cloud SDK installation", ex);
+          logger.log(Level.FINE, "Unable to check Cloud SDK installation", ex); //$NON-NLS-1$
         } catch (ManagedSdkVerificationException ex) {
-          logger.log(Level.SEVERE, "Unable to check Cloud SDK installation. Possible causes include"
-              + " network connection problem or corrupt Cloud SDK installation.", ex);
+          logger.log(Level.SEVERE, "Unable to check Cloud SDK installation. Possible causes include" //$NON-NLS-1$
+              + " network connection problem or corrupt Cloud SDK installation.", ex); //$NON-NLS-1$
         } catch (ManagedSdkVersionMismatchException ex) {
-          throw new IllegalStateException("This is never thrown because we always use LATEST.", ex);
+          throw new IllegalStateException("This is never thrown because we always use LATEST.", ex); //$NON-NLS-1$
         }
         return Status.OK_STATUS;
       }
@@ -94,7 +94,7 @@ public class ManagedCloudSdkStartup implements IStartup {
     // Use a WorkbenchJob to trigger the check to ensure we start after the workbench window has
     // appeared, but perform the actual check within a normal Job so that we don't monopolize the
     // display thread.
-    Job triggerInstallationJob = new WorkbenchJob("Check Google Cloud SDK") {
+    Job triggerInstallationJob = new WorkbenchJob(Messages.getString("CheckUpToDateJobTitle")) { //$NON-NLS-1$
       @Override
       public IStatus runInUIThread(IProgressMonitor monitor) {
         checkInstallationJob.setSystem(true);

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/messages.properties
@@ -1,3 +1,4 @@
+CheckUpToDateJobTitle=Check Google Cloud SDK
 CloudSdkRequired=Google Cloud Tools for Eclipse requires the \
  <a href="https://cloud.google.com/sdk/">Google Cloud SDK</a> with the \
  <a href="https://cloud.google.com/sdk/docs/managing-components">App Engine Java components</a>.
@@ -16,7 +17,7 @@ AppEngineJavaComponentsNotInstalled=App Engine Java components not installed
 NoSuchDirectory=Directory {0} does not exist
 FileNotDirectory={0} is a file, not a directory
 UpdateSdk=Update
-CloudSdkUpdateNotificationTitle=Google Cloud SDK Update Available
+CloudSdkUpdateNotificationTitle=Google Cloud SDK Update Installation
 CloudSdkUpdateNotificationMessage=\
- <a href="update">Update now</a> or from the Google Cloud Tools preference page.\n\
+ Installation will begin momentarily, or <a href="skip">skip for now</a>.\n\
  See the <a href="https://cloud.google.com/sdk/docs/release-notes">release notes</a> for changes since {0}.


### PR DESCRIPTION
Fixes #3054 by installing updates by default unless the user indicates they wish to skip.

<img width="351" alt="new-update-notification" src="https://user-images.githubusercontent.com/202851/40449980-40f81962-5ea8-11e8-8da4-591f57107830.PNG">

The implementation is a bit tricky.  I had hoped to just use the JFace Window/Dialog's support for setting a return code (i.e., `OK` or `CANCEL`).  Unfortunately Mylyn's `AbstractNotificationPopup` implementation has a bug in its _notification-close_ handling (where the user clicks on the `X` in the upper-right to close the notification) in that [it calls `close()` *before* setting the popup's return code](http://git.eclipse.org/c/mylyn/org.eclipse.mylyn.commons.git/tree/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/commons/ui/dialogs/AbstractNotificationPopup.java#n213), unlike the rest of the code that first sets the return code and then closes the popup. 

Further complicating the situation is that the [fade-out code calls `Shell#close()`](http://git.eclipse.org/c/mylyn/org.eclipse.mylyn.commons.git/tree/org.eclipse.mylyn.commons.ui/src/org/eclipse/mylyn/commons/ui/dialogs/AbstractNotificationPopup.java#n509), which triggers a _ShellClosed_ event, eventually calling into [`Window#handleShellCloseEvent()`](http://git.eclipse.org/c/platform/eclipse.platform.ui.git/tree/bundles/org.eclipse.jface/src/org/eclipse/jface/window/Window.java?h=master#n732) .  That calls `setReturnCode(CANCEL)`.  As a result it's hard to tell whether the notification has faded away (= trigger update) vs the user keying _ESC_ or killing the window (= cancel installation).  I discovered that I could use the `Shell`'s _alpha_ value to differentiate between _faded-away_ or _ESC_/_killing-window_, but that's not enough to differentiate on the _notification-close_.

So this PR instead ignores the _returnCode_ and maintains a separate _installation directive_ based on whether the user explicitly selected an item or if the notification faded away.

Note that I left in support for explicitly selecting an _install_ link just in case we want to tweak the text a bit.