### PR TITLE
Notify user prior to installing Managed Cloud SDK

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.test.util,
+Import-Package: com.google.cloud.tools.appengine.cloudsdk.serialization;version="0.6.0",
+ com.google.cloud.tools.eclipse.test.util,
  com.google.cloud.tools.eclipse.test.util.ui,
  org.eclipse.swtbot.swt.finder.widgets

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
@@ -16,6 +16,10 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <useUIHarness>true</useUIHarness>
+          <useUIThread>true</useUIThread>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
@@ -34,6 +34,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CloudSdkInstallNotificationTest {
   @Mock private IWorkbench workbench;
+  Runnable trigger = mock(Runnable.class);
 
   @Before
   public void setUp() {
@@ -42,28 +43,36 @@ public class CloudSdkInstallNotificationTest {
 
   @Test
   public void testDefaults() {
-    Runnable trigger = mock(Runnable.class);
     CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
     assertTrue(notification.shouldInstall);
   }
 
   @Test
-  public void testNotTriggeredOnSkipLink() {
-    Runnable trigger = mock(Runnable.class);
-    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
-    notification.linkSelected("skip");
-    assertFalse(notification.shouldInstall);
-    notification.close();
-    verify(trigger, never()).run();
-  }
-
-  @Test
   public void testTriggerOnCloseButton() {
-    Runnable trigger = mock(Runnable.class);
     CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
     notification.open();
     assertTrue(notification.shouldInstall);
     notification.close();
     verify(trigger).run();
+  }
+
+  @Test
+  public void testTriggeredOnFade() {
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    // simulate fade away
+    notification.open();
+    notification.getShell().setAlpha(0);
+    assertTrue(notification.shouldInstall);
+    notification.close();
+    verify(trigger).run();
+  }
+
+  @Test
+  public void testNotTriggeredOnSkipLink() {
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    notification.linkSelected("skip");
+    assertFalse(notification.shouldInstall);
+    notification.close();
+    verify(trigger, never()).run();
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
@@ -58,18 +58,6 @@ public class CloudSdkInstallNotificationTest {
   }
 
   @Test
-  public void testTriggeredOnFade() {
-    Runnable trigger = mock(Runnable.class);
-    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
-    // simulate fade away
-    notification.open();
-    notification.getShell().setAlpha(0);
-    assertTrue(notification.shouldInstall);
-    notification.close();
-    verify(trigger).run();
-  }
-
-  @Test
   public void testTriggerOnCloseButton() {
     Runnable trigger = mock(Runnable.class);
     CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkInstallNotificationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.sdk.ui;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbench;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkInstallNotificationTest {
+  @Mock private IWorkbench workbench;
+
+  @Before
+  public void setUp() {
+    when(workbench.getDisplay()).thenReturn(Display.getCurrent());
+  }
+
+  @Test
+  public void testDefaults() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    assertTrue(notification.shouldInstall);
+  }
+
+  @Test
+  public void testNotTriggeredOnSkipLink() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    notification.linkSelected("skip");
+    assertFalse(notification.shouldInstall);
+    notification.close();
+    verify(trigger, never()).run();
+  }
+
+  @Test
+  public void testTriggeredOnFade() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    // simulate fade away
+    notification.open();
+    notification.getShell().setAlpha(0);
+    assertTrue(notification.shouldInstall);
+    notification.close();
+    verify(trigger).run();
+  }
+
+  @Test
+  public void testTriggerOnCloseButton() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkInstallNotification notification = new CloudSdkInstallNotification(workbench, trigger);
+    notification.open();
+    assertTrue(notification.shouldInstall);
+    notification.close();
+    verify(trigger).run();
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/CloudSdkUpdateNotificationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.sdk.ui;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.appengine.cloudsdk.serialization.CloudSdkVersion;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IWorkbench;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSdkUpdateNotificationTest {
+  @Mock private IWorkbench workbench;
+
+  @Before
+  public void setUp() {
+    when(workbench.getDisplay()).thenReturn(Display.getCurrent());
+  }
+
+  @Test
+  public void testTriggeredOnUpdateLink() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
+    notification.linkSelected("update");
+    verify(trigger).run();
+  }
+
+  @Test
+  public void testNotTriggeredOnFade() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
+    // simulate fade away
+    notification.open();
+    notification.getShell().setAlpha(0);
+    notification.close();
+    verify(trigger, never()).run();
+  }
+
+  @Test
+  public void testNotTriggeredOnCloseButton() {
+    Runnable trigger = mock(Runnable.class);
+    CloudSdkUpdateNotification notification =
+        new CloudSdkUpdateNotification(workbench, new CloudSdkVersion("178.0.0"), trigger);
+    notification.open();
+    notification.close();
+    verify(trigger, never()).run();
+  }
+
+}

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartupTest.java
@@ -49,14 +49,17 @@ public class ManagedCloudSdkStartupTest {
   }
 
   @Test
-  public void testInstallIfNotInstalled()
+  public void testNotifiedIfNotInstalled()
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException {
     doReturn(false).when(installation).isInstalled();
-    
+    doReturn(false).when(installation).isUpToDate();
+
     ManagedCloudSdkStartup startup = new ManagedCloudSdkStartup(workbench);
     startup.checkInstallation(sdkManager, installation, null);
-    verify(sdkManager).installManagedSdkAsync();
     verify(installation).isInstalled();
+    // indirectly check that the user was notified of the update
+    verify(workbench).getDisplay();
+    verify(display).asyncExec(any(Runnable.class));
     verifyNoMoreInteractions(sdkManager, installation, workbench, display);
   }
 
@@ -65,7 +68,7 @@ public class ManagedCloudSdkStartupTest {
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException {
     doReturn(true).when(installation).isInstalled();
     doReturn(false).when(installation).isUpToDate();
-    
+
     ManagedCloudSdkStartup startup = new ManagedCloudSdkStartup(workbench);
     startup.checkInstallation(sdkManager, installation, null);
     verify(installation).isInstalled();

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/MessagesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/src/com/google/cloud/tools/eclipse/sdk/ui/MessagesTest.java
@@ -28,6 +28,22 @@ public class MessagesTest {
   }
 
   @Test
+  public void testCloudSdkInstallNotificationTitle() {
+    Assert.assertEquals(
+        "Google Cloud SDK Required", Messages.getString("CloudSdkInstallNotificationTitle"));
+  }
+
+  @Test
+  public void testCloudSdkInstallNotificationMessage() {
+    Assert.assertEquals(
+        "Google Cloud Tools for Eclipse requires the"
+            + " <a href=\"https://cloud.google.com/sdk/\">Google Cloud SDK</a> with the"
+            + " <a href=\"https://cloud.google.com/sdk/docs/managing-components\">App Engine Java components</a>."
+            + " Installation will begin momentarily, or <a href=\"skip\">skip for now</a>.",
+        Messages.getString("CloudSdkInstallNotificationMessage", new CloudSdkVersion("1.9.0")));
+  }
+
+  @Test
   public void testCloudSdkUpdateNotificationTitle() {
     Assert.assertEquals(
         "Google Cloud SDK Update Available", Messages.getString("CloudSdkUpdateNotificationTitle"));
@@ -36,8 +52,8 @@ public class MessagesTest {
   @Test
   public void testCloudSdkUpdateNotificationMessage() {
     Assert.assertEquals(
-        "<a href=\"update\">Update now</a> or from the Google Cloud Tools preference page.\n"
-            + "See the <a href=\"https://cloud.google.com/sdk/docs/release-notes\">release notes</a> for changes since 1.9.0.",
+        "<a href=\"update\">Update now</a> or from the Google Cloud Tools preference page."
+            + " See the <a href=\"https://cloud.google.com/sdk/docs/release-notes\">release notes</a> for changes since 1.9.0.",
         Messages.getString("CloudSdkUpdateNotificationMessage", new CloudSdkVersion("1.9.0")));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
@@ -87,8 +87,8 @@ public class ManagedCloudSdkStartup implements IStartup {
               logger.log(
                   Level.SEVERE,
                   "Unable to check Cloud SDK installation. Possible causes include" //$NON-NLS-1$
-                      + " network connection problem or corrupt Cloud SDK installation.",
-                  ex); //$NON-NLS-1$
+                      + " network connection problem or corrupt Cloud SDK installation.", //$NON-NLS-1$
+                  ex);
             } catch (ManagedSdkVersionMismatchException ex) {
               throw new IllegalStateException(
                   "This is never thrown because we always use LATEST.", ex); // $NON-NLS-1$

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/ManagedCloudSdkStartup.java
@@ -41,15 +41,9 @@ import org.eclipse.ui.progress.WorkbenchJob;
 
 /**
  * A simple startup task for triggering events relating to the managed Google Cloud SDK, when
- * enabled. If the Google Cloud SDK is not installed, then we silently trigger installation of the
- * Google Cloud SDK. Otherwise we check if the managed installation is up-to-date and if not, notify
- * the user of the update.
- *
- * <p>earlyStartup() is called on a non-UI worker thread and runs before the Eclipse Workbench is
- * actually rendered. Since installing the SDK takes some time, we launch a WorkspaceJob to wait
- * until the workbench is actually up and running, especially so we don't slow down startup. Our use
- * of a wait and WorkbenchJob also ensures that our job doesn't start if the user realizes they made
- * a mistake and quickly exits.
+ * enabled. If the Google Cloud SDK is not installed then, after notifying the user, we trigger
+ * installation of the Google Cloud SDK. Otherwise we check if the managed installation is
+ * up-to-date and if not, notify the user of the update.
  */
 public class ManagedCloudSdkStartup implements IStartup {
   private static final Logger logger = Logger.getLogger(ManagedCloudSdkStartup.class.getName());
@@ -67,34 +61,46 @@ public class ManagedCloudSdkStartup implements IStartup {
 
   @Override
   public void earlyStartup() {
-    // TODO: notify the user of updates for manual installs too
     if (!CloudSdkPreferences.isAutoManaging()) {
+      // TODO: notify the user of updates for manual installs too
       return;
     }
 
-    Job checkInstallationJob = new Job("Check Google Cloud SDK") {
-      @Override
-      protected IStatus run(IProgressMonitor monitor) {
-        try {
-          CloudSdkManager sdkManager = CloudSdkManager.getInstance();
-          ManagedCloudSdk installer = ManagedCloudSdk.newManagedSdk();
-          checkInstallation(sdkManager, installer, monitor);
-        } catch (UnsupportedOsException ex) {
-          logger.log(Level.FINE, "Unable to check Cloud SDK installation", ex);
-        } catch (ManagedSdkVerificationException ex) {
-          logger.log(Level.SEVERE, "Unable to check Cloud SDK installation. Possible causes include"
-              + " network connection problem or corrupt Cloud SDK installation.", ex);
-        } catch (ManagedSdkVersionMismatchException ex) {
-          throw new IllegalStateException("This is never thrown because we always use LATEST.", ex);
-        }
-        return Status.OK_STATUS;
-      }
-    };
+    /*
+     * earlyStartup() is called on a non-UI worker thread and runs before the Eclipse Workbench is
+     * actually rendered. Since installing the SDK takes some time, we launch a WorkspaceJob to wait
+     * until the workbench is actually up and running, especially so we don't slow down startup. Our use
+     * of a wait and WorkbenchJob also ensures that our job doesn't start if the user realizes they made
+     * a mistake and quickly exits.
+     */
+
+    Job checkInstallationJob = new Job(Messages.getString("CheckUpToDateJobTitle")) { // $NON-NLS-1$
+          @Override
+          protected IStatus run(IProgressMonitor monitor) {
+            try {
+              CloudSdkManager sdkManager = CloudSdkManager.getInstance();
+              ManagedCloudSdk installer = ManagedCloudSdk.newManagedSdk();
+              checkInstallation(sdkManager, installer, monitor);
+            } catch (UnsupportedOsException ex) {
+              logger.log(Level.FINE, "Unable to check Cloud SDK installation", ex); // $NON-NLS-1$
+            } catch (ManagedSdkVerificationException ex) {
+              logger.log(
+                  Level.SEVERE,
+                  "Unable to check Cloud SDK installation. Possible causes include" //$NON-NLS-1$
+                      + " network connection problem or corrupt Cloud SDK installation.",
+                  ex); //$NON-NLS-1$
+            } catch (ManagedSdkVersionMismatchException ex) {
+              throw new IllegalStateException(
+                  "This is never thrown because we always use LATEST.", ex); // $NON-NLS-1$
+            }
+            return Status.OK_STATUS;
+          }
+        };
 
     // Use a WorkbenchJob to trigger the check to ensure we start after the workbench window has
     // appeared, but perform the actual check within a normal Job so that we don't monopolize the
     // display thread.
-    Job triggerInstallationJob = new WorkbenchJob("Check Google Cloud SDK") {
+    Job triggerInstallationJob = new WorkbenchJob(Messages.getString("CheckUpToDateJobTitle")) { //$NON-NLS-1$
       @Override
       public IStatus runInUIThread(IProgressMonitor monitor) {
         checkInstallationJob.setSystem(true);
@@ -111,7 +117,7 @@ public class ManagedCloudSdkStartup implements IStartup {
       CloudSdkManager manager, ManagedCloudSdk installation, IProgressMonitor monitor)
       throws ManagedSdkVerificationException, ManagedSdkVersionMismatchException {
     if (!installation.isInstalled()) {
-      manager.installManagedSdkAsync();
+      CloudSdkInstallNotification.showNotification(workbench, manager::installManagedSdkAsync);
     } else if (!installation.isUpToDate()) {
       CloudSdkVersion currentVersion = getVersion(installation.getSdkHome());
       CloudSdkUpdateNotification.showNotification(

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui/src/com/google/cloud/tools/eclipse/sdk/ui/messages.properties
@@ -13,7 +13,14 @@ AppEngineJavaComponentsNotInstalled=App Engine Java components not installed
 NoSuchDirectory=Directory {0} does not exist
 FileNotDirectory={0} is a file, not a directory
 UpdateSdk=Update
+CheckUpToDateJobTitle=Check Google Cloud SDK
+CloudSdkInstallNotificationTitle=Google Cloud SDK Required
+CloudSdkInstallNotificationMessage=\
+ Google Cloud Tools for Eclipse requires the \
+ <a href="https://cloud.google.com/sdk/">Google Cloud SDK</a> with the \
+ <a href="https://cloud.google.com/sdk/docs/managing-components">App Engine Java components</a>. \
+ Installation will begin momentarily, or <a href="skip">skip for now</a>.
 CloudSdkUpdateNotificationTitle=Google Cloud SDK Update Available
 CloudSdkUpdateNotificationMessage=\
- <a href="update">Update now</a> or from the Google Cloud Tools preference page.\n\
+ <a href="update">Update now</a> or from the Google Cloud Tools preference page. \
  See the <a href="https://cloud.google.com/sdk/docs/release-notes">release notes</a> for changes since {0}.


### PR DESCRIPTION
Notifies the user before installing the Cloud SDK.  Installation proceeds after the notification is closed (either fade away or explicitly dismissed). Adds some tests for both installation and updating.  Feedback on wording is welcome!

<img width="409" alt="screen shot 2018-06-12 at 12 08 46 pm" src="https://user-images.githubusercontent.com/202851/41303312-e5fcc8f8-6e3a-11e8-9d03-d9adcb049a59.PNG">

Fixes #3140