### PR TITLE
Associate default image with status command to avoid status area gap

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui.status/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.ui.status/plugin.xml
@@ -28,6 +28,13 @@
       </command>
    </extension>
    <extension
+         point="org.eclipse.ui.commandImages">
+      <image
+            commandId="com.google.cloud.tools.eclipse.ui.status.showGcpStatus"
+            icon="platform:/plugin/com.google.cloud.tools.eclipse.ui/icons/obj16/gcp.png">
+      </image>
+   </extension>
+   <extension
          point="org.eclipse.ui.startup">
       <startup
             class="com.google.cloud.tools.eclipse.ui.status.WorkbenchStartup">


### PR DESCRIPTION
Associates the GCP icon as the command image for the _Show Google Cloud Platform Status_ command, so that the command name is not used in toolbars. 

<img width="76" alt="screen shot 2018-05-25 at 11 40 49 am" src="https://user-images.githubusercontent.com/202851/40553393-7ce8df74-6010-11e8-88f1-54516c68f28d.PNG">

Fixes #3093