### PR TITLE
Update SnakeYAML to 1.21

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -37,7 +37,7 @@
    <bundle id="org.apache.commons.compress" version="0.0.0"/>
    <bundle id="jackson-core-asl" version="1.9.13"/>
    <bundle id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
-   <bundle id="org.yaml.snakeyaml" version="1.17"/>
+   <bundle id="org.yaml.snakeyaml" version="1.21"/>
    <bundle id="org.glassfish.javax.json" version="1.0.4"/>
    
    <!--

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -105,7 +105,7 @@
          id="org.yaml.snakeyaml"
          download-size="0"
          install-size="0"
-         version="1.17.0"
+         version="1.21.0"
          unpack="false"/>
          
    <plugin

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
       <!-- bundle: org.yaml.snakeyaml -->
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.17</version>
+      <version>1.21</version>
     </dependency>
     <dependency>
       <!-- bundle: org.glassfish.javax.json -->


### PR DESCRIPTION
Fixes #3102

This change is independent of https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/647 as `appengine-plugins-core` imports the `org.snakeyaml` packages with broad ranges of `[1.17,2)`.