### PR TITLE
Add Objectify filter when creating new projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CloudSdkStagingHelper.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy/src/com/google/cloud/tools/eclipse/appengine/deploy/CloudSdkStagingHelper.java
@@ -71,7 +71,7 @@ public class CloudSdkStagingHelper {
   public static void stageFlexible(IPath appEngineDirectory, IPath deployArtifact,
       IPath stagingDirectory, IProgressMonitor monitor) throws AppEngineException {
     if (monitor.isCanceled()) {
-      throw new OperationCanceledException("canceled early");
+      throw new OperationCanceledException("canceled early"); //$NON-NLS-1$
     }
 
     SubMonitor progress = SubMonitor.convert(monitor, 1);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineWebDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineWebDescriptor.java
@@ -30,8 +30,7 @@ import org.eclipse.jface.viewers.StyledString;
 public class AppEngineWebDescriptor extends AppEngineResourceElement {
   private final AppEngineDescriptor descriptor;
 
-  public AppEngineWebDescriptor(IProject project, IFile file,
-      AppEngineDescriptor descriptor) {
+  public AppEngineWebDescriptor(IProject project, IFile file, AppEngineDescriptor descriptor) {
     super(project, file);
     this.descriptor = Preconditions.checkNotNull(descriptor);
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -187,33 +187,33 @@ public class CodeTemplatesTest {
   }
 
   @Test
-  public void testSelectedObjectify_notSelected() {
+  public void testIsObjectifySelected_notSelected() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
-    assertFalse(CodeTemplates.selectedObjectify(config));
+    assertFalse(CodeTemplates.isObjectifySelected(config));
   }
 
   @Test
-  public void testSelectedObjectify_selected() {
+  public void testIsObjectifySelected_selected() {
     List<Library> libraries = Arrays.asList(new Library("a-library"), new Library("objectify"));
 
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setAppEngineLibraries(libraries);
 
-    assertTrue(CodeTemplates.selectedObjectify(config));
+    assertTrue(CodeTemplates.isObjectifySelected(config));
   }
 
   @Test
-  public void testSelectedStandardJava7Runtime_java7() {
+  public void testIsStandardJava7RuntimeSelected_java7() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setRuntimeId(null);  // null runtime corresponds to Java 7 runtime
-    assertTrue(CodeTemplates.selectedStandardJava7Runtime(config));
+    assertTrue(CodeTemplates.isStandardJava7RuntimeSelected(config));
   }
 
   @Test
-  public void testSelectedStandardJava7Runtime_java8() {
+  public void testIsStandardJava7RuntimeSelected_java8() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setRuntimeId("java8");
-    assertFalse(CodeTemplates.selectedStandardJava7Runtime(config));
+    assertFalse(CodeTemplates.isStandardJava7RuntimeSelected(config));
   }
 
   private boolean objectifyFilterClassExists() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -187,34 +187,33 @@ public class CodeTemplatesTest {
   }
 
   @Test
-  public void testIsObjectifySelected_notSelected() {
+  public void testSelectedObjectify_notSelected() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
-    assertFalse(CodeTemplates.isObjectifySelected(config));
+    assertFalse(CodeTemplates.selectedObjectify(config));
   }
 
   @Test
-  public void testIsObjectifySelected_selected() {
-    List<Library> libraries = Arrays.asList(
-        new Library("someLibrary"), new Library("objectify"), new Library("anotherLibrary"));
+  public void testSelectedObjectify_selected() {
+    List<Library> libraries = Arrays.asList(new Library("a-library"), new Library("objectify"));
 
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setAppEngineLibraries(libraries);
 
-    assertTrue(CodeTemplates.isObjectifySelected(config));
+    assertTrue(CodeTemplates.selectedObjectify(config));
   }
 
   @Test
-  public void testIsStandardJava7Runtime_nullRuntimeIsJava7() {
+  public void testSelectedStandardJava7Runtime_java7() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
-    config.setRuntimeId(null);
-    assertTrue(CodeTemplates.isStandardJava7Runtime(config));
+    config.setRuntimeId(null);  // null runtime corresponds to Java 7 runtime
+    assertTrue(CodeTemplates.selectedStandardJava7Runtime(config));
   }
 
   @Test
-  public void testIsStandardJava7Runtime_nonNullRuntime() {
+  public void testSelectedStandardJava7Runtime_java8() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setRuntimeId("java8");
-    assertFalse(CodeTemplates.isStandardJava7Runtime(config));
+    assertFalse(CodeTemplates.selectedStandardJava7Runtime(config));
   }
 
   private boolean objectifyFilterClassExists() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -16,8 +16,11 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.util.MappedNamespaceContext;
@@ -31,7 +34,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.xml.parsers.DocumentBuilder;
@@ -96,6 +102,49 @@ public class CodeTemplatesTest {
   }
 
   @Test
+  public void testMaterializeAppEngineStandardFiles_noObjectifyWithJava7()
+      throws CoreException, ParserConfigurationException, SAXException, IOException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
+    assertFalse(objectifyFilterClassExists());
+    validateObjectifyFilterConfigInWebXml(false);
+  }
+
+  @Test
+  public void testMaterializeAppEngineStandardFiles_objectifyWithJava7()
+      throws CoreException, ParserConfigurationException, SAXException, IOException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(Collections.singleton(new Library("objectify")));
+
+    CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
+    assertFalse(objectifyFilterClassExists());
+    validateObjectifyFilterConfigInWebXml(true);
+  }
+
+  @Test
+  public void testMaterializeAppEngineStandardFiles_noObjectifyWithJava8()
+      throws CoreException, ParserConfigurationException, SAXException, IOException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setRuntimeId(AppEngineRuntime.STANDARD_JAVA_8.getId());
+
+    CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
+    assertFalse(objectifyFilterClassExists());
+    validateObjectifyFilterConfigInWebXml(false);
+  }
+
+  @Test
+  public void testMaterializeAppEngineStandardFiles_objectifyWithJava8()
+      throws CoreException, ParserConfigurationException, SAXException, IOException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setRuntimeId(AppEngineRuntime.STANDARD_JAVA_8.getId());
+    config.setAppEngineLibraries(Collections.singleton(new Library("objectify")));
+
+    CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
+    assertTrue(objectifyFilterClassExists());
+    validateObjectifyFilterConfigInWebXml(false);
+  }
+
+  @Test
   public void testMaterializeAppEngineStandardFiles_noPomXml() throws CoreException {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
@@ -135,6 +184,62 @@ public class CodeTemplatesTest {
     config.setUseMaven("my.project.group.id", "my-project-artifact-id", "98.76.54");
     CodeTemplates.materializeAppEngineFlexFiles(project, config, monitor);
     validateFlexPomXml();
+  }
+
+  @Test
+  public void testIsObjectifySelected_notSelected() {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    assertFalse(CodeTemplates.isObjectifySelected(config));
+  }
+
+  @Test
+  public void testIsObjectifySelected_selected() {
+    List<Library> libraries = Arrays.asList(
+        new Library("someLibrary"), new Library("objectify"), new Library("anotherLibrary"));
+
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(libraries);
+
+    assertTrue(CodeTemplates.isObjectifySelected(config));
+  }
+
+  @Test
+  public void testIsStandardJava7Runtime_nullRuntimeIsJava7() {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setRuntimeId(null);
+    assertTrue(CodeTemplates.isStandardJava7Runtime(config));
+  }
+
+  @Test
+  public void testIsStandardJava7Runtime_nonNullRuntime() {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setRuntimeId("java8");
+    assertFalse(CodeTemplates.isStandardJava7Runtime(config));
+  }
+
+  private boolean objectifyFilterClassExists() {
+    return project.getFile("src/main/java/ObjectifyWebFilter.java").exists();
+  }
+
+  private void validateObjectifyFilterConfigInWebXml(boolean configExpected)
+      throws ParserConfigurationException, SAXException, IOException, CoreException {
+    IFile webXml = project.getFile("src/main/webapp/WEB-INF/web.xml");
+    Element root = buildDocument(webXml).getDocumentElement();
+
+    NodeList filterNames =
+        root.getElementsByTagNameNS("http://java.sun.com/xml/ns/javaee", "filter-name");
+    if (configExpected) {
+      assertEquals(2, filterNames.getLength());
+      assertEquals("ObjectifyFilter", filterNames.item(0).getTextContent());
+      assertEquals("ObjectifyFilter", filterNames.item(1).getTextContent());
+
+      NodeList filterClass =
+          root.getElementsByTagNameNS("http://java.sun.com/xml/ns/javaee", "filter-class");
+      assertEquals(
+          "com.googlecode.objectify.ObjectifyFilter", filterClass.item(0).getTextContent());
+    } else {
+      assertEquals(0, filterNames.getLength());
+    }
   }
 
   private void validateNonConfigFiles(IFile mostImportant,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -193,8 +193,18 @@ public class CodeTemplatesTest {
   }
 
   @Test
-  public void testIsObjectifySelected_selected() {
+  public void testIsObjectifySelected_objectify5() {
     List<Library> libraries = Arrays.asList(new Library("a-library"), new Library("objectify"));
+
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(libraries);
+
+    assertTrue(CodeTemplates.isObjectifySelected(config));
+  }
+
+  @Test
+  public void testIsObjectifySelected_objectify6() {
+    List<Library> libraries = Arrays.asList(new Library("objectify6"), new Library("a-library"));
 
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setAppEngineLibraries(libraries);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.newproject;
 
+import com.google.cloud.tools.eclipse.appengine.libraries.model.Library;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineRuntime;
 import com.google.cloud.tools.eclipse.util.ArtifactRetriever;
 import com.google.cloud.tools.eclipse.util.Templates;
@@ -25,7 +26,9 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -100,7 +103,7 @@ public class CodeTemplates {
 
   private static IFile createJavaSourceFiles(IProject project, AppEngineProjectConfig config,
       boolean isStandardProject, IProgressMonitor monitor) throws CoreException {
-    SubMonitor subMonitor = SubMonitor.convert(monitor, 15);
+    SubMonitor subMonitor = SubMonitor.convert(monitor, 20);
 
     String packageName = config.getPackageName();
     String packagePath = packageName.replace('.', '/');
@@ -109,8 +112,9 @@ public class CodeTemplates {
 
     Map<String, String> properties = new HashMap<>();
     properties.put("package", Strings.nullToEmpty(packageName)); //$NON-NLS-1$
-    if (isStandardProject
-        && Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId())) {
+
+    boolean servlet25 = isStandardProject && isStandardJava7Runtime(config); 
+    if (servlet25) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
     } else {
       properties.put("servletVersion", "3.1"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -118,14 +122,20 @@ public class CodeTemplates {
 
     IFile hello = createChildFile("HelloAppEngine.java", //$NON-NLS-1$
         Templates.HELLO_APPENGINE_TEMPLATE,
-        mainPackageFolder, properties, subMonitor.newChild(5));
+        mainPackageFolder, properties, subMonitor.split(5));
 
     createChildFile("HelloAppEngineTest.java", //$NON-NLS-1$
-        Templates.HELLO_APPENGINE_TEST_TEMPLATE, testPackageFolder,
-        properties, subMonitor.newChild(5));
+        Templates.HELLO_APPENGINE_TEST_TEMPLATE,
+        testPackageFolder, properties, subMonitor.split(5));
     createChildFile("MockHttpServletResponse.java", //$NON-NLS-1$
         Templates.MOCK_HTTPSERVLETRESPONSE_TEMPLATE,
-        testPackageFolder, properties, subMonitor.newChild(5));
+        testPackageFolder, properties, subMonitor.split(5));
+
+    if (isObjectifySelected(config) && !servlet25) {
+      createChildFile("ObjectifyWebFilter.java", //$NON-NLS-1$
+          Templates.OBJECTIFY_WEB_FILTER_TEMPLATE,
+          mainPackageFolder, properties, subMonitor.split(5));
+    }
 
     return hello;
   }
@@ -165,10 +175,13 @@ public class CodeTemplates {
     String packageValue = config.getPackageName().isEmpty()
         ? ""  //$NON-NLS-1$
         : config.getPackageName() + "."; //$NON-NLS-1$
-    properties.put("package", packageValue);  //$NON-NLS-1$
+    properties.put("package", packageValue); //$NON-NLS-1$
 
-    if (isStandardProject
-        && Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId())) {
+    if (isObjectifySelected(config)) {
+      properties.put("objectifyAdded", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    if (isStandardProject && isStandardJava7Runtime(config)) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("namespace", "http://java.sun.com/xml/ns/javaee"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("schemaUrl", "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -181,6 +194,16 @@ public class CodeTemplates {
     IFolder webInf = project.getFolder("src/main/webapp/WEB-INF"); //$NON-NLS-1$
     createChildFile("web.xml", Templates.WEB_XML_TEMPLATE, webInf, //$NON-NLS-1$
         properties, monitor);
+  }
+
+  private static boolean isStandardJava7Runtime(AppEngineProjectConfig config) {
+    return Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId());
+  }
+
+  private static boolean isObjectifySelected(AppEngineProjectConfig config) {
+    Predicate<Library> isObjectify = library -> "objectify".equals(library.getId()); //$NON-NLS-1$
+    List<Library> selectedLibraries = config.getAppEngineLibraries();
+    return selectedLibraries.stream().anyMatch(isObjectify);
   }
 
   private static void createWebContents(IProject project, IProgressMonitor monitor)
@@ -220,7 +243,7 @@ public class CodeTemplates {
     properties.put("appEngineApiSdkVersion", sdkVersion); //$NON-NLS-1$
     
     if (isStandardProject) {
-      if (Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId())) {
+      if (isStandardJava7Runtime(config)) {
         properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
         properties.put("compilerVersion", "1.7"); //$NON-NLS-1$ //$NON-NLS-2$
       } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -113,7 +113,7 @@ public class CodeTemplates {
     Map<String, String> properties = new HashMap<>();
     properties.put("package", Strings.nullToEmpty(packageName)); //$NON-NLS-1$
 
-    boolean servlet25 = isStandardProject && selectedStandardJava7Runtime(config);
+    boolean servlet25 = isStandardProject && isStandardJava7RuntimeSelected(config);
     if (servlet25) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
     } else {
@@ -131,7 +131,7 @@ public class CodeTemplates {
         Templates.MOCK_HTTPSERVLETRESPONSE_TEMPLATE,
         testPackageFolder, properties, subMonitor.split(5));
 
-    if (selectedObjectify(config) && !servlet25) {
+    if (isObjectifySelected(config) && !servlet25) {
       createChildFile("ObjectifyWebFilter.java", //$NON-NLS-1$
           Templates.OBJECTIFY_WEB_FILTER_TEMPLATE,
           mainPackageFolder, properties, subMonitor.split(5));
@@ -177,11 +177,11 @@ public class CodeTemplates {
         : config.getPackageName() + "."; //$NON-NLS-1$
     properties.put("package", packageValue); //$NON-NLS-1$
 
-    if (selectedObjectify(config)) {
+    if (isObjectifySelected(config)) {
       properties.put("objectifyAdded", "true"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    if (isStandardProject && selectedStandardJava7Runtime(config)) {
+    if (isStandardProject && isStandardJava7RuntimeSelected(config)) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("namespace", "http://java.sun.com/xml/ns/javaee"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("schemaUrl", "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -197,12 +197,12 @@ public class CodeTemplates {
   }
 
   @VisibleForTesting
-  static boolean selectedStandardJava7Runtime(AppEngineProjectConfig config) {
+  static boolean isStandardJava7RuntimeSelected(AppEngineProjectConfig config) {
     return Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId());
   }
 
   @VisibleForTesting
-  static boolean selectedObjectify(AppEngineProjectConfig config) {
+  static boolean isObjectifySelected(AppEngineProjectConfig config) {
     Predicate<Library> isObjectify = library -> "objectify".equals(library.getId()); //$NON-NLS-1$
     List<Library> selectedLibraries = config.getAppEngineLibraries();
     return selectedLibraries.stream().anyMatch(isObjectify);
@@ -245,7 +245,7 @@ public class CodeTemplates {
     properties.put("appEngineApiSdkVersion", sdkVersion); //$NON-NLS-1$
     
     if (isStandardProject) {
-      if (selectedStandardJava7Runtime(config)) {
+      if (isStandardJava7RuntimeSelected(config)) {
         properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
         properties.put("compilerVersion", "1.7"); //$NON-NLS-1$ //$NON-NLS-2$
       } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -203,7 +203,9 @@ public class CodeTemplates {
 
   @VisibleForTesting
   static boolean isObjectifySelected(AppEngineProjectConfig config) {
-    Predicate<Library> isObjectify = library -> "objectify".equals(library.getId()); //$NON-NLS-1$
+    Predicate<Library> isObjectify = library ->
+        ("objectify".equals(library.getId()) //$NON-NLS-1$
+            || "objectify6".equals(library.getId())); //$NON-NLS-1$
     List<Library> selectedLibraries = config.getAppEngineLibraries();
     return selectedLibraries.stream().anyMatch(isObjectify);
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -113,7 +113,7 @@ public class CodeTemplates {
     Map<String, String> properties = new HashMap<>();
     properties.put("package", Strings.nullToEmpty(packageName)); //$NON-NLS-1$
 
-    boolean servlet25 = isStandardProject && isStandardJava7Runtime(config); 
+    boolean servlet25 = isStandardProject && selectedStandardJava7Runtime(config);
     if (servlet25) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
     } else {
@@ -131,7 +131,7 @@ public class CodeTemplates {
         Templates.MOCK_HTTPSERVLETRESPONSE_TEMPLATE,
         testPackageFolder, properties, subMonitor.split(5));
 
-    if (isObjectifySelected(config) && !servlet25) {
+    if (selectedObjectify(config) && !servlet25) {
       createChildFile("ObjectifyWebFilter.java", //$NON-NLS-1$
           Templates.OBJECTIFY_WEB_FILTER_TEMPLATE,
           mainPackageFolder, properties, subMonitor.split(5));
@@ -177,11 +177,11 @@ public class CodeTemplates {
         : config.getPackageName() + "."; //$NON-NLS-1$
     properties.put("package", packageValue); //$NON-NLS-1$
 
-    if (isObjectifySelected(config)) {
+    if (selectedObjectify(config)) {
       properties.put("objectifyAdded", "true"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    if (isStandardProject && isStandardJava7Runtime(config)) {
+    if (isStandardProject && selectedStandardJava7Runtime(config)) {
       properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("namespace", "http://java.sun.com/xml/ns/javaee"); //$NON-NLS-1$ //$NON-NLS-2$
       properties.put("schemaUrl", "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -197,12 +197,12 @@ public class CodeTemplates {
   }
 
   @VisibleForTesting
-  static boolean isStandardJava7Runtime(AppEngineProjectConfig config) {
+  static boolean selectedStandardJava7Runtime(AppEngineProjectConfig config) {
     return Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId());
   }
 
   @VisibleForTesting
-  static boolean isObjectifySelected(AppEngineProjectConfig config) {
+  static boolean selectedObjectify(AppEngineProjectConfig config) {
     Predicate<Library> isObjectify = library -> "objectify".equals(library.getId()); //$NON-NLS-1$
     List<Library> selectedLibraries = config.getAppEngineLibraries();
     return selectedLibraries.stream().anyMatch(isObjectify);
@@ -245,7 +245,7 @@ public class CodeTemplates {
     properties.put("appEngineApiSdkVersion", sdkVersion); //$NON-NLS-1$
     
     if (isStandardProject) {
-      if (isStandardJava7Runtime(config)) {
+      if (selectedStandardJava7Runtime(config)) {
         properties.put("servletVersion", "2.5"); //$NON-NLS-1$ //$NON-NLS-2$
         properties.put("compilerVersion", "1.7"); //$NON-NLS-1$ //$NON-NLS-2$
       } else {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -196,11 +196,13 @@ public class CodeTemplates {
         properties, monitor);
   }
 
-  private static boolean isStandardJava7Runtime(AppEngineProjectConfig config) {
+  @VisibleForTesting
+  static boolean isStandardJava7Runtime(AppEngineProjectConfig config) {
     return Objects.equal(AppEngineRuntime.STANDARD_JAVA_7.getId(), config.getRuntimeId());
   }
 
-  private static boolean isObjectifySelected(AppEngineProjectConfig config) {
+  @VisibleForTesting
+  static boolean isObjectifySelected(AppEngineProjectConfig config) {
     Predicate<Library> isObjectify = library -> "objectify".equals(library.getId()); //$NON-NLS-1$
     List<Library> selectedLibraries = config.getAppEngineLibraries();
     return selectedLibraries.stream().anyMatch(isObjectify);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineRuntime.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineRuntime.java
@@ -23,7 +23,7 @@ import java.util.EnumSet;
  */
 public enum AppEngineRuntime {
   STANDARD_JAVA_7(Messages.getString("appengine.runtimes.java7"), null), // $NON-NLS-1$
-  STANDARD_JAVA_8(Messages.getString("appengine.runtimes.java8"), "java8"); // $NON-NLS-1$$NON-NLS-2$
+  STANDARD_JAVA_8(Messages.getString("appengine.runtimes.java8"), "java8"); // $NON-NLS-1$ //$NON-NLS-2$
 
   public static final EnumSet<AppEngineRuntime> STANDARD_RUNTIMES =
       EnumSet.of(STANDARD_JAVA_7, STANDARD_JAVA_8);

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -44,7 +44,7 @@ public class TemplatesTest {
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
-  private IProgressMonitor monitor = new NullProgressMonitor();
+  private final IProgressMonitor monitor = new NullProgressMonitor();
   private IProject project;
   private String fileLocation;
   private final Map<String, String> dataMap = new HashMap<>();
@@ -66,9 +66,7 @@ public class TemplatesTest {
 
   @Test
   public void testCreateFileContent_appengineWebXml() throws CoreException, IOException {
-    Templates.createFileContent(fileLocation,
-        Templates.APPENGINE_WEB_XML_TEMPLATE,
-        dataMap);
+    Templates.createFileContent(fileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE, dataMap);
 
     compareToFile("appengineWebXml.txt");
   }
@@ -77,9 +75,7 @@ public class TemplatesTest {
   public void testCreateFileContent_appengineWebXmlWithService()
       throws CoreException, IOException {
     dataMap.put("service", "foobar");
-    Templates.createFileContent(fileLocation,
-        Templates.APPENGINE_WEB_XML_TEMPLATE,
-        dataMap);
+    Templates.createFileContent(fileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE, dataMap);
 
     compareToFile("appengineWebXmlWithService.txt");
   }
@@ -88,9 +84,7 @@ public class TemplatesTest {
   public void testCreateFileContent_appengineWebXmlWithRuntime()
       throws CoreException, IOException {
     dataMap.put("runtime", "java8");
-    Templates.createFileContent(fileLocation,
-        Templates.APPENGINE_WEB_XML_TEMPLATE,
-        dataMap);
+    Templates.createFileContent(fileLocation, Templates.APPENGINE_WEB_XML_TEMPLATE, dataMap);
 
     compareToFile("appEngineWebXmlWithRuntime.txt");
   }
@@ -100,9 +94,7 @@ public class TemplatesTest {
   public void testCreateFileContent_appYamlWithService()
       throws CoreException, IOException {
     dataMap.put("service", "foobar");
-    Templates.createFileContent(fileLocation,
-        Templates.APP_YAML_TEMPLATE,
-        dataMap);
+    Templates.createFileContent(fileLocation, Templates.APP_YAML_TEMPLATE, dataMap);
 
     compareToFile("appYamlWithService.txt");
   }
@@ -111,8 +103,7 @@ public class TemplatesTest {
   public void testCreateFileContent_helloAppEngineWithPackage() throws CoreException, IOException {
     dataMap.put("package", "com.example");
     dataMap.put("servletVersion", "2.5");
-    Templates.createFileContent(fileLocation,
-        Templates.HELLO_APPENGINE_TEMPLATE, dataMap);
+    Templates.createFileContent(fileLocation, Templates.HELLO_APPENGINE_TEMPLATE, dataMap);
 
     compareToFile("helloAppEngineWithPackage.txt");
   }
@@ -122,8 +113,7 @@ public class TemplatesTest {
       throws CoreException, IOException {
     dataMap.put("package", "");
     dataMap.put("servletVersion", "2.5");
-    Templates.createFileContent(fileLocation,
-        Templates.HELLO_APPENGINE_TEMPLATE, dataMap);
+    Templates.createFileContent(fileLocation, Templates.HELLO_APPENGINE_TEMPLATE, dataMap);
 
     compareToFile("helloAppEngineWithoutPackage.txt");
   }
@@ -142,8 +132,7 @@ public class TemplatesTest {
     dataMap.put("servletVersion", "2.5");
     dataMap.put("namespace", "http://java.sun.com/xml/ns/javaee");
     dataMap.put("schemaUrl", "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd");
-    Templates.createFileContent(fileLocation,
-        Templates.WEB_XML_TEMPLATE, dataMap);
+    Templates.createFileContent(fileLocation, Templates.WEB_XML_TEMPLATE, dataMap);
 
     compareToFile("web25.txt");
   }
@@ -175,6 +164,24 @@ public class TemplatesTest {
     Templates.createFileContent(fileLocation, Templates.LOGGING_PROPERTIES_TEMPLATE, dataMap);
 
     compareToFile("loggingProperties.txt");
+  }
+
+  @Test
+  public void testCreateFileContent_objectifyWebFilterWithPackage()
+      throws CoreException, IOException {
+    dataMap.put("package", "com.example");
+    Templates.createFileContent(fileLocation, Templates.OBJECTIFY_WEB_FILTER_TEMPLATE, dataMap);
+
+    compareToFile("objectifyWebFilterWithPackage.txt");
+  }
+
+  @Test
+  public void testCreateFileContent_objectifyWebFilterWithoutPackage()
+      throws CoreException, IOException {
+    dataMap.put("package", "");
+    Templates.createFileContent(fileLocation, Templates.OBJECTIFY_WEB_FILTER_TEMPLATE, dataMap);
+
+    compareToFile("objectifyWebFilterWithoutPackage.txt");
   }
 
   private static InputStream getDataFile(String fileName) throws IOException {

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -138,6 +138,18 @@ public class TemplatesTest {
   }
 
   @Test
+  public void testCreateFileContent_web25ObjectifyFilter() throws CoreException, IOException {
+    dataMap.put("package", "com.example.");
+    dataMap.put("servletVersion", "2.5");
+    dataMap.put("namespace", "http://java.sun.com/xml/ns/javaee");
+    dataMap.put("schemaUrl", "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd");
+    dataMap.put("objectifyAdded", "true");
+    Templates.createFileContent(fileLocation, Templates.WEB_XML_TEMPLATE, dataMap);
+
+    compareToFile("web25ObjectifyFilter.txt");
+  }
+
+  @Test
   public void testCreateFileContent_web31() throws CoreException, IOException {
     dataMap.put("package", "com.example.");
     dataMap.put("servletVersion", "3.1");

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -159,6 +159,18 @@ public class TemplatesTest {
 
     compareToFile("web31.txt");
   }
+
+  @Test
+  public void testCreateFileContent_noObjectifyFilterForWeb31() throws CoreException, IOException {
+    dataMap.put("package", "com.example.");
+    dataMap.put("servletVersion", "3.1");
+    dataMap.put("namespace", "http://xmlns.jcp.org/xml/ns/javaee");
+    dataMap.put("schemaUrl", "http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd");
+    dataMap.put("objectifyAdded", "true");
+    Templates.createFileContent(fileLocation, Templates.WEB_XML_TEMPLATE, dataMap);
+
+    compareToFile("web31.txt");
+  }
   
   @Test
   public void testCreateFileContent_Java8Servlet() throws CoreException, IOException {

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineJava8.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineJava8.txt
@@ -16,7 +16,7 @@ public class HelloAppEngine extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
       throws IOException {
-      
+
     response.setContentType("text/plain");
     response.setCharacterEncoding("UTF-8");
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineWithPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineWithPackage.txt
@@ -11,7 +11,7 @@ public class HelloAppEngine extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
       throws IOException {
-      
+
     response.setContentType("text/plain");
     response.setCharacterEncoding("UTF-8");
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineWithoutPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/helloAppEngineWithoutPackage.txt
@@ -9,7 +9,7 @@ public class HelloAppEngine extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
       throws IOException {
-      
+
     response.setContentType("text/plain");
     response.setCharacterEncoding("UTF-8");
 

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebFilterWithPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebFilterWithPackage.txt
@@ -1,0 +1,12 @@
+package com.example;
+
+import javax.servlet.annotation.WebFilter;
+
+import com.googlecode.objectify.ObjectifyFilter;
+
+/**
+ * Filter required by Objectify to clean up any thread-local transaction contexts and pending
+ * asynchronous operations that remain at the end of a request.
+ */
+@WebFilter(urlPatterns = {"/*"})
+public class ObjectifyWebFilter extends ObjectifyFilter {}

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebFilterWithoutPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebFilterWithoutPackage.txt
@@ -1,0 +1,10 @@
+import javax.servlet.annotation.WebFilter;
+
+import com.googlecode.objectify.ObjectifyFilter;
+
+/**
+ * Filter required by Objectify to clean up any thread-local transaction contexts and pending
+ * asynchronous operations that remain at the end of a request.
+ */
+@WebFilter(urlPatterns = {"/*"})
+public class ObjectifyWebFilter extends ObjectifyFilter {}

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/web25ObjectifyFilter.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/web25ObjectifyFilter.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         version="2.5">
+  <servlet>
+    <servlet-name>HelloAppEngine</servlet-name>
+    <servlet-class>com.example.HelloAppEngine</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>HelloAppEngine</servlet-name>
+    <url-pattern>/hello</url-pattern>
+  </servlet-mapping>
+  <filter>
+    <filter-name>ObjectifyFilter</filter-name>
+    <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ObjectifyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+    <welcome-file>index.jsp</welcome-file>
+  </welcome-file-list>
+</web-app>

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
@@ -46,6 +46,7 @@ public class Templates {
   public static final String POM_XML_STANDARD_TEMPLATE = "pom.xml.standard.ftl";
   public static final String POM_XML_FLEX_TEMPLATE = "pom.xml.flex.ftl";
   public static final String LOGGING_PROPERTIES_TEMPLATE = "logging.properties.ftl";
+  public static final String OBJECTIFY_WEB_FILTER_TEMPLATE = "ObjectifyWebFilter.java.ftl";
 
   private static Configuration configuration;
 

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/HelloAppEngine.java.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/HelloAppEngine.java.ftl
@@ -20,7 +20,7 @@ public class HelloAppEngine extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
       throws IOException {
-      
+
     response.setContentType("text/plain");
     response.setCharacterEncoding("UTF-8");
 

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/ObjectifyWebFilter.java.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/ObjectifyWebFilter.java.ftl
@@ -1,0 +1,12 @@
+<#if package != "">package ${package};
+
+</#if>import javax.servlet.annotation.WebFilter;
+
+import com.googlecode.objectify.ObjectifyFilter;
+
+/**
+ * Filter required by Objectify to clean up any thread-local transaction contexts and pending
+ * asynchronous operations that remain at the end of a request.
+ */
+@WebFilter(urlPatterns = {"/*"})
+public class ObjectifyWebFilter extends ObjectifyFilter {}

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/web.xml.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/web.xml.ftl
@@ -12,6 +12,16 @@
     <servlet-name>HelloAppEngine</servlet-name>
     <url-pattern>/hello</url-pattern>
   </servlet-mapping>
+<#if objectifyAdded??>
+  <filter>
+    <filter-name>ObjectifyFilter</filter-name>
+    <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>ObjectifyFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+</#if>
 </#if>
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>


### PR DESCRIPTION
Fixes #3076

The filter is needed for both Objectify 5 and 6. The filter covers all incoming URLs (`/*`).

- Standard Java 7: `<filter> and <filter-mapping>` in `web.xml`
- Standard Java 8 and Flexible: new `ObjectifyWebFilter` class with the `@WebFilter` annotation (no change in `web.xml`)