### PR TITLE
Update to Photon RC3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Maven for building Eclipse bundles and features.
 
 1. The [Google Cloud SDK](https://cloud.google.com/sdk/); install
   this somewhere on your file system.
+  
+  An alternative is to install _Cloud Tools for Eclipse_ into your Eclipse IDE and use its option to automatically install the _Cloud SDK_.
+
+1. JDK 8
 
 1. The [Eclipse IDE](https://www.eclipse.org/downloads/eclipse-packages/).
   It's easiest to use the _Eclipse IDE for Java EE Developers_ package. You must use
@@ -36,14 +40,12 @@ Maven for building Eclipse bundles and features.
      for _Dependency_ and install.
 
   3. The [Google Java Format plugin for Eclipse](https://github.com/google/google-java-format/).
-     Download the [latest version](https://github.com/google/google-java-format/releases/).
+     Download the [latest version](https://github.com/google/google-java-format/releases/)
      and place the jar into your Eclipse installation's `dropins/` directory
      (on MacOS this may be in `Eclipse.app/Contents/Eclipse/dropins/`).
 
 1. Maven 3.5.0 or later.  Although m2eclipse is bundled with its own Maven install,
    Maven is necessary to test command-line builds.
-
-1. JDK 8
 
 1. git (optional: you can use EGit from within Eclipse instead)
 
@@ -181,7 +183,8 @@ target platform whenever dependencies are updated.
      contains the project.
 
   1. Under `Projects:` the `pom.xml` files representing modules should be
-     displayed. Make sure that all of them are selected, and click `Finish`.
+     displayed. Make sure that all of them are selected _except_ the sub-directories under `eclipse`, and click `Finish`.
+     - The subprojects under the `eclipse` directory define target platforms for the Tycho build. It's easier to edit the files from the `eclipse-setup` project.
 
   1. Maven may prompt you to install several additional plugin connector plugins from
   [Tycho](https://eclipse.org/tycho/) if they are not already installed. Click
@@ -194,7 +197,7 @@ target platform whenever dependencies are updated.
   1. There should be no errors in the `Markers` or `Problems` views in Eclipse.
     However you may see several low-priority warnings.
 
-      1. You may see Maven-related errors like _"plugin execution not
+      - You may see Maven-related errors like _"plugin execution not
          covered by lifecycle configuration"_.
          If so, right-click on the problem and select
          _Quick Fix_ > _Discover new m2e connectors_

--- a/eclipse/common-dependencies.tpd
+++ b/eclipse/common-dependencies.tpd
@@ -1,0 +1,23 @@
+/*
+ * Common Dependencies for the different platform Target Platform Dependencies.
+ */
+target "Cloud Tools for Eclipse: Common Dependencies"
+
+location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
+  org.hamcrest.core [1.3.0,1.3.1)
+  org.hamcrest.integration [1.3.0,1.3.1)
+  org.hamcrest.library [1.3.0,1.3.1)
+  org.slf4j.api
+  org.slf4j.apis.jcl
+  org.slf4j.apis.log4j
+  org.slf4j.bridge.jul
+  ch.qos.logback.slf4j
+}
+
+location "http://dadacoalition.org/yedit/" {
+  org.dadacoalition.yedit.feature.feature.group
+}
+
+location "http://download.eclipse.org/technology/swtbot/milestones/photon-m7/" {
+  org.eclipse.swtbot.eclipse.feature.group
+}

--- a/eclipse/common-dependencies.tpd
+++ b/eclipse/common-dependencies.tpd
@@ -18,6 +18,8 @@ location "http://dadacoalition.org/yedit/" {
   org.dadacoalition.yedit.feature.feature.group
 }
 
-location "http://download.eclipse.org/technology/swtbot/milestones/photon-m7/" {
+// SWTBot 2.7.0 will be released with Photon, and supports Neon, Oxygen, and Photon
+// Once released, link will be http://download.eclipse.org/technology/swtbot/releases/2.7.0
+location "http://download.eclipse.org/technology/swtbot/milestones/photon-rc3/" {
   org.eclipse.swtbot.eclipse.feature.group
 }

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1528475897">
+<target name="GCP for Eclipse Neon" sequenceNumber="1528482238">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
@@ -54,8 +54,8 @@
       <repository location="http://dadacoalition.org/yedit/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
-      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806051340"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-rc3/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1527803874">
+<target name="GCP for Eclipse Neon" sequenceNumber="1528475897">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
@@ -12,7 +12,6 @@
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.1.20160831-1005"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.21.0.v20160707-1856"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201607131827"/>
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.5.0.201609021837"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.4.v20170307-1435"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.4.v20170307-1435"/>
       <unit id="org.eclipse.jetty.http" version="9.3.9.v20160517"/>
@@ -32,6 +31,14 @@
       <repository location="http://download.eclipse.org/webtools/repository/neon/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.3.0.201704251823"/>
+      <repository location="http://download.eclipse.org/linuxtools/update-docker-neon3respinb"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
@@ -43,16 +50,12 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.3.0.201704251823"/>
-      <repository location="http://download.eclipse.org/linuxtools/update-docker-neon3respinb"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>
       <repository location="http://dadacoalition.org/yedit/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -20,7 +20,6 @@ location "http://download.eclipse.org/releases/neon/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group
 	org.eclipse.epp.logging.aeri.feature.source.feature.group
@@ -42,17 +41,6 @@ location "http://download.eclipse.org/webtools/repository/neon/" {
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
-    org.hamcrest.core [1.3.0,1.3.1)
-    org.hamcrest.integration [1.3.0,1.3.1)
-    org.hamcrest.library [1.3.0,1.3.1)
-    org.slf4j.api
-    org.slf4j.apis.jcl
-    org.slf4j.apis.log4j
-    org.slf4j.bridge.jul
-    ch.qos.logback.slf4j
-}
-
 location "http://docker-editor.openanalytics.eu/update/" {
     eu.openanalytics.editor.docker.feature.group
 }
@@ -62,6 +50,4 @@ location "http://download.eclipse.org/linuxtools/update-docker-neon3respinb" {
     org.eclipse.linuxtools.docker.feature.feature.group
 }
 
-location "http://dadacoalition.org/yedit/" {
-  org.dadacoalition.yedit.feature.feature.group
-}
+include "../common-dependencies.tpd"

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1528475893">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1528482234">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.3.v20180330-0919"/>
@@ -54,8 +54,8 @@
       <repository location="http://dadacoalition.org/yedit/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
-      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806051340"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-rc3/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1527803821">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1528475893">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.3.v20180330-0919"/>
@@ -12,7 +12,6 @@
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.3.20170823-1905"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170503-0014"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201803161350"/>
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.jetty.http" version="9.4.8.v20171121"/>
@@ -32,6 +31,14 @@
       <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.2/R-3.9.2-20171201000141/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
+      <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
@@ -43,16 +50,12 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
-      <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>
       <repository location="http://dadacoalition.org/yedit/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -20,7 +20,6 @@ location "http://download.eclipse.org/releases/oxygen/" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group
 	org.eclipse.epp.logging.aeri.feature.source.feature.group
@@ -42,17 +41,6 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.9.2/R-3.9.2-20
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
 }
 
-location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
-    org.hamcrest.core [1.3.0,1.3.1)
-    org.hamcrest.integration [1.3.0,1.3.1)
-    org.hamcrest.library [1.3.0,1.3.1)
-    org.slf4j.api
-    org.slf4j.apis.jcl
-    org.slf4j.apis.log4j
-    org.slf4j.bridge.jul
-    ch.qos.logback.slf4j
-}
-
 location "http://docker-editor.openanalytics.eu/update/" {
     eu.openanalytics.editor.docker.feature.group
 }
@@ -61,7 +49,4 @@ location "http://download.eclipse.org/linuxtools/update-docker" {
     org.eclipse.linuxtools.docker.feature.feature.group
 }
 
-location "http://dadacoalition.org/yedit/" {
-    org.dadacoalition.yedit.feature.feature.group
-}
-
+include "../common-dependencies.tpd"

--- a/eclipse/photon/gcp-eclipse-photon.target
+++ b/eclipse/photon/gcp-eclipse-photon.target
@@ -1,35 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Photon" sequenceNumber="1527803852">
+<target name="GCP for Eclipse Photon" sequenceNumber="1528475970">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180308-0630"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180308-0630"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180313-2237"/>
-      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.9.0.20180313-2237"/>
-      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.2.20170517-2015"/>
-      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.2.20170517-2015"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180531-1055"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180531-0700"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180606-2036"/>
+      <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.9.0.20180606-2036"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.0.20180606-2005"/>
+      <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.0.v20170629-1728"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.100.v201803012210"/>
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201803161350"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20170906-1327"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.8.v20171121"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.8.v20171121"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.8.v20171121"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.8.v20171121"/>
-      <repository location="http://download.eclipse.org/releases/photon/201803161000"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.10.v20180503"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.10.v20180503"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.10.v20180503"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.10.v20180503"/>
+      <repository location="http://download.eclipse.org/releases/photon/201806081000/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201802202154"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.301.v201802152148"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201802151734"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.1.v201802151734"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.2.v201802091707"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.10.0.v201804190136"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201802202154"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.601.v201802152148"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.10.0/I-3.10.0-20180309052619/repository"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.10.0/S-3.10.0.RC3a-20180606053829/repository"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
+      <repository location="http://docker-editor.openanalytics.eu/update/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
+      <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
@@ -43,16 +50,12 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
-      <repository location="http://docker-editor.openanalytics.eu/update/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
-      <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>
       <repository location="http://dadacoalition.org/yedit/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/photon/gcp-eclipse-photon.target
+++ b/eclipse/photon/gcp-eclipse-photon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Photon" sequenceNumber="1528475970">
+<target name="GCP for Eclipse Photon" sequenceNumber="1528482232">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180531-1055"/>
@@ -54,8 +54,8 @@
       <repository location="http://dadacoalition.org/yedit/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201805151425"/>
-      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-m7/"/>
+      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806051340"/>
+      <repository location="http://download.eclipse.org/technology/swtbot/milestones/photon-rc3/"/>
     </location>
   </locations>
 </target>

--- a/eclipse/photon/gcp-eclipse-photon.tpd
+++ b/eclipse/photon/gcp-eclipse-photon.tpd
@@ -11,8 +11,8 @@
  */
 target "GCP for Eclipse Photon" with source requirements
 
-// Photon M6 (composite at http://download.eclipse.org/releases/photon/)
-location "http://download.eclipse.org/releases/photon/201803161000" {
+// Photon RC3 (composite at http://download.eclipse.org/releases/photon/)
+location "http://download.eclipse.org/releases/photon/201806081000/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -21,7 +21,6 @@ location "http://download.eclipse.org/releases/photon/201803161000" {
 	org.eclipse.m2e.wtp.sdk.feature.feature.group
 	org.eclipse.mylyn.commons.feature.group
 	org.eclipse.jpt.jpa.feature.feature.group
-	org.eclipse.swtbot.eclipse.feature.group
 	
 	org.eclipse.epp.logging.aeri.feature.feature.group
 	org.eclipse.epp.logging.aeri.feature.source.feature.group
@@ -34,7 +33,7 @@ location "http://download.eclipse.org/releases/photon/201803161000" {
 
 // WTP SDKs aren't exposed through the main release links
 // (composite at http://download.eclipse.org/webtools/repository/photon)
-location "http://download.eclipse.org/webtools/downloads/drops/R3.10.0/I-3.10.0-20180309052619/repository" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.10.0/S-3.10.0.RC3a-20180606053829/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
@@ -42,17 +41,6 @@ location "http://download.eclipse.org/webtools/downloads/drops/R3.10.0/I-3.10.0-
     org.eclipse.wst.web_sdk.feature.feature.group
     org.eclipse.jst.enterprise_sdk.feature.feature.group
     org.eclipse.wst.server_adapters.sdk.feature.feature.group
-}
-
-location "http://download.eclipse.org/tools/orbit/downloads/latest-R/" {
-    org.hamcrest.core [1.3.0,1.3.1)
-    org.hamcrest.integration [1.3.0,1.3.1)
-    org.hamcrest.library [1.3.0,1.3.1)
-    org.slf4j.api
-    org.slf4j.apis.jcl
-    org.slf4j.apis.log4j
-    org.slf4j.bridge.jul
-    ch.qos.logback.slf4j
 }
 
 location "http://docker-editor.openanalytics.eu/update/" {
@@ -63,6 +51,4 @@ location "http://download.eclipse.org/linuxtools/update-docker" {
     org.eclipse.linuxtools.docker.feature.feature.group
 }
 
-location "http://dadacoalition.org/yedit/" {
-  org.dadacoalition.yedit.feature.feature.group
-}
+include "../common-dependencies.tpd"

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -17,7 +17,18 @@
     <module>neon</module>
     <module>oxygen</module>
     <module>photon</module>
-    <module>ide-target-platform</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <!--
+        create a copy of the build target platform, suitable for setting
+        as an Eclipse Target Platform
+      -->
+      <id>ide-target-platform</id>
+      <modules>
+        <module>ide-target-platform</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>features</module>
     <module>plugins</module>
     <module>third_party</module>
+    <module>eclipse</module>
   </modules>
 
   <properties>
@@ -409,9 +410,6 @@
          <jettyMaxVersion>9.4</jettyMaxVersion>
       </properties>
       <!-- build against a known target platform -->
-      <modules>
-        <module>eclipse/neon</module>
-      </modules>
       <build>
         <plugins>
           <plugin>
@@ -445,9 +443,6 @@
          <jettyMaxVersion>9.5</jettyMaxVersion>
       </properties>
       <!-- build against a known target platform -->
-      <modules>
-        <module>eclipse/oxygen</module>
-      </modules>
       <build>
         <plugins>
           <plugin>
@@ -479,9 +474,6 @@
          <jettyMaxVersion>9.5</jettyMaxVersion>
       </properties>
       <!-- build against a known target platform -->
-      <modules>
-        <module>eclipse/photon</module>
-      </modules>
       <build>
         <plugins>
           <plugin>
@@ -499,17 +491,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <!--
-        create a copy of the build target platform, suitable for setting
-        as an Eclipse Target Platform
-      -->
-      <id>ide-target-platform</id>
-      <modules>
-        <module>eclipse/ide-target-platform</module>
-      </modules>
     </profile>
 
     <!--


### PR DESCRIPTION
- pulls out common dependencies into `eclipse/common-dependencies.tpd`
- uses latest SWTBot to ensure consistency across all supported platforms