### PR TITLE
com.google.cloud.tools.eclipse.sdk.ui tests require the workbench

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
@@ -22,5 +22,20 @@
         </configuration>
       </plugin>
     </plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
   </build>
 </project>

--- a/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.sdk.ui.test/pom.xml
@@ -21,7 +21,6 @@
           <useUIThread>true</useUIThread>
         </configuration>
       </plugin>
-    </plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
@@ -37,5 +36,6 @@
           </dependency-resolution>
         </configuration>
       </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Our build logs for `.sdk.ui.tests` are filled with errors like the following:
```
!ENTRY org.eclipse.e4.ui.workbench 4 0 2018-06-20 15:00:06.250
!MESSAGE Event Admin service is not available, unable to publish event org.osgi.service.event.Event [topic=org/eclipse/e4/ui/renderer/requestEnablementUpdate] {org.eclipse.e4.data=ALL}.
!ENTRY org.eclipse.e4.ui.workbench 4 0 2018-06-20 15:00:06.341
!MESSAGE Event Admin service is not available, unable to publish event org.osgi.service.event.Event [topic=org/eclipse/e4/ui/model/basic/PartDescriptorContainer/descriptors/ADD] {ChangedElement=org.eclipse.e4.ui.model.application.impl.ApplicationImpl@22bb5646 (elementId: org.eclipse.e4.legacy.ide.application, tags: [activeSchemeId:org.eclipse.ui.defaultAcceleratorConfiguration, ModelMigrationProcessor.001], contributorURI: platform:/plugin/org.eclipse.ui.workbench) (widget: null, renderer: null, toBeRendered: true, onTop: false, visible: true, containerData: null, accessibilityPhrase: null) (context: WorkbenchContext, variables: null), org.eclipse.e4.data={ChangedElement=org.eclipse.e4.ui.model.application.impl.ApplicationImpl@22bb5646 (elementId: org.eclipse.e4.legacy.ide.application, tags: [activeSchemeId:org.eclipse.ui.defaultAcceleratorConfiguration, ModelMigrationProcessor.001], contributorURI: platform:/plugin/org.eclipse.ui.workbench) (widget: null, renderer: null, toBeRendered: true, onTop: false, visible: true, containerData: null, accessibilityPhrase: null) (context: WorkbenchContext, variables: null), AttName=descriptors, EventType=ADD, Position=0, Widget=null, NewValue=org.eclipse.e4.ui.model.application.descriptor.basic.impl.PartDescriptorImpl@68868328 (elementId: org.eclipse.e4.ui.compatibility.editor, tags: [Editor], contributorURI: null) (label: null, iconURI: null, tooltip: null, allowMultiple: true, category: org.eclipse.e4.primaryDataStack, closeable: true, dirtyable: false, contributionURI: bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityEditor, description: null, variables: null)}, AttName=descriptors, EventType=ADD, Position=0, Widget=null, NewValue=org.eclipse.e4.ui.model.application.descriptor.basic.impl.PartDescriptorImpl@68868328 (elementId: org.eclipse.e4.ui.compatibility.editor, tags: [Editor], contributorURI: null) (label: null, iconURI: null, tooltip: null, allowMultiple: true, category: org.eclipse.e4.primaryDataStack, closeable: true, dirtyable: false, contributionURI: bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityEditor, description: null, variables: null)}.
```

With changing `.sdk.ui.tests` to require the Workbench (`<useUIHarness>true</useUIHarness>`) we need to include the workbench dependencies.