### PR TITLE
Avoid warnings in integration tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEnginePublishOperationTest.java
@@ -82,9 +82,7 @@ public class LocalAppEnginePublishOperationTest {
   @After
   public void tearDown() throws CoreException {
     if (projects != null) {
-      for (IProject project : projects.values()) {
-        project.delete(true, null);
-      }
+      serverProject.getWorkspace().delete(projects.values().toArray(new IProject[0]), true, null);
     }
     if (server != null) {
       server.delete();

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/BaseProjectTest.java
@@ -59,8 +59,13 @@ public abstract class BaseProjectTest {
   @After
   public void tearDown() {
     if (project != null) {
+      // Collapse projects to avoid "No IModelProvider exists for project" errors
+      // https://bugs.eclipse.org/bugs/show_bug.cgi?id=511541
+      SwtBotProjectActions.collapseProjects(bot);
+
       // close editors, so no property changes are dispatched on delete
       bot.closeAllEditors();
+      
       // ensure there are no jobs
       SwtBotWorkbenchActions.waitForProjects(bot, project);
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
@@ -45,8 +45,7 @@ import org.junit.runner.RunWith;
 @RunWith(SWTBotJunit4ClassRunner.class)
 public abstract class ChildModuleWarPublishTest {
 
-  @Rule
-  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  @Rule public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   private static final IProgressMonitor monitor = new NullProgressMonitor();
   private static Map<String, IProject> allProjects;
@@ -64,10 +63,11 @@ public abstract class ChildModuleWarPublishTest {
 
   @AfterClass
   public static void tearDown() {
-    ProjectUtils.waitForProjects(allProjects.values());
-    for (IProject project : allProjects.values()) {
+    IProject[] projects = allProjects.values().toArray(new IProject[0]);
+    ProjectUtils.waitForProjects(projects);
+    if (projects.length > 0) {
       try {
-        project.delete(true, null);
+        projects[0].getWorkspace().delete(projects, true, null);
       } catch (CoreException | RuntimeException ex) {
         Logger.getLogger(ChildModuleWarPublishTest.class.getName()).log(Level.WARNING,
             ex.getMessage(), ex);

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ChildModuleWarPublishTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.appengine.deploy.WarPublisher;
+import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.ZipUtil;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
@@ -36,6 +37,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -51,6 +53,8 @@ public abstract class ChildModuleWarPublishTest {
   private static Map<String, IProject> allProjects;
   private static IProject project;
 
+  private static final SWTWorkbenchBot bot = new SWTWorkbenchBot();
+
   protected abstract List<String> getExpectedChildModuleNames();
 
   protected static void loadTestProjectZip(String testZip, String mainProject)
@@ -63,6 +67,13 @@ public abstract class ChildModuleWarPublishTest {
 
   @AfterClass
   public static void tearDown() {
+    // Collapse projects to avoid "No IModelProvider exists for project" errors
+    // https://bugs.eclipse.org/bugs/show_bug.cgi?id=511541
+    SwtBotProjectActions.collapseProjects(bot);
+
+    // close editors, so no property changes are dispatched on delete
+    bot.closeAllEditors();
+
     IProject[] projects = allProjects.values().toArray(new IProject[0]);
     ProjectUtils.waitForProjects(projects);
     if (projects.length > 0) {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectContextMenuTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectContextMenuTest.java
@@ -23,7 +23,9 @@ import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.cloud.tools.eclipse.swtbot.MenuMatcher;
 import com.google.cloud.tools.eclipse.swtbot.SwtBotProjectActions;
+import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
@@ -36,6 +38,7 @@ import org.junit.rules.TemporaryFolder;
 public class ProjectContextMenuTest extends BaseProjectTest {
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   @Test
   public void testPlainJavaProject() {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectContextMenuTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectContextMenuTest.java
@@ -137,7 +137,7 @@ public class ProjectContextMenuTest extends BaseProjectTest {
 
   @Test
   public void testMavenAppEngineStandardJava7() {
-    IProject project =
+    project =
         SwtBotAppEngineActions.createMavenWebAppProject(
             bot,
             "projectContextMenuJava7",
@@ -160,7 +160,7 @@ public class ProjectContextMenuTest extends BaseProjectTest {
 
   @Test
   public void testMavenAppEngineStandardJava8() {
-    IProject project =
+    project =
         SwtBotAppEngineActions.createMavenWebAppProject(
             bot,
             "projectContextMenuJava8",

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotProjectActions.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.matchers.WidgetMatcherFactory;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.finders.ContextMenuHelper;
@@ -32,6 +33,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.ui.IPageLayout;
 
 /**
  * SWTBot utility methods that perform general workbench actions.
@@ -247,6 +249,18 @@ public final class SwtBotProjectActions {
       item = item.getNode(folder);
     }
     return item;
+  }
+
+  /** Collapse all projects shown in the Project Explorer. */
+  public static void collapseProjects(SWTWorkbenchBot bot) {
+    for (SWTBotView explorer :
+        bot.views(WidgetMatcherFactory.withPartId(IPageLayout.ID_PROJECT_EXPLORER))) {
+      Widget explorerWidget = explorer.getWidget();
+      Tree explorerTree = bot.widget(widgetOfType(Tree.class), explorerWidget);
+      for (SWTBotTreeItem item : new SWTBotTree(explorerTree).getAllItems()) {
+        item.collapse();
+      }
+    }
   }
 
   private SwtBotProjectActions() {}


### PR DESCRIPTION
  - use `IWorkspace#delete(IResource[], …)` to delete all related projects to avoid build errors from dependent projects disappearing
  - collapse projects shown in _Project Explorer_ to avoid model-refreshes during project deletion
  - ensure maven projects are deleted (`project` field should not be shadowed)

Fixes #3104 