### PR TITLE
Prefer active window for opt-in dialog

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -303,14 +303,18 @@ public class AnalyticsPingManager {
     }
 
     try {
+      Shell activeShell = Display.getCurrent().getActiveShell();
+      if (activeShell != null) {
+        return activeShell;
+      }
       IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
       if (window != null) {
         return window.getShell();
       }
+      return null;
     } catch (IllegalStateException ise) {  // getWorkbench() might throw this.
-      // Fall through.
+      return null;
     }
-    return Display.getCurrent().getActiveShell();
   }
 
   private static void flushPreferences(IEclipsePreferences preferences) {


### PR DESCRIPTION
@briandealwis I remember the original code was basically what you suggested. Now it looks to me it's better to flip the order to prefer an active window and use the workbench window as a last resort. At least this takes care of one case I just encountered where some dialog was open and the opt-in dialog is unresponsive. WDYT?