### PR TITLE
Update target platforms

### DIFF
--- a/eclipse/neon/gcp-eclipse-neon.target
+++ b/eclipse/neon/gcp-eclipse-neon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Neon" sequenceNumber="1528482238">
+<target name="GCP for Eclipse Neon" sequenceNumber="1530132654">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.6.3.v20170301-0400"/>
@@ -19,16 +19,6 @@
       <unit id="org.eclipse.jetty.server" version="9.3.9.v20160517"/>
       <unit id="org.eclipse.jetty.util" version="9.3.9.v20160517"/>
       <repository location="http://download.eclipse.org/releases/neon/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201608191717"/>
-      <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201606081655"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201603091933"/>
-      <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.8.0.v201609072018"/>
-      <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.0.v201605251556"/>
-      <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201606081655"/>
-      <repository location="http://download.eclipse.org/webtools/repository/neon/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>

--- a/eclipse/neon/gcp-eclipse-neon.tpd
+++ b/eclipse/neon/gcp-eclipse-neon.tpd
@@ -31,15 +31,16 @@ location "http://download.eclipse.org/releases/neon/" {
 }
 
 // WTP SDKs aren't exposed through the main release links
-location "http://download.eclipse.org/webtools/repository/neon/" {
-    org.eclipse.jst.web_sdk.feature.feature.group
-    org.eclipse.jst.server_sdk.feature.feature.group
-    org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
-    org.eclipse.wst.common.fproj.sdk.feature.group
-    org.eclipse.wst.web_sdk.feature.feature.group
-    org.eclipse.jst.enterprise_sdk.feature.feature.group
-    org.eclipse.wst.server_adapters.sdk.feature.feature.group
-}
+// 2018/06/27: WTP seems to have removed the downloads for Neon and before
+//location "http://download.eclipse.org/webtools/repository/neon/" {
+//    org.eclipse.jst.web_sdk.feature.feature.group
+//    org.eclipse.jst.server_sdk.feature.feature.group
+//    org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group
+//    org.eclipse.wst.common.fproj.sdk.feature.group
+//    org.eclipse.wst.web_sdk.feature.feature.group
+//    org.eclipse.jst.enterprise_sdk.feature.feature.group
+//    org.eclipse.wst.server_adapters.sdk.feature.feature.group
+//}
 
 location "http://docker-editor.openanalytics.eu/update/" {
     eu.openanalytics.editor.docker.feature.group

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1528482234">
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1530132107">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.3.v20180330-0919"/>
@@ -21,21 +21,21 @@
       <repository location="http://download.eclipse.org/releases/oxygen/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201711302141"/>
+      <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201802152012"/>
       <unit id="org.eclipse.jst.server_sdk.feature.feature.group" version="3.4.300.v201709251835"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group" version="3.8.0.v201710021614"/>
       <unit id="org.eclipse.wst.common.fproj.sdk.feature.group" version="3.7.1.v201707201954"/>
-      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.1.v201711152154"/>
-      <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201711302141"/>
+      <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.9.2.v201802281510"/>
+      <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201802121827"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.600.v201711302104"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.2/R-3.9.2-20171201000141/repository"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.9.3/R-3.9.3-20180302093744/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
       <repository location="http://docker-editor.openanalytics.eu/update/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.0.0.201806122135"/>
       <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -31,7 +31,7 @@ location "http://download.eclipse.org/releases/oxygen/" {
 }
 
 // WTP SDKs aren't exposed through the main release links
-location "http://download.eclipse.org/webtools/downloads/drops/R3.9.2/R-3.9.2-20171201000141/repository" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.9.3/R-3.9.3-20180302093744/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group

--- a/eclipse/photon/gcp-eclipse-photon.target
+++ b/eclipse/photon/gcp-eclipse-photon.target
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Photon" sequenceNumber="1528482232">
+<target name="GCP for Eclipse Photon" sequenceNumber="1530132066">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180531-1055"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180531-0700"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180611-0826"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180611-0500"/>
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180606-2036"/>
       <unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.9.0.20180606-2036"/>
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.4.0.20180606-2005"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.0.v20170629-1728"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.0.v20180613-1658"/>
       <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201803161350"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20170906-1327"/>
@@ -18,7 +18,7 @@
       <unit id="org.eclipse.jetty.servlet" version="9.4.10.v20180503"/>
       <unit id="org.eclipse.jetty.server" version="9.4.10.v20180503"/>
       <unit id="org.eclipse.jetty.util" version="9.4.10.v20180503"/>
-      <repository location="http://download.eclipse.org/releases/photon/201806081000/"/>
+      <repository location="http://download.eclipse.org/releases/photon/201806271001/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jst.web_sdk.feature.feature.group" version="3.8.0.v201802202154"/>
@@ -28,14 +28,14 @@
       <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.10.0.v201804190136"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201802202154"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.601.v201802152148"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.10.0/S-3.10.0.RC3a-20180606053829/repository"/>
+      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.10.0/R-3.10.0-20180611164516/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="eu.openanalytics.editor.docker.feature.group" version="1.0.0.201506222127"/>
       <repository location="http://docker-editor.openanalytics.eu/update/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="3.2.1.201803061555"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.0.0.201806122135"/>
       <repository location="http://download.eclipse.org/linuxtools/update-docker"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/eclipse/photon/gcp-eclipse-photon.tpd
+++ b/eclipse/photon/gcp-eclipse-photon.tpd
@@ -11,8 +11,8 @@
  */
 target "GCP for Eclipse Photon" with source requirements
 
-// Photon RC3 (composite at http://download.eclipse.org/releases/photon/)
-location "http://download.eclipse.org/releases/photon/201806081000/" {
+// Photon SR0 (composite at http://download.eclipse.org/releases/photon/)
+location "http://download.eclipse.org/releases/photon/201806271001/" {
 	org.eclipse.sdk.feature.group
 	org.eclipse.jdt.feature.group
 	org.eclipse.m2e.feature.feature.group
@@ -33,7 +33,7 @@ location "http://download.eclipse.org/releases/photon/201806081000/" {
 
 // WTP SDKs aren't exposed through the main release links
 // (composite at http://download.eclipse.org/webtools/repository/photon)
-location "http://download.eclipse.org/webtools/downloads/drops/R3.10.0/S-3.10.0.RC3a-20180606053829/repository" {
+location "http://download.eclipse.org/webtools/downloads/drops/R3.10.0/R-3.10.0-20180611164516/repository" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group


### PR DESCRIPTION
- Photon was released today
- Update Oxygen to SR3
- WTP seems to have removed their old releases from Neon and prior, so the SDK features aren't available