### PR TITLE
Tycho 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
   </modules>
 
   <properties>
-    <tycho.version>1.1.0</tycho.version>
-    <tycho-extras.version>1.0.0</tycho-extras.version>
+    <tycho.version>1.2.0</tycho.version>
+    <tycho-extras.version>1.2.0</tycho-extras.version>
     <product.version.qualifier.suffix/>  <!-- 0-length string by default -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>oxygen</eclipse.target>


### PR DESCRIPTION
Tycho 1.2.0 has been released.  It supports JUnit 5 tests and Java 10.  Nothing that affects us, but keeping up to date is good.