### PR TITLE
IResourceChangeEvent#getDelta() may return null

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/io/ResourceUtilsTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/io/ResourceUtilsTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -68,12 +67,9 @@ public class ResourceUtilsTest {
 
   @Test
   public void testGetAffectedFiles_null() throws CoreException {
-    try {
-      ResourceUtils.getAffectedFiles(null);
-      fail();
-    } catch (NullPointerException ex) {
-      /* expected */
-    }
+    Collection<IFile> files = ResourceUtils.getAffectedFiles(null);
+    assertNotNull(files);
+    assertEquals(0, files.size());
   }
 
   @Test
@@ -85,7 +81,7 @@ public class ResourceUtilsTest {
   }
 
   @Test
-  public void testGetAffectedDelta_changedFile() throws CoreException {
+  public void testGetAffectedFiles_changedFile() throws CoreException {
     IFile file = mock(IFile.class, "/filename");
 
     IResourceDelta delta = mockDelta();
@@ -100,7 +96,7 @@ public class ResourceUtilsTest {
   }
 
   @Test
-  public void testGetAffectedDelta_projectFolderFiles() throws CoreException {
+  public void testGetAffectedFiles_projectFolderFiles() throws CoreException {
     @SuppressWarnings("hiding") // nothing to delete
     IProject project = mock(IProject.class, "/project");
 

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/io/ResourceUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/io/ResourceUtils.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.util.io;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -57,6 +58,10 @@ public class ResourceUtils {
   }
 
   public static Collection<IFile> getAffectedFiles(IResourceDelta topDelta) throws CoreException {
+    if (topDelta == null) {
+      return Collections.emptyList();
+    }
+
     Collection<IFile> files = new ArrayList<>();
     topDelta.accept(
         delta -> {


### PR DESCRIPTION
Noticed a lot of traces like the following in the logs.  Oops, `IResourceChangeEvent#getDelta()` may return a `null` delta.

```
!ENTRY org.eclipse.core.resources 4 2 2018-06-12 19:54:05.956
!MESSAGE Problems occurred when invoking code from plug-in: "org.eclipse.core.resources".
!STACK 0
java.lang.NullPointerException
	at com.google.cloud.tools.eclipse.util.io.ResourceUtils.getAffectedFiles(ResourceUtils.java:61)
	at com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.AppEngineContentProvider.resourceChanged(AppEngineContentProvider.java:122)
	at org.eclipse.core.internal.events.NotificationManager$1.run(NotificationManager.java:297)
```