### PR TITLE
Update misleading variable names and string constants

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/status/StatusUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/status/StatusUtilTest.java
@@ -180,24 +180,22 @@ public class StatusUtilTest {
   
   @Test
   public void testMulti_noError() {
-    MultiStatus error = StatusUtil.multi(StatusUtil.class, "test status msg");
-    assertThat(error.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
-    assertThat(error.getMessage(), is("test status msg"));
+    MultiStatus status = StatusUtil.multi(StatusUtil.class, "test OK msg");
+    verifyStatus(status, IStatus.OK, "test OK msg");
   }
 
   @Test
   public void testMulti_withError() {
     Throwable exception = new RuntimeException();
-    MultiStatus error = StatusUtil.multi(StatusUtil.class, "test status msg", exception);
-    assertThat(error.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
-    assertThat(error.getMessage(), is("test status msg"));
-    assertThat(error.getException(), is(sameInstance(exception)));
+    MultiStatus status = StatusUtil.multi(StatusUtil.class, "test OK msg", exception);
+    verifyStatus(status, IStatus.OK, "test OK msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testFilter_normalStatus() {
-    IStatus error = StatusUtil.error(StatusUtil.class, "test error msg");
-    assertThat(StatusUtil.filter(error), is(sameInstance(error)));
+    IStatus status = StatusUtil.error(StatusUtil.class, "test error msg");
+    assertThat(StatusUtil.filter(status), is(sameInstance(status)));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/status/StatusUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/status/StatusUtilTest.java
@@ -34,118 +34,118 @@ public class StatusUtilTest {
 
   @Test
   public void testCreate_errorWithClass() {
-    IStatus error = StatusUtil.create(IStatus.ERROR, StatusUtil.class, "test error msg");
-    verifyStatus(error, IStatus.ERROR);
+    IStatus status = StatusUtil.create(IStatus.ERROR, StatusUtil.class, "test error msg");
+    verifyStatus(status, IStatus.ERROR, "test error msg");
   }
 
   @Test
   public void testCreate_errorWithClassAndException() {
     Throwable exception = new Exception();
-    IStatus error = StatusUtil.create(IStatus.ERROR, StatusUtil.class, "test error msg", exception);
-    verifyStatus(error, IStatus.ERROR);
-    assertThat(error.getException(), is(sameInstance(exception)));
+    IStatus status = StatusUtil.create(IStatus.ERROR, StatusUtil.class, "test error msg", exception);
+    verifyStatus(status, IStatus.ERROR, "test error msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testCreate_warnWithClass() {
-    IStatus warn = StatusUtil.create(IStatus.WARNING, StatusUtil.class, "test error msg");
-    verifyStatus(warn, IStatus.WARNING);
+    IStatus status = StatusUtil.create(IStatus.WARNING, StatusUtil.class, "test warning msg");
+    verifyStatus(status, IStatus.WARNING, "test warning msg");
   }
 
   @Test
   public void testCreate_warnWithClassAndException() {
     Throwable exception = new Exception();
-    IStatus warn =
-        StatusUtil.create(IStatus.WARNING, StatusUtil.class, "test error msg", exception);
-    verifyStatus(warn, IStatus.WARNING);
-    assertThat(warn.getException(), is(sameInstance(exception)));
+    IStatus status =
+        StatusUtil.create(IStatus.WARNING, StatusUtil.class, "test warning msg", exception);
+    verifyStatus(status, IStatus.WARNING, "test warning msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testError_withClass() {
-    IStatus error = StatusUtil.error(StatusUtil.class, "test error msg");
-    verifyStatus(error, IStatus.ERROR);
+    IStatus status = StatusUtil.error(StatusUtil.class, "test error msg");
+    verifyStatus(status, IStatus.ERROR, "test error msg");
   }
   
   @Test
   public void testError_withCode() {
-    IStatus error = StatusUtil.error(StatusUtil.class, "test error msg", 356);
-    verifyStatus(error, IStatus.ERROR);
-    assertEquals(356, error.getCode());
+    IStatus status = StatusUtil.error(StatusUtil.class, "test error msg", 356);
+    verifyStatus(status, IStatus.ERROR, "test error msg");
+    assertEquals(356, status.getCode());
   }
 
   @Test
   public void testError_nullSource() {
-    IStatus error = StatusUtil.error(null, "test error msg");
-    verifyStatus(error, IStatus.ERROR);
+    IStatus status = StatusUtil.error(null, "test error msg");
+    verifyStatus(status, IStatus.ERROR, "test error msg");
   }
 
   @Test
   public void testError_nonOsgiSource() {
-    IStatus error = StatusUtil.error("a string from the system classloader", "test error msg");
-    assertThat(error.getSeverity(), is(IStatus.ERROR));
-    assertThat(error.getMessage(), is("test error msg"));
-    assertThat(error.getPlugin(), is("java.lang.String"));
+    IStatus status = StatusUtil.error("a string from the system classloader", "test error msg");
+    assertThat(status.getSeverity(), is(IStatus.ERROR));
+    assertThat(status.getMessage(), is("test error msg"));
+    assertThat(status.getPlugin(), is("java.lang.String"));
   }
 
   @Test
   public void testError_withClassAndException() {
     Throwable exception = new Exception();
-    IStatus error = StatusUtil.error(StatusUtil.class, "test error msg", exception);
-    verifyStatus(error, IStatus.ERROR);
-    assertThat(error.getException(), is(sameInstance(exception)));
+    IStatus status = StatusUtil.error(StatusUtil.class, "test error msg", exception);
+    verifyStatus(status, IStatus.ERROR, "test error msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testError_withInstance() {
-    IStatus error = StatusUtil.error(this, "test error msg");
-    verifyStatus(error, IStatus.ERROR);
+    IStatus status = StatusUtil.error(this, "test error msg");
+    verifyStatus(status, IStatus.ERROR, "test error msg");
   }
 
   @Test
   public void testError_withInstanceAndException() {
     Throwable exception = new Exception();
-    IStatus error = StatusUtil.error(this, "test error msg", exception);
-    verifyStatus(error, IStatus.ERROR);
-    assertThat(error.getException(), is(sameInstance(exception)));
+    IStatus status = StatusUtil.error(this, "test error msg", exception);
+    verifyStatus(status, IStatus.ERROR, "test error msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testWarn_withClass() {
-    IStatus error = StatusUtil.warn(StatusUtil.class, "test error msg");
-    verifyStatus(error, IStatus.WARNING);
+    IStatus status = StatusUtil.warn(StatusUtil.class, "test warning msg");
+    verifyStatus(status, IStatus.WARNING, "test warning msg");
   }
 
   @Test
   public void testWarn_withClassAndException() {
     Throwable exception = new Exception();
-    IStatus error = StatusUtil.warn(StatusUtil.class, "test error msg", exception);
-    verifyStatus(error, IStatus.WARNING);
-    assertThat(error.getException(), is(sameInstance(exception)));
+    IStatus status = StatusUtil.warn(StatusUtil.class, "test warning msg", exception);
+    verifyStatus(status, IStatus.WARNING, "test warning msg");
+    assertThat(status.getException(), is(sameInstance(exception)));
   }
 
   @Test
   public void testWarn_withInstance() {
-    IStatus error = StatusUtil.warn(this, "test error msg");
-    verifyStatus(error, IStatus.WARNING);
+    IStatus status = StatusUtil.warn(this, "test warning msg");
+    verifyStatus(status, IStatus.WARNING, "test warning msg");
   }
 
   @Test
   public void testInfo_withClass() {
-    IStatus error = StatusUtil.info(StatusUtil.class, "test error msg");
-    verifyStatus(error, IStatus.INFO);
+    IStatus status = StatusUtil.info(StatusUtil.class, "test info msg");
+    verifyStatus(status, IStatus.INFO, "test info msg");
   }
 
   @Test
   public void testInfo_withInstance() {
-    IStatus error = StatusUtil.info(this, "test error msg");
-    verifyStatus(error, IStatus.INFO);
+    IStatus status = StatusUtil.info(this, "test info msg");
+    verifyStatus(status, IStatus.INFO, "test info msg");
   }
 
-  private void verifyStatus(IStatus error, int severity) {
-    assertThat(error.getSeverity(), is(severity));
-    assertThat(error.getMessage(), is("test error msg"));
-    assertThat(error.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
+  private void verifyStatus(IStatus status, int severity, String message) {
+    assertThat(status.getSeverity(), is(severity));
+    assertThat(status.getMessage(), is(message));
+    assertThat(status.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
   }
 
   @Test
@@ -159,7 +159,8 @@ public class StatusUtilTest {
   @Test
   public void testErrorMessage_Status() {
     IStatus originalStatus = StatusUtil.info(this, "testing");
-    IStatus status = StatusUtil.setErrorStatus(this, "test message from StatusUtilTest", originalStatus);
+    IStatus status =
+        StatusUtil.setErrorStatus(this, "test message from StatusUtilTest", originalStatus);
     Assert.assertEquals("test message from StatusUtilTest: testing", status.getMessage());
   }
 
@@ -179,19 +180,17 @@ public class StatusUtilTest {
   
   @Test
   public void testMulti_noError() {
-    IStatus error = StatusUtil.multi(StatusUtil.class, "test error msg");
-    assertThat(error, instanceOf(MultiStatus.class));
+    MultiStatus error = StatusUtil.multi(StatusUtil.class, "test status msg");
     assertThat(error.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
-    assertThat(error.getMessage(), is("test error msg"));
+    assertThat(error.getMessage(), is("test status msg"));
   }
 
   @Test
   public void testMulti_withError() {
     Throwable exception = new RuntimeException();
-    IStatus error = StatusUtil.multi(StatusUtil.class, "test error msg", exception);
-    assertThat(error, instanceOf(MultiStatus.class));
+    MultiStatus error = StatusUtil.multi(StatusUtil.class, "test status msg", exception);
     assertThat(error.getPlugin(), is("com.google.cloud.tools.eclipse.util"));
-    assertThat(error.getMessage(), is("test error msg"));
+    assertThat(error.getMessage(), is("test status msg"));
     assertThat(error.getException(), is(sameInstance(exception)));
   }
 
@@ -212,7 +211,7 @@ public class StatusUtilTest {
     assertEquals(IStatus.ERROR, result.getSeverity());
     assertThat(result, instanceOf(MultiStatus.class));
     assertEquals(1, ((MultiStatus) result).getChildren().length);
-    verifyStatus(((MultiStatus) result).getChildren()[0], IStatus.ERROR);
+    verifyStatus(((MultiStatus) result).getChildren()[0], IStatus.ERROR, "test error msg");
   }
 
   @Test
@@ -220,6 +219,5 @@ public class StatusUtilTest {
     IStatus multi = StatusUtil.multi(StatusUtil.class, "test multi msg"); //$NON-NLS-1$
     assertThat(StatusUtil.filter(multi), is(Status.OK_STATUS));
   }
-
 
 }


### PR DESCRIPTION
Every variable name was blindly and confusingly `error`. Likewise, it was always `test error message`.

Besides that, no behavioral change.