### PR TITLE
Rename image placeholder to avoid compiler warning

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.ui/src/com/google/cloud/tools/eclipse/ui/util/OpenDropDownMenuHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.ui/src/com/google/cloud/tools/eclipse/ui/util/OpenDropDownMenuHandler.java
@@ -49,7 +49,7 @@ import org.eclipse.ui.menus.IMenuService;
  *                style=&quot;pulldown&quot;
  *                commandId=&quot;com.google.cloud.tools.eclipse.ui.util.showPopup&quot;
  *                id=&quot;com.google.cloud.tools.eclipse.ui.actions&quot;
- *                icon=&quot;xxx.png&quot; /&gt;
+ *                icon=&quot;image.png&quot; /&gt;
  *       &lt;/toolbar&gt;
  *    &lt;/menuContribution&gt;
  *    &lt;menuContribution locationURI=&quot;menu:com.google.cloud.tools.eclipse.ui.actions&quot;&gt;


### PR DESCRIPTION
Rename `xxx.png` to avoid compiler warning as `xxx` is interpreted as a todo marker.
```
128413 [INFO] --- tycho-compiler-plugin:1.1.0:compile (default-compile) @ com.google.cloud.tools.eclipse.ui ---
128417 [INFO] Compiling 16 source files to /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.ui/target/classes
[…]
128938 [WARNING] /home/travis/build/GoogleCloudPlatform/google-cloud-eclipse/plugins/com.google.cloud.tools.eclipse.ui/src/com/google/cloud/tools/eclipse/ui/util/OpenDropDownMenuHandler.java:[52] 
	*                icon=&quot;xxx.png&quot; /&gt;
	                            ^^^^^^^^^^^^^^^^^^^
XXX.png&quot; /&gt;
```