### PR TITLE
Add SwtBotTreeUtilities#getMatchingNode() to select matching node

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectExplorerAppEngineBlockTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/ProjectExplorerAppEngineBlockTest.java
@@ -66,9 +66,8 @@ public class ProjectExplorerAppEngineBlockTest extends BaseProjectTest {
     assertThat(appEngineNode.getNodes(), hasSize(0));
 
     // ensure App Engine content block does not appear in Deployment Descriptor
-    SWTBotTreeItem deploymentDescriptorNode = selected.getNode(1);
-    SwtBotTreeUtilities.waitUntilTreeTextMatches(
-        bot, deploymentDescriptorNode, startsWith("Deployment Descriptor:"));
+    SWTBotTreeItem deploymentDescriptorNode =
+        SwtBotTreeUtilities.getMatchingNode(bot, selected, startsWith("Deployment Descriptor:"));
     deploymentDescriptorNode.expand();
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, deploymentDescriptorNode);
     SWTBotTreeItem firstNode = deploymentDescriptorNode.getNode(0);


### PR DESCRIPTION
I had `ProjectExplorerAppEngineBlockTest` fail locally as the _Deployment Descriptor_ block appeared at a different location in the Project Explorer.  This PR adds a new utility method to wait and return a tree node that matches a given matcher.

<img width="248" alt="screen shot 2018-06-26 at 2 07 47 pm" src="https://user-images.githubusercontent.com/202851/41930874-606fb022-794a-11e8-9fa6-092c046a37db.PNG">
