### PR TITLE
Add support for YAML files for App Engine content block

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
@@ -16,13 +16,18 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import com.google.common.io.ByteSource;
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -37,6 +42,33 @@ public class AppEngineConfigurationUtilTest {
   @Rule
   public TestProjectCreator projectCreator =
       new TestProjectCreator().withFacets(WebFacetUtils.WEB_31, JavaFacet.VERSION_1_8);
+
+  @Test
+  public void testCreateConfigurationFile_byteContent() throws CoreException, IOException {
+    IFile file =
+        AppEngineConfigurationUtil.createConfigurationFile(
+            projectCreator.getProject(),
+            new Path("example.txt"),
+            new ByteArrayInputStream(new byte[] {0, 1, 2, 3}),
+            true,
+            null);
+    try (InputStream input = file.getContents()) {
+      byte[] contents = ByteStreams.toByteArray(input);
+      assertArrayEquals(new byte[] {0, 1, 2, 3}, contents);
+    }
+  }
+
+  @Test
+  public void testCreateConfigurationFile_charContent() throws CoreException, IOException {
+    String original = "\u1f64c this is a test \u00b5";
+    IFile file =
+        AppEngineConfigurationUtil.createConfigurationFile(
+            projectCreator.getProject(), new Path("example.txt"), original, true, null);
+    try (InputStream input = file.getContents()) {
+      String contents = new String(ByteStreams.toByteArray(input), StandardCharsets.UTF_8);
+      assertEquals(original, contents);
+    }
+  }
 
   @Test
   public void testCreateConfigurationFile_noAppEngineDir() throws CoreException, IOException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.facets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
+import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
+import com.google.common.io.ByteSource;
+import java.io.IOException;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jst.common.project.facet.core.JavaFacet;
+import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AppEngineConfigurationUtilTest {
+  @Rule
+  public TestProjectCreator projectCreator =
+      new TestProjectCreator().withFacets(WebFacetUtils.WEB_31, JavaFacet.VERSION_1_8);
+
+  @Test
+  public void testCreateConfigurationFile_noAppEngineDir() throws CoreException, IOException {
+    IFile file =
+        AppEngineConfigurationUtil.createConfigurationFile(
+            projectCreator.getProject(), "index.yaml", ByteSource.empty().openStream(), true, null);
+    assertEquals(new Path("WebContent/WEB-INF/index.yaml"), file.getProjectRelativePath());
+  }
+
+  @Test
+  public void testCreateConfigurationFile_withAppEngineDir() throws CoreException, IOException {
+    IProject project = projectCreator.getProject();
+    IFolder srcMainAppengine = project.getFolder(new Path("src/main/appengine"));
+    ResourceUtils.createFolders(srcMainAppengine, null);
+    IFile file =
+        AppEngineConfigurationUtil.createConfigurationFile(
+            project, "index.yaml", ByteSource.empty().openStream(), true, null);
+    assertEquals(new Path("src/main/appengine/index.yaml"), file.getProjectRelativePath());
+  }
+
+  @Test
+  public void testFindConfigurationFile_noAppEngineDir() throws CoreException, IOException {
+    // ensure the configured WEB-INF directory (WebContent) is found
+    IProject project = projectCreator.getProject();
+    assertTrue(project.getFolder("WebContent/WEB-INF").exists());
+    ResourceUtils.createFolders(project.getFolder("src/main/appengine"), null);
+
+    IFile original = project.getFile(new Path("WebContent/WEB-INF/index.yaml"));
+    original.create(ByteSource.empty().openStream(), true, null);
+
+    IFile resolved = AppEngineConfigurationUtil.findConfigurationFile(project, "index.yaml");
+    assertEquals(original, resolved);
+  }
+
+  /** Ensure the file found in src/main/appengine wins. */
+  @Test
+  public void testFindConfigurationFile_withAppEngineDir() throws CoreException, IOException {
+    IProject project = projectCreator.getProject();
+    assertTrue(project.getFolder("WebContent/WEB-INF").exists());
+    ResourceUtils.createFolders(project.getFolder("src/main/appengine"), null);
+
+    project
+        .getFile("WebContent/WEB-INF/index.yaml")
+        .create(ByteSource.empty().openStream(), true, null);
+    IFile original = project.getFile("src/main/appengine/index.yaml");
+    original.create(ByteSource.empty().openStream(), true, null);
+
+    IFile resolved = AppEngineConfigurationUtil.findConfigurationFile(project, "index.yaml");
+    assertEquals(original, resolved);
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtilTest.java
@@ -42,7 +42,11 @@ public class AppEngineConfigurationUtilTest {
   public void testCreateConfigurationFile_noAppEngineDir() throws CoreException, IOException {
     IFile file =
         AppEngineConfigurationUtil.createConfigurationFile(
-            projectCreator.getProject(), "index.yaml", ByteSource.empty().openStream(), true, null);
+            projectCreator.getProject(),
+            new Path("index.yaml"),
+            ByteSource.empty().openStream(),
+            true,
+            null);
     assertEquals(new Path("WebContent/WEB-INF/index.yaml"), file.getProjectRelativePath());
   }
 
@@ -53,7 +57,7 @@ public class AppEngineConfigurationUtilTest {
     ResourceUtils.createFolders(srcMainAppengine, null);
     IFile file =
         AppEngineConfigurationUtil.createConfigurationFile(
-            project, "index.yaml", ByteSource.empty().openStream(), true, null);
+            project, new Path("index.yaml"), ByteSource.empty().openStream(), true, null);
     assertEquals(new Path("src/main/appengine/index.yaml"), file.getProjectRelativePath());
   }
 
@@ -67,7 +71,8 @@ public class AppEngineConfigurationUtilTest {
     IFile original = project.getFile(new Path("WebContent/WEB-INF/index.yaml"));
     original.create(ByteSource.empty().openStream(), true, null);
 
-    IFile resolved = AppEngineConfigurationUtil.findConfigurationFile(project, "index.yaml");
+    IFile resolved =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("index.yaml"));
     assertEquals(original, resolved);
   }
 
@@ -84,7 +89,8 @@ public class AppEngineConfigurationUtilTest {
     IFile original = project.getFile("src/main/appengine/index.yaml");
     original.create(ByteSource.empty().openStream(), true, null);
 
-    IFile resolved = AppEngineConfigurationUtil.findConfigurationFile(project, "index.yaml");
+    IFile resolved =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("index.yaml"));
     assertEquals(original, resolved);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/convert/AppEngineStandardProjectConvertJobTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
@@ -59,7 +60,9 @@ public class AppEngineStandardProjectConvertJobTest {
     // verify App Engine standard files are present
     IFile webXml = WebProjectUtil.findInWebInf(project, new Path("web.xml"));
     assertTrue(webXml.exists());
-    assertTrue(WebProjectUtil.findInWebInf(project, new Path("appengine-web.xml")).exists());
+    IFile appEngineWebXml =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("appengine-web.xml"));
+    assertTrue(appEngineWebXml.exists());
 
     // verify no overlap in WEB-INF and source paths
     // Java 1.7 facet sets the source path to src/ which will overlap with the

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
@@ -360,8 +360,8 @@ public class AppEngineContentProviderTest {
   }
 
   /**
-   * Test that creating that a newly-created {@code appengine-web.xml} "overrides" the previous
-   * {@code app.yaml} for the {@link AppEngineProjectElement}.
+   * Test that a newly-created {@code appengine-web.xml} replaces the {@code app.yaml} for the
+   * {@link AppEngineProjectElement}.
    */
   @Test
   public void testDynamicChanges_appEngineWebXml_appYaml() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
@@ -50,6 +50,7 @@ import java.util.function.BiConsumer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
@@ -306,7 +307,8 @@ public class AppEngineContentProviderTest {
 
     ByteArrayInputStream stream =
         new ByteArrayInputStream("runtime: java\n".getBytes(StandardCharsets.UTF_8));
-    AppEngineConfigurationUtil.createConfigurationFile(project, "app.yaml", stream, true, null);
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, new Path("app.yaml"), stream, true, null);
 
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     Object[] children = fixture.getChildren(projectCreator.getFacetedProject());
@@ -320,7 +322,7 @@ public class AppEngineContentProviderTest {
 
     IFile cronYaml =
         AppEngineConfigurationUtil.createConfigurationFile(
-            project, "cron.yaml", ByteSource.empty().openStream(), true, null);
+            project, new Path("cron.yaml"), ByteSource.empty().openStream(), true, null);
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     children = fixture.getChildren(projectCreator.getFacetedProject());
     assertNotNull(children);
@@ -332,7 +334,7 @@ public class AppEngineContentProviderTest {
     assertThat(children, hasItemInArray(instanceOf(CronDescriptor.class)));
 
     AppEngineConfigurationUtil.createConfigurationFile(
-        project, "index.yaml", ByteSource.empty().openStream(), true, null);
+        project, new Path("index.yaml"), ByteSource.empty().openStream(), true, null);
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     children = fixture.getChildren(projectCreator.getFacetedProject());
     assertNotNull(children);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
@@ -364,7 +364,7 @@ public class AppEngineContentProviderTest {
    * {@code app.yaml} for the {@link AppEngineProjectElement}.
    */
   @Test
-  public void testDynamicChanges_appEngineWebXml_appYaml() throws CoreException, IOException {
+  public void testDynamicChanges_appEngineWebXml_appYaml() throws CoreException {
     projectCreator.withFacets(AppEngineStandardFacet.JRE7, WebFacetUtils.WEB_25);
     IProject project = projectCreator.getProject();
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProviderTest.java
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineResourceElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.CronDescriptor;
@@ -50,7 +50,6 @@ import java.util.function.BiConsumer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.viewers.StructuredViewer;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
@@ -307,7 +306,7 @@ public class AppEngineContentProviderTest {
 
     ByteArrayInputStream stream =
         new ByteArrayInputStream("runtime: java\n".getBytes(StandardCharsets.UTF_8));
-    WebProjectUtil.createFileInWebInf(project, new Path("app.yaml"), stream, true, null);
+    AppEngineConfigurationUtil.createConfigurationFile(project, "app.yaml", stream, true, null);
 
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     Object[] children = fixture.getChildren(projectCreator.getFacetedProject());
@@ -320,8 +319,8 @@ public class AppEngineContentProviderTest {
     assertEquals(0, children.length);
 
     IFile cronYaml =
-        WebProjectUtil.createFileInWebInf(
-            project, new Path("cron.yaml"), ByteSource.empty().openStream(), true, null);
+        AppEngineConfigurationUtil.createConfigurationFile(
+            project, "cron.yaml", ByteSource.empty().openStream(), true, null);
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     children = fixture.getChildren(projectCreator.getFacetedProject());
     assertNotNull(children);
@@ -332,8 +331,8 @@ public class AppEngineContentProviderTest {
     assertEquals(1, children.length);
     assertThat(children, hasItemInArray(instanceOf(CronDescriptor.class)));
 
-    WebProjectUtil.createFileInWebInf(
-        project, new Path("index.yaml"), ByteSource.empty().openStream(), true, null);
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, "index.yaml", ByteSource.empty().openStream(), true, null);
     verify(refreshHandler, atLeastOnce()).accept(anyObject(), anyObject());
     children = fixture.getChildren(projectCreator.getFacetedProject());
     assertNotNull(children);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProviderTest.java
@@ -19,12 +19,13 @@ package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.tools.appengine.AppEngineDescriptor;
-import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.CronDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.DatastoreIndexesDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.DenialOfServiceDescriptor;
@@ -32,12 +33,22 @@ import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.Dispat
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.TaskQueuesDescriptor;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.resource.DeviceResourceDescriptor;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceManager;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AppEngineLabelProviderTest {
-  private final AppEngineLabelProvider fixture =
-      new AppEngineLabelProvider(mock(ResourceManager.class));
+  private final ResourceManager resourceManager = mock(ResourceManager.class);
+  private final AppEngineLabelProvider fixture = new AppEngineLabelProvider(resourceManager);
+
+  @Before
+  public void setUp() {
+    // Many of ResourceManager's methods are final; we check getImage() methods
+    // by verifying that create() is called
+    doReturn(null).when(resourceManager).create(any(DeviceResourceDescriptor.class));
+  }
 
   @Test
   public void testProjectText_noAppEngineWebXml() {
@@ -45,153 +56,191 @@ public class AppEngineLabelProviderTest {
     // descriptor, which is generated from getVersionTuple(). This test ensures that
     // we don't generate a text string when no appengine-web.xml is found.
     IProject project = mock(IProject.class);
-    assertNull(AppEngineLabelProvider.getAppEngineStandardProjectText(project));
+    assertNull(AppEngineLabelProvider.getAppEngineProjectText(project));
   }
 
   @Test
-  public void testAppEngineVersionTuple_null() throws AppEngineException {
-    String result = AppEngineLabelProvider.getVersionTuple(null);
+  public void testAppEngineVersionTuple_nulls() {
+    String result = AppEngineLabelProvider.getVersionTuple(null, null, null);
     assertNotNull(result);
     assertEquals(0, result.length());
   }
 
   @Test
-  public void testAppEngineVersionTuple_noData() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn(null).when(descriptor).getProjectId();
-    doReturn(null).when(descriptor).getServiceId();
-    doReturn(null).when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
-    assertNotNull(result);
-    assertEquals(0, result.length());
-  }
-
-  @Test
-  public void testAppEngineVersionTuple_project() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn("project").when(descriptor).getProjectId();
-    doReturn(null).when(descriptor).getServiceId();
-    doReturn(null).when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  public void testAppEngineVersionTuple_project() {
+    String result = AppEngineLabelProvider.getVersionTuple("project", null, null);
     assertEquals("project", result);
   }
 
   @Test
-  public void testAppEngineVersionTuple_service() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn(null).when(descriptor).getProjectId();
-    doReturn("service").when(descriptor).getServiceId();
-    doReturn(null).when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
-    assertEquals("service", result);
-  }
-
-  @Test
-  public void testAppEngineVersionTuple_version() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn(null).when(descriptor).getProjectId();
-    doReturn(null).when(descriptor).getServiceId();
-    doReturn("version").when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  public void testAppEngineVersionTuple_version() {
+    String result = AppEngineLabelProvider.getVersionTuple(null, "version", null);
     assertEquals("version", result);
   }
 
   @Test
-  public void testAppEngineVersionTuple_projectVersion() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn("project").when(descriptor).getProjectId();
-    doReturn(null).when(descriptor).getServiceId();
-    doReturn("version").when(descriptor).getProjectVersion();
+  public void testAppEngineVersionTuple_service() {
+    String result = AppEngineLabelProvider.getVersionTuple(null, null, "service");
+    assertEquals("service", result);
+  }
 
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  @Test
+  public void testAppEngineVersionTuple_project_version() {
+    String result = AppEngineLabelProvider.getVersionTuple("project", "version", null);
     assertEquals("project:version", result);
   }
 
   @Test
-  public void testAppEngineVersionTuple_projectService() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn("project").when(descriptor).getProjectId();
-    doReturn("service").when(descriptor).getServiceId();
-    doReturn(null).when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  public void testAppEngineVersionTuple_project_service() {
+    String result = AppEngineLabelProvider.getVersionTuple("project", null, "service");
     assertEquals("project:service", result);
   }
 
   @Test
-  public void testAppEngineVersionTuple_versionService() throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn(null).when(descriptor).getProjectId();
-    doReturn("service").when(descriptor).getServiceId();
-    doReturn("version").when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  public void testAppEngineVersionTuple_version_service() {
+    String result = AppEngineLabelProvider.getVersionTuple(null, "version", "service");
     assertEquals("service:version", result);
   }
 
   @Test
-  public void testAppEngineVersionTuple_projectVersionService()
-      throws AppEngineException {
-    AppEngineDescriptor descriptor = mock(AppEngineDescriptor.class);
-    doReturn("project").when(descriptor).getProjectId();
-    doReturn("service").when(descriptor).getServiceId();
-    doReturn("version").when(descriptor).getProjectVersion();
-
-    String result = AppEngineLabelProvider.getVersionTuple(descriptor);
+  public void testAppEngineVersionTuple_project_version_service() {
+    String result = AppEngineLabelProvider.getVersionTuple("project", "version", "service");
     assertEquals("project:service:version", result);
   }
 
   @Test
-  public void testCronDescriptor() {
+  public void testGetText_cronDescriptor_xml() {
     IFile file = mock(IFile.class);
     when(file.getName()).thenReturn("cron.xml");
     when(file.exists()).thenReturn(true);
     when(file.getProject()).thenReturn(mock(IProject.class));
     CronDescriptor element = new CronDescriptor(file);
-    assertEquals("Scheduled Tasks", fixture.getText(element));
+    assertEquals("Scheduled Tasks - cron.xml", fixture.getText(element));
   }
 
   @Test
-  public void testDatastoreIndexesDescriptor() {
+  public void testGetText_datastoreIndexesDescriptor_xml() {
     IFile file = mock(IFile.class);
     when(file.getName()).thenReturn("datastore-indexes.xml");
     when(file.exists()).thenReturn(true);
     when(file.getProject()).thenReturn(mock(IProject.class));
     DatastoreIndexesDescriptor element = new DatastoreIndexesDescriptor(file);
-    assertEquals("Datastore Indexes", fixture.getText(element));
+    assertEquals("Datastore Indexes - datastore-indexes.xml", fixture.getText(element));
   }
 
   @Test
-  public void testDenialOfServiceDescriptor() {
+  public void testGetText_denialOfServiceDescriptor_xml() {
     IFile file = mock(IFile.class);
     when(file.getName()).thenReturn("dos.xml");
     when(file.exists()).thenReturn(true);
     when(file.getProject()).thenReturn(mock(IProject.class));
     DenialOfServiceDescriptor element = new DenialOfServiceDescriptor(file);
-    assertEquals("Denial of Service Protection", fixture.getText(element));
+    assertEquals("Denial of Service Protection - dos.xml", fixture.getText(element));
   }
 
   @Test
-  public void testDispatchRoutingDescriptor() {
+  public void testGetText_dispatchRoutingDescriptor_xml() {
     IFile file = mock(IFile.class);
     when(file.getName()).thenReturn("dispatch.xml");
     when(file.exists()).thenReturn(true);
     when(file.getProject()).thenReturn(mock(IProject.class));
     DispatchRoutingDescriptor element = new DispatchRoutingDescriptor(file);
-    assertEquals("Dispatch Routing Rules", fixture.getText(element));
+    assertEquals("Dispatch Routing Rules - dispatch.xml", fixture.getText(element));
   }
 
   @Test
-  public void testTaskQueuesDescriptor() {
+  public void testGetText_taskQueuesDescriptor_xml() {
     IFile file = mock(IFile.class);
     when(file.getName()).thenReturn("queue.xml");
     when(file.exists()).thenReturn(true);
     when(file.getProject()).thenReturn(mock(IProject.class));
     TaskQueuesDescriptor element = new TaskQueuesDescriptor(file);
-    assertEquals("Task Queue Definitions", fixture.getText(element));
+    assertEquals("Task Queue Definitions - queue.xml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetText_cronDescriptor_yaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("cron.yaml");
+    when(file.exists()).thenReturn(true);
+    when(file.getProject()).thenReturn(mock(IProject.class));
+    CronDescriptor element = new CronDescriptor(file);
+    assertEquals("Scheduled Tasks - cron.yaml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetText_datastoreIndexesDescriptor_yaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("index.yaml");
+    when(file.exists()).thenReturn(true);
+    when(file.getProject()).thenReturn(mock(IProject.class));
+    DatastoreIndexesDescriptor element = new DatastoreIndexesDescriptor(file);
+    assertEquals("Datastore Indexes - index.yaml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetText_denialOfServiceDescriptor_yaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("dos.yaml");
+    when(file.exists()).thenReturn(true);
+    when(file.getProject()).thenReturn(mock(IProject.class));
+    DenialOfServiceDescriptor element = new DenialOfServiceDescriptor(file);
+    assertEquals("Denial of Service Protection - dos.yaml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetText_dispatchRoutingDescriptor_yaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("dispatch.yaml");
+    when(file.exists()).thenReturn(true);
+    when(file.getProject()).thenReturn(mock(IProject.class));
+    DispatchRoutingDescriptor element = new DispatchRoutingDescriptor(file);
+    assertEquals("Dispatch Routing Rules - dispatch.yaml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetText_taskQueuesDescriptor_yaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("queue.yaml");
+    when(file.exists()).thenReturn(true);
+    when(file.getProject()).thenReturn(mock(IProject.class));
+    TaskQueuesDescriptor element = new TaskQueuesDescriptor(file);
+    assertEquals("Task Queue Definitions - queue.yaml", fixture.getText(element));
+  }
+
+  @Test
+  public void testGetImage_appEngineProjectElement() {
+    fixture.getImage(mock(AppEngineProjectElement.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
+  }
+
+  @Test
+  public void testGetImage_cronDescriptor() {
+    fixture.getImage(mock(CronDescriptor.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
+  }
+
+  @Test
+  public void testGetImage_datastoreIndexesDescriptor() {
+    fixture.getImage(mock(DatastoreIndexesDescriptor.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
+  }
+
+  @Test
+  public void testGetImage_denialOfServiceDescriptor() {
+    fixture.getImage(mock(DenialOfServiceDescriptor.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
+  }
+
+  @Test
+  public void testGetImage_dispatchRoutingDescriptor() {
+    fixture.getImage(mock(DispatchRoutingDescriptor.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
+  }
+
+  @Test
+  public void testGetImage_taskQueueDescriptor() {
+    fixture.getImage(mock(TaskQueuesDescriptor.class));
+    verify(resourceManager).create(any(ImageDescriptor.class));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProviderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProviderTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,22 +32,14 @@ import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.Dispat
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.TaskQueuesDescriptor;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.jface.resource.DeviceResourceDescriptor;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceManager;
-import org.junit.Before;
 import org.junit.Test;
 
 public class AppEngineLabelProviderTest {
   private final ResourceManager resourceManager = mock(ResourceManager.class);
   private final AppEngineLabelProvider fixture = new AppEngineLabelProvider(resourceManager);
-
-  @Before
-  public void setUp() {
-    // Many of ResourceManager's methods are final; we check getImage() methods
-    // by verifying that create() is called
-    doReturn(null).when(resourceManager).create(any(DeviceResourceDescriptor.class));
-  }
+  private final AppEngineProjectElement programElement = mock(AppEngineProjectElement.class);
 
   @Test
   public void testProjectText_noAppEngineWebXml() {
@@ -61,50 +52,62 @@ public class AppEngineLabelProviderTest {
 
   @Test
   public void testAppEngineVersionTuple_nulls() {
-    String result = AppEngineLabelProvider.getVersionTuple(null, null, null);
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertNotNull(result);
     assertEquals(0, result.length());
   }
 
   @Test
   public void testAppEngineVersionTuple_project() {
-    String result = AppEngineLabelProvider.getVersionTuple("project", null, null);
+    when(programElement.getProjectId()).thenReturn("project");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("project", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_version() {
-    String result = AppEngineLabelProvider.getVersionTuple(null, "version", null);
+    when(programElement.getProjectVersion()).thenReturn("version");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("version", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_service() {
-    String result = AppEngineLabelProvider.getVersionTuple(null, null, "service");
+    when(programElement.getServiceId()).thenReturn("service");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("service", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_project_version() {
-    String result = AppEngineLabelProvider.getVersionTuple("project", "version", null);
+    when(programElement.getProjectId()).thenReturn("project");
+    when(programElement.getProjectVersion()).thenReturn("version");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("project:version", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_project_service() {
-    String result = AppEngineLabelProvider.getVersionTuple("project", null, "service");
+    when(programElement.getProjectId()).thenReturn("project");
+    when(programElement.getServiceId()).thenReturn("service");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("project:service", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_version_service() {
-    String result = AppEngineLabelProvider.getVersionTuple(null, "version", "service");
+    when(programElement.getProjectVersion()).thenReturn("version");
+    when(programElement.getServiceId()).thenReturn("service");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("service:version", result);
   }
 
   @Test
   public void testAppEngineVersionTuple_project_version_service() {
-    String result = AppEngineLabelProvider.getVersionTuple("project", "version", "service");
+    when(programElement.getProjectId()).thenReturn("project");
+    when(programElement.getProjectVersion()).thenReturn("version");
+    when(programElement.getServiceId()).thenReturn("service");
+    String result = AppEngineLabelProvider.getVersionTuple(programElement);
     assertEquals("project:service:version", result);
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/PluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/PluginXmlTest.java
@@ -19,8 +19,10 @@ package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexJarFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineStandardProjectElement;
+import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.CronDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.DatastoreIndexesDescriptor;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.DenialOfServiceDescriptor;
@@ -95,6 +97,37 @@ public class PluginXmlTest extends BasePluginXmlTest {
   }
 
   @Test
+  public void testNavigatorContentTriggerExpression_appEngineFlexibleWarJavaProject()
+      throws CoreException {
+    Element triggerPoints =
+        findElement(
+            "//plugin/extension[@point='org.eclipse.ui.navigator.navigatorContent']"
+                + "/navigatorContent[@id='com.google.cloud.tools.eclipse.appengine.navigator']"
+                + "/triggerPoints/*");
+    Expression triggerExpression = checkExpression(triggerPoints);
+    projectCreator.withFacets(
+        AppEngineFlexWarFacet.FACET_VERSION, JavaFacet.VERSION_1_8, WebFacetUtils.WEB_31);
+    assertEquals(
+        EvaluationResult.TRUE,
+        triggerExpression.evaluate(new EvaluationContext(null, projectCreator.getProject())));
+  }
+
+  @Test
+  public void testNavigatorContentTriggerExpression_appEngineFlexibleJarJavaProject()
+      throws CoreException {
+    Element triggerPoints =
+        findElement(
+            "//plugin/extension[@point='org.eclipse.ui.navigator.navigatorContent']"
+                + "/navigatorContent[@id='com.google.cloud.tools.eclipse.appengine.navigator']"
+                + "/triggerPoints/*");
+    Expression triggerExpression = checkExpression(triggerPoints);
+    projectCreator.withFacets(AppEngineFlexJarFacet.FACET_VERSION, JavaFacet.VERSION_1_8);
+    assertEquals(
+        EvaluationResult.TRUE,
+        triggerExpression.evaluate(new EvaluationContext(null, projectCreator.getProject())));
+  }
+
+  @Test
   public void testNavigatorContentActionProvider() throws CoreException {
     Element actionProvider =
         findElement(
@@ -110,7 +143,7 @@ public class PluginXmlTest extends BasePluginXmlTest {
     assertEquals(
         EvaluationResult.TRUE,
         enablementExpression.evaluate(
-            new EvaluationContext(null, mock(AppEngineStandardProjectElement.class))));
+            new EvaluationContext(null, mock(AppEngineProjectElement.class))));
     assertEquals(
         EvaluationResult.TRUE,
         enablementExpression.evaluate(new EvaluationContext(null, mock(CronDescriptor.class))));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
@@ -114,4 +114,25 @@ public class AppEngineProjectElementTest {
         .thenReturn(new Path(".settings/org.eclipse.wst.common.project.facet.core.xml"));
     assertTrue(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
+
+  @Test
+  public void testHasAppEngineDescriptor_normalFile() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("org.eclipse.wst.common.project.facet.core.xml");
+    assertFalse(AppEngineProjectElement.hasAppEngineDescriptor(Collections.singleton(file)));
+  }
+
+  @Test
+  public void testHasAppEngineDescriptor_appEngineWebXml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("appengine-web.xml");
+    assertTrue(AppEngineProjectElement.hasAppEngineDescriptor(Collections.singleton(file)));
+  }
+
+  @Test
+  public void testHasAppEngineDescriptor_appYaml() {
+    IFile file = mock(IFile.class);
+    when(file.getName()).thenReturn("app.yaml");
+    assertTrue(AppEngineProjectElement.hasAppEngineDescriptor(Collections.singleton(file)));
+  }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
@@ -24,12 +24,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.util.Collections;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
@@ -61,6 +63,61 @@ public class AppEngineProjectElementTest {
     assertNotNull(projectElement);
     assertNotNull(projectElement.getDescriptorFile());
     assertEquals("app.yaml", projectElement.getDescriptorFile().getName());
+  }
+
+  @Test
+  public void testEnvironmentRuntime_xml_noRuntime() throws CoreException, AppEngineException {
+    IProject project = projectCreator.getProject();
+    String contents = "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'/>";
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, new Path("appengine-web.xml"), contents, true, null);
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertEquals("standard", projectElement.getEnvironmentType());
+    assertEquals("java7", projectElement.getRuntime());
+  }
+
+  @Test
+  public void testEnvironmentRuntime_xml_java8Runtime() throws CoreException, AppEngineException {
+    IProject project = projectCreator.getProject();
+    String contents =
+        "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>"
+            + "<runtime>java8</runtime>"
+            + "</appengine-web-app>";
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, new Path("appengine-web.xml"), contents, true, null);
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertEquals("standard", projectElement.getEnvironmentType());
+    assertEquals("java8", projectElement.getRuntime());
+  }
+
+  @Test
+  public void testEnvironmentRuntime_yaml_python27() throws CoreException, AppEngineException {
+    IProject project = projectCreator.getProject();
+    String contents = "runtime: python27";
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, new Path("app.yaml"), contents, true, null);
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertEquals("standard", projectElement.getEnvironmentType());
+    assertEquals("python27", projectElement.getRuntime());
+  }
+
+  @Test
+  public void testEnvironmentRuntime_yaml_python27_flex() throws CoreException, AppEngineException {
+    IProject project = projectCreator.getProject();
+    String contents = "runtime: python27\nenv: flex";
+    AppEngineConfigurationUtil.createConfigurationFile(
+        project, new Path("app.yaml"), contents, true, null);
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertEquals("flex", projectElement.getEnvironmentType());
+    assertEquals("python27", projectElement.getRuntime());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
@@ -40,11 +40,9 @@ public class AppEngineProjectElementTest {
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
 
   @Test
-  public void testCreation_appEngineStandardJava8() throws AppEngineException {
+  public void testCreation_appEngineStandardJava7() throws AppEngineException {
     projectCreator.withFacets(
-        AppEngineStandardFacet.FACET.getVersion("JRE8"),
-        WebFacetUtils.WEB_31,
-        JavaFacet.VERSION_1_8);
+        AppEngineStandardFacet.JRE7, WebFacetUtils.WEB_25, JavaFacet.VERSION_1_7);
     IProject project = projectCreator.getProject();
 
     AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElementTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.util.Collections;
@@ -34,8 +36,34 @@ import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class AppEngineStandardProjectElementTest {
+public class AppEngineProjectElementTest {
   @Rule public TestProjectCreator projectCreator = new TestProjectCreator();
+
+  @Test
+  public void testCreation_appEngineStandardJava8() throws AppEngineException {
+    projectCreator.withFacets(
+        AppEngineStandardFacet.FACET.getVersion("JRE8"),
+        WebFacetUtils.WEB_31,
+        JavaFacet.VERSION_1_8);
+    IProject project = projectCreator.getProject();
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertNotNull(projectElement.getDescriptorFile());
+    assertEquals("appengine-web.xml", projectElement.getDescriptorFile().getName());
+  }
+
+  @Test
+  public void testCreation_appEngineFlexibleWar() throws AppEngineException {
+    projectCreator.withFacets(
+        AppEngineFlexWarFacet.FACET_VERSION, WebFacetUtils.WEB_31, JavaFacet.VERSION_1_8);
+    IProject project = projectCreator.getProject();
+
+    AppEngineProjectElement projectElement = AppEngineProjectElement.create(project);
+    assertNotNull(projectElement);
+    assertNotNull(projectElement.getDescriptorFile());
+    assertEquals("app.yaml", projectElement.getDescriptorFile().getName());
+  }
 
   @Test
   public void testGetAdapter() throws AppEngineException {
@@ -45,8 +73,8 @@ public class AppEngineStandardProjectElementTest {
         JavaFacet.VERSION_1_7);
     IProject project = projectCreator.getProject();
 
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     assertNotNull(projectElement);
     assertNotNull(projectElement.getAdapter(IFile.class));
   }
@@ -55,7 +83,7 @@ public class AppEngineStandardProjectElementTest {
   public void testHasLayoutChanged_normalFile() {
     IFile file = mock(IFile.class);
     when(file.getProjectRelativePath()).thenReturn(new Path("foo"));
-    assertFalse(AppEngineStandardProjectElement.hasLayoutChanged(Collections.singleton(file)));
+    assertFalse(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
 
   @Test
@@ -63,14 +91,14 @@ public class AppEngineStandardProjectElementTest {
     IFile file = mock(IFile.class);
     // not in .settings
     when(file.getProjectRelativePath()).thenReturn(new Path("org.eclipse.wst.common.component"));
-    assertFalse(AppEngineStandardProjectElement.hasLayoutChanged(Collections.singleton(file)));
+    assertFalse(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
 
   @Test
   public void testHasLayoutChanged_settingsFile() {
     IFile file = mock(IFile.class);
     when(file.getProjectRelativePath()).thenReturn(new Path(".settings/foo"));
-    assertFalse(AppEngineStandardProjectElement.hasLayoutChanged(Collections.singleton(file)));
+    assertFalse(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
 
   @Test
@@ -78,7 +106,7 @@ public class AppEngineStandardProjectElementTest {
     IFile file = mock(IFile.class);
     when(file.getProjectRelativePath())
         .thenReturn(new Path(".settings/org.eclipse.wst.common.component"));
-    assertTrue(AppEngineStandardProjectElement.hasLayoutChanged(Collections.singleton(file)));
+    assertTrue(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
 
   @Test
@@ -86,6 +114,6 @@ public class AppEngineStandardProjectElementTest {
     IFile file = mock(IFile.class);
     when(file.getProjectRelativePath())
         .thenReturn(new Path(".settings/org.eclipse.wst.common.project.facet.core.xml"));
-    assertTrue(AppEngineStandardProjectElement.hasLayoutChanged(Collections.singleton(file)));
+    assertTrue(AppEngineProjectElement.hasLayoutChanged(Collections.singleton(file)));
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
@@ -69,7 +69,7 @@ public class ModelRefreshTests {
 
   /** Verify that the content block is configured for initial configuration files. */
   @Test
-  public void testAppEngineStandardProjectElementCreate_initial() throws AppEngineException {
+  public void testAppEngineProjectElementCreate_initial() throws AppEngineException {
     IProject project = projectCreator.getProject();
     IFile cronXml = ConfigurationFileUtils.createEmptyCronXml(project);
     IFile datastoreIndexesXml =
@@ -103,7 +103,7 @@ public class ModelRefreshTests {
 
   /** Verify that the content block is progressively updated as configuration files are added. */
   @Test
-  public void testAppEngineStandardProjectElementCreate_staggered() throws AppEngineException {
+  public void testAppEngineProjectElementCreate_staggered() throws AppEngineException {
     IProject project = projectCreator.getProject();
     AppEngineProjectElement projectElement =
         AppEngineProjectElement.create(project);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
@@ -57,7 +57,7 @@ import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 
-/** Test creation of AppEngineStandardProjectElement and its sub-elements. */
+/** Test creation of AppEngineProjectElement and its sub-elements. */
 public class ModelRefreshTests {
   @Rule
   public TestProjectCreator projectCreator =
@@ -78,8 +78,8 @@ public class ModelRefreshTests {
     IFile dosXml = ConfigurationFileUtils.createEmptyDosXml(project);
     IFile queueXml = ConfigurationFileUtils.createEmptyQueueXml(project);
     
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     AppEngineResourceElement[] subElements = projectElement.getConfigurations();
     assertNotNull(subElements);
     assertEquals(5, subElements.length);
@@ -105,8 +105,8 @@ public class ModelRefreshTests {
   @Test
   public void testAppEngineStandardProjectElementCreate_staggered() throws AppEngineException {
     IProject project = projectCreator.getProject();
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     AppEngineResourceElement[] subElements = projectElement.getConfigurations();
     assertNotNull(subElements);
     assertEquals(0, subElements.length);
@@ -181,8 +181,8 @@ public class ModelRefreshTests {
     ConfigurationFileUtils.createEmptyDispatchXml(project);
     ConfigurationFileUtils.createEmptyDosXml(project);
     ConfigurationFileUtils.createEmptyQueueXml(project);
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     final AppEngineResourceElement[] subElements = projectElement.getConfigurations();
     assertEquals(5, subElements.length);
     assertThat(subElements, hasItemInArray(instanceOf(CronDescriptor.class)));
@@ -213,8 +213,8 @@ public class ModelRefreshTests {
     ConfigurationFileUtils.createEmptyDispatchXml(project);
     ConfigurationFileUtils.createEmptyDosXml(project);
     ConfigurationFileUtils.createEmptyQueueXml(project);
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     final AppEngineResourceElement[] subElements = projectElement.getConfigurations();
     assertEquals(5, subElements.length);
     assertThat(subElements, hasItemInArray(instanceOf(CronDescriptor.class)));
@@ -245,8 +245,8 @@ public class ModelRefreshTests {
     files.add(ConfigurationFileUtils.createEmptyDosXml(project));
     files.add(ConfigurationFileUtils.createEmptyQueueXml(project));
 
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     files.add(projectElement.getDescriptorFile());
     final AppEngineResourceElement[] subElements = projectElement.getConfigurations();
 
@@ -268,8 +268,8 @@ public class ModelRefreshTests {
     IProject project = projectCreator.getProject();
     ConfigurationFileUtils.createAppEngineWebXml(project, "non-default");
 
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     AppEngineResourceElement[] subElements = projectElement.getConfigurations();
     assertEquals(0, subElements.length);
 
@@ -289,8 +289,8 @@ public class ModelRefreshTests {
     IProject project = projectCreator.getProject();
     // verify the new files are not picked up yet
     IFile oldCronXml = ConfigurationFileUtils.createEmptyCronXml(project);
-    AppEngineStandardProjectElement projectElement =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement projectElement =
+        AppEngineProjectElement.create(project);
     final AppEngineResourceElement[] oldElements = projectElement.getConfigurations();
     assertEquals(1, oldElements.length);
     assertThat(oldElements, hasItemInArray(instanceOf(CronDescriptor.class)));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/plugin.xml
@@ -312,10 +312,20 @@
               <instanceof
                     value="org.eclipse.core.resources.IProject">
               </instanceof>
-              <test
-                    property="org.eclipse.wst.common.project.facet.core.projectFacet"
-                    value="com.google.cloud.tools.eclipse.appengine.facets.standard">
-              </test>
+              <or>
+                 <test
+                       property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                       value="com.google.cloud.tools.eclipse.appengine.facets.standard">
+                 </test>
+                 <test
+                       property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                       value="com.google.cloud.tools.eclipse.appengine.facets.flex">
+                 </test>
+                 <test
+                       property="org.eclipse.wst.common.project.facet.core.projectFacet"
+                       value="com.google.cloud.tools.eclipse.appengine.facets.flex.jar">
+                 </test>
+              </or>
            </and>
         </triggerPoints>
         <possibleChildren>
@@ -332,7 +342,7 @@
                        value="com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineResourceElement">
                  </instanceof>
                  <instanceof
-                       value="com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineStandardProjectElement">
+                       value="com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement">
                  </instanceof>
               </or>
            </enablement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.eclipse.appengine.facets;
 
 import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -45,7 +47,26 @@ public class AppEngineConfigurationUtil {
    * Create an App Engine configuration file in the appropriate location for the project.
    *
    * @param project the hosting project
-   * @param relativePath the file name
+   * @param relativePath the path of the file relative to the configuration location
+   * @param contents the content for the file
+   * @param overwrite if {@code true} then overwrite the file if it exists
+   */
+  public static IFile createConfigurationFile(
+      IProject project,
+      IPath relativePath,
+      String contents,
+      boolean overwrite,
+      IProgressMonitor monitor)
+      throws CoreException {
+    InputStream bytes = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
+    return createConfigurationFile(project, relativePath, bytes, overwrite, monitor);
+  }
+
+  /**
+   * Create an App Engine configuration file in the appropriate location for the project.
+   *
+   * @param project the hosting project
+   * @param relativePath the path of the file relative to the configuration location
    * @param contents the content for the file
    * @param overwrite if {@code true} then overwrite the file if it exists
    */

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.facets;
+
+import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
+import java.io.InputStream;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Utility class for resolving App Engine configuration files in a project. The goal of this class
+ * is to insulate callers from having to know how and when configuration files are placed within a
+ * project. For example, Java projects for the flexible environment typically place their YAML
+ * configuration files in {@code src/main/appengine} whereas Java projects for the standard
+ * environment place their XML configuration files within the {@code WEB-INF} directory.
+ *
+ * @see WebProjectUtil
+ */
+public class AppEngineConfigurationUtil {
+  /** A well-known location for App Engine configuration files. */
+  private static final IPath DEFAULT_CONFIGURATION_FILE_LOCATION = new Path("src/main/appengine");
+
+  /**
+   * Create an App Engine configuration file in the appropriate location for the project.
+   *
+   * @param project the hosting project
+   * @param baseName the file name
+   * @param contents the content for the file
+   * @param overwrite if {@code true} then overwrite the file if it exists
+   */
+  public static IFile createConfigurationFile(
+      IProject project,
+      String baseName,
+      InputStream contents,
+      boolean overwrite,
+      IProgressMonitor monitor)
+      throws CoreException {
+    IFolder appengineFolder = project.getFolder(DEFAULT_CONFIGURATION_FILE_LOCATION);
+    if (appengineFolder != null && appengineFolder.exists()) {
+      IFile destination = appengineFolder.getFile(baseName);
+      if (!destination.exists()) {
+        IContainer parent = destination.getParent();
+        ResourceUtils.createFolders(parent, monitor);
+        destination.create(contents, true, monitor);
+      } else if (overwrite) {
+        destination.setContents(contents, IResource.FORCE, monitor);
+      }
+      return destination;
+    }
+    return WebProjectUtil.createFileInWebInf(
+        project, new Path(baseName), contents, overwrite, monitor);
+  }
+
+  /**
+   * Attempt to resolve the given file within the project's {@code WEB-INF}. Note that this method
+   * may return a file that is in a build location (e.g., {@code
+   * target/m2e-wtp/web-resources/WEB-INF}) which may be frequently removed or regenerated.
+   *
+   * @return the file location or {@code null} if not found
+   */
+  public static IFile findConfigurationFile(IProject project, String baseName) {
+    IFolder appengineFolder = project.getFolder(DEFAULT_CONFIGURATION_FILE_LOCATION);
+    IFile destination = appengineFolder.getFile(baseName);
+    if (destination.exists()) {
+      return destination;
+    }
+    return WebProjectUtil.findInWebInf(project, new Path(baseName));
+  }
+
+  private AppEngineConfigurationUtil() {} // not intended to be instantiated
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineConfigurationUtil.java
@@ -45,20 +45,20 @@ public class AppEngineConfigurationUtil {
    * Create an App Engine configuration file in the appropriate location for the project.
    *
    * @param project the hosting project
-   * @param baseName the file name
+   * @param relativePath the file name
    * @param contents the content for the file
    * @param overwrite if {@code true} then overwrite the file if it exists
    */
   public static IFile createConfigurationFile(
       IProject project,
-      String baseName,
+      IPath relativePath,
       InputStream contents,
       boolean overwrite,
       IProgressMonitor monitor)
       throws CoreException {
     IFolder appengineFolder = project.getFolder(DEFAULT_CONFIGURATION_FILE_LOCATION);
     if (appengineFolder != null && appengineFolder.exists()) {
-      IFile destination = appengineFolder.getFile(baseName);
+      IFile destination = appengineFolder.getFile(relativePath);
       if (!destination.exists()) {
         IContainer parent = destination.getParent();
         ResourceUtils.createFolders(parent, monitor);
@@ -68,8 +68,7 @@ public class AppEngineConfigurationUtil {
       }
       return destination;
     }
-    return WebProjectUtil.createFileInWebInf(
-        project, new Path(baseName), contents, overwrite, monitor);
+    return WebProjectUtil.createFileInWebInf(project, relativePath, contents, overwrite, monitor);
   }
 
   /**
@@ -79,13 +78,15 @@ public class AppEngineConfigurationUtil {
    *
    * @return the file location or {@code null} if not found
    */
-  public static IFile findConfigurationFile(IProject project, String baseName) {
+  public static IFile findConfigurationFile(IProject project, IPath relativePath) {
     IFolder appengineFolder = project.getFolder(DEFAULT_CONFIGURATION_FILE_LOCATION);
-    IFile destination = appengineFolder.getFile(baseName);
-    if (destination.exists()) {
-      return destination;
+    if (appengineFolder != null && appengineFolder.exists()) {
+      IFile destination = appengineFolder.getFile(relativePath);
+      if (destination.exists()) {
+        return destination;
+      }
     }
-    return WebProjectUtil.findInWebInf(project, new Path(baseName));
+    return WebProjectUtil.findInWebInf(project, relativePath);
   }
 
   private AppEngineConfigurationUtil() {} // not intended to be instantiated

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardJre7ProjectFacetDetector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/AppEngineStandardJre7ProjectFacetDetector.java
@@ -57,7 +57,8 @@ public class AppEngineStandardJre7ProjectFacetDetector extends ProjectFacetDetec
     }
 
     IFile appEngineWebXml =
-        WebProjectUtil.findInWebInf(workingCopy.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            workingCopy.getProject(), new Path("appengine-web.xml"));
     progress.worked(1);
     if (appEngineWebXml == null || !appEngineWebXml.exists()) {
       logger.fine("skipping " + projectName + ": cannot find appengine-web.xml");

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -144,8 +144,12 @@ public class StandardFacetInstallDelegate implements IDelegate {
     if (appEngineRuntime instanceof String) {
       parameters.put("runtime", (String) appEngineRuntime);
     }
-    createFileInWebInf(project, "appengine-web.xml", Templates.APPENGINE_WEB_XML_TEMPLATE,
-        parameters, progress.split(5));
+    createAppEngineConfigurationFile(
+        project,
+        "appengine-web.xml",
+        Templates.APPENGINE_WEB_XML_TEMPLATE,
+        parameters,
+        progress.split(5));
   }
 
   /** Creates a file in the WEB-INF folder if it doesn't exist. */
@@ -161,6 +165,35 @@ public class StandardFacetInstallDelegate implements IDelegate {
     // Use the virtual component model to decide where to create the file
     targetFile =
         WebProjectUtil.createFileInWebInf(
+            project,
+            new Path(filename),
+            new ByteArrayInputStream(new byte[0]),
+            false /* overwrite */,
+            progress.split(2));
+    String fileLocation = targetFile.getLocation().toString();
+    Templates.createFileContent(fileLocation, templateName, templateParameters);
+    progress.worked(4);
+    targetFile.refreshLocal(IFile.DEPTH_ZERO, progress.split(1));
+  }
+
+  /** Creates an App Engine configuration file in the appropriate folder, if it doesn't exist. */
+  private void createAppEngineConfigurationFile(
+      IProject project,
+      String filename,
+      String templateName,
+      Map<String, String> templateParameters,
+      IProgressMonitor monitor)
+      throws CoreException {
+    SubMonitor progress = SubMonitor.convert(monitor, 7);
+
+    IFile targetFile =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path(filename));
+    if (targetFile != null && targetFile.exists()) {
+      return;
+    }
+
+    targetFile =
+        AppEngineConfigurationUtil.createConfigurationFile(
             project,
             new Path(filename),
             new ByteArrayInputStream(new byte[0]),

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -192,6 +192,7 @@ public class StandardFacetInstallDelegate implements IDelegate {
       return;
     }
 
+    // todo Templates should provide content as an InputStream
     targetFile =
         AppEngineConfigurationUtil.createConfigurationFile(
             project,

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProvider.java
@@ -17,9 +17,11 @@
 package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator;
 
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexJarFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
+import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineResourceElement;
-import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineStandardProjectElement;
 import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -28,6 +30,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -89,14 +92,17 @@ public class AppEngineContentProvider implements ITreeContentProvider {
     return null;
   }
 
-  /** Return {@code true} if the project is an App Engine Standard project. */
-  static boolean isStandard(IProject project) {
+  /** Return {@code true} if the project is an App Engine project. */
+  static boolean isAppEngine(IProject project) {
     Preconditions.checkNotNull(project);
     try {
       IFacetedProject facetedProject = ProjectFacetsManager.create(project);
-      return facetedProject != null && AppEngineStandardFacet.hasFacet(facetedProject);
+      return facetedProject != null
+          && (AppEngineStandardFacet.hasFacet(facetedProject)
+              || AppEngineFlexWarFacet.hasFacet(facetedProject)
+              || AppEngineFlexJarFacet.hasFacet(facetedProject));
     } catch (CoreException ex) {
-      logger.log(Level.INFO, "Project is not faceted", ex);
+      // Project is not faceted
       return false;
     }
   }
@@ -106,26 +112,25 @@ public class AppEngineContentProvider implements ITreeContentProvider {
    *
    * @throws AppEngineException if not an App Engine project
    */
-  @VisibleForTesting
-  static AppEngineStandardProjectElement loadRepresentation(IProject project)
+  static AppEngineProjectElement loadRepresentation(IProject project)
       throws AppEngineException {
     Preconditions.checkNotNull(project);
-    if (!project.exists() || !isStandard(project)) {
+    if (!project.exists() || !isAppEngine(project)) {
       throw new AppEngineException("Not an App Engine project");
     }
-    AppEngineStandardProjectElement appEngineProject =
-        AppEngineStandardProjectElement.create(project);
+    AppEngineProjectElement appEngineProject =
+        AppEngineProjectElement.create(project);
     return appEngineProject;
   }
 
   /** Cached representation of App Engine projects. */
-  private final LoadingCache<IProject, AppEngineStandardProjectElement> projectMapping =
+  private final LoadingCache<IProject, AppEngineProjectElement> projectMapping =
       CacheBuilder.newBuilder()
           .weakKeys()
           .build(
-              new CacheLoader<IProject, AppEngineStandardProjectElement>() {
+              new CacheLoader<IProject, AppEngineProjectElement>() {
                 @Override
-                public AppEngineStandardProjectElement load(IProject key) throws Exception {
+                public AppEngineProjectElement load(IProject key) throws Exception {
                   return AppEngineContentProvider.loadRepresentation(key);
                 }
               });
@@ -185,7 +190,7 @@ public class AppEngineContentProvider implements ITreeContentProvider {
       }
       Collection<IFile> projectFiles = affected.get(project);
       // Do we have a model for this project?  If so, then update it.
-      AppEngineStandardProjectElement projectElement = projectMapping.getIfPresent(project);
+      AppEngineProjectElement projectElement = projectMapping.getIfPresent(project);
       if (projectElement != null) {
         try {
           if (projectElement.resourcesChanged(projectFiles)) {
@@ -204,8 +209,7 @@ public class AppEngineContentProvider implements ITreeContentProvider {
           projectMapping.invalidate(project);
           toBeRefreshed.add(project);
         }
-      } else if (Iterables.any(
-          projectFiles, file -> file != null && "appengine-web.xml".equals(file.getName()))) {
+      } else if (anyMatch(projectFiles, Sets.newHashSet("appengine-web.xml", "app.yaml"))) {
         // We have no project model (wasn't an App Engine project previously) but it seems to
         // contain an App Engine descriptor.  So trigger refresh of project.
         toBeRefreshed.add(project);
@@ -214,6 +218,11 @@ public class AppEngineContentProvider implements ITreeContentProvider {
     if (!toBeRefreshed.isEmpty() || !toBeUpdated.isEmpty()) {
       refreshHandler.accept(toBeRefreshed, toBeUpdated);
     }
+  }
+
+  /** Return true if any file's {@link IFile#getName() base name} is in matches. */
+  private static boolean anyMatch(Collection<IFile> files, Set<String> names) {
+    return Iterables.any(files, file -> file != null && names.contains(file.getName()));
   }
 
   private void refreshElements(Collection<Object> toBeRefreshed, Collection<Object> toBeUpdated) {
@@ -239,8 +248,8 @@ public class AppEngineContentProvider implements ITreeContentProvider {
 
   @Override
   public boolean hasChildren(Object element) {
-    if (element instanceof AppEngineStandardProjectElement) {
-      AppEngineStandardProjectElement projectElement = (AppEngineStandardProjectElement) element;
+    if (element instanceof AppEngineProjectElement) {
+      AppEngineProjectElement projectElement = (AppEngineProjectElement) element;
       return projectElement.getConfigurations().length > 0;
     } else if (element instanceof AppEngineResourceElement) {
       // none of our descriptor models have children
@@ -250,19 +259,19 @@ public class AppEngineContentProvider implements ITreeContentProvider {
     if (project == null) {
       return false;
     }
-    AppEngineStandardProjectElement webProject = projectMapping.getIfPresent(project);
+    AppEngineProjectElement webProject = projectMapping.getIfPresent(project);
     return webProject != null ? webProject.getConfigurations().length > 0 : true;
   }
 
   @Override
   public Object[] getChildren(Object parentElement) {
-    if (parentElement instanceof AppEngineStandardProjectElement) {
-      return ((AppEngineStandardProjectElement) parentElement).getConfigurations();
+    if (parentElement instanceof AppEngineProjectElement) {
+      return ((AppEngineProjectElement) parentElement).getConfigurations();
     }
     IProject project = getProject(parentElement);
     if (project != null) {
       try {
-        AppEngineStandardProjectElement projectElement = projectMapping.get(project);
+        AppEngineProjectElement projectElement = projectMapping.get(project);
         return projectElement == null ? EMPTY_ARRAY : new Object[] {projectElement};
       } catch (ExecutionException ex) {
         // ignore: either not an App Engine project, or load failed due to a validation problem
@@ -274,8 +283,8 @@ public class AppEngineContentProvider implements ITreeContentProvider {
 
   @Override
   public Object getParent(Object element) {
-    if (element instanceof AppEngineStandardProjectElement) {
-      return ((AppEngineStandardProjectElement) element).getProject();
+    if (element instanceof AppEngineProjectElement) {
+      return ((AppEngineProjectElement) element).getProject();
     } else if (element instanceof AppEngineResourceElement) {
       IProject project = ((AppEngineResourceElement) element).getProject();
       return projectMapping.getIfPresent(project);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineContentProvider.java
@@ -28,9 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -209,7 +207,7 @@ public class AppEngineContentProvider implements ITreeContentProvider {
           projectMapping.invalidate(project);
           toBeRefreshed.add(project);
         }
-      } else if (anyMatch(projectFiles, Sets.newHashSet("appengine-web.xml", "app.yaml"))) {
+      } else if (AppEngineProjectElement.hasAppEngineDescriptor(projectFiles)) {
         // We have no project model (wasn't an App Engine project previously) but it seems to
         // contain an App Engine descriptor.  So trigger refresh of project.
         toBeRefreshed.add(project);
@@ -218,11 +216,6 @@ public class AppEngineContentProvider implements ITreeContentProvider {
     if (!toBeRefreshed.isEmpty() || !toBeUpdated.isEmpty()) {
       refreshHandler.accept(toBeRefreshed, toBeUpdated);
     }
-  }
-
-  /** Return true if any file's {@link IFile#getName() base name} is in matches. */
-  private static boolean anyMatch(Collection<IFile> files, Set<String> names) {
-    return Iterables.any(files, file -> file != null && names.contains(file.getName()));
   }
 
   private void refreshElements(Collection<Object> toBeRefreshed, Collection<Object> toBeUpdated) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProvider.java
@@ -68,11 +68,7 @@ public class AppEngineLabelProvider extends LabelProvider implements IStyledLabe
     try {
       AppEngineProjectElement projectElement = AppEngineContentProvider.loadRepresentation(project);
       StyledString result = new StyledString(project.getName());
-      String qualifier =
-          getVersionTuple(
-              projectElement.getProjectId(),
-              projectElement.getProjectVersion(),
-              projectElement.getServiceId());
+      String qualifier = getVersionTuple(projectElement);
       if (qualifier.length() > 0) {
         result.append(" [", StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
         result.append(qualifier.toString(), StyledString.QUALIFIER_STYLER);
@@ -87,17 +83,23 @@ public class AppEngineLabelProvider extends LabelProvider implements IStyledLabe
 
   /** Returns a <em>project:service:version</em> tuple from the App Engine descriptor. */
   @VisibleForTesting
-  static String getVersionTuple(String projectId, String projectVersion, String serviceId) {
+  static String getVersionTuple(AppEngineProjectElement projectElement) {
     StringBuilder qualifier = new StringBuilder();
+
+    String projectId = projectElement.getProjectId();
     if (!Strings.isNullOrEmpty(projectId)) {
       qualifier.append(projectId);
     }
+
+    String serviceId = projectElement.getServiceId();
     if (!Strings.isNullOrEmpty(serviceId)) {
       if (qualifier.length() > 0) {
         qualifier.append(':');
       }
       qualifier.append(serviceId);
     }
+
+    String projectVersion = projectElement.getProjectVersion();
     if (!Strings.isNullOrEmpty(projectVersion)) {
       if (qualifier.length() > 0) {
         qualifier.append(':');

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProvider.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/AppEngineLabelProvider.java
@@ -16,22 +16,15 @@
 
 package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator;
 
-import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineResourceElement;
-import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.AppEngineStandardProjectElement;
 import com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model.DatastoreIndexesDescriptor;
 import com.google.cloud.tools.eclipse.appengine.ui.AppEngineImages;
 import com.google.cloud.tools.eclipse.ui.util.images.SharedImages;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import java.io.IOException;
-import java.io.InputStream;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.jface.resource.ResourceManager;
@@ -39,7 +32,6 @@ import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelP
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Image;
-import org.xml.sax.SAXException;
 
 public class AppEngineLabelProvider extends LabelProvider implements IStyledLabelProvider {
   private final ResourceManager resources;
@@ -61,10 +53,10 @@ public class AppEngineLabelProvider extends LabelProvider implements IStyledLabe
 
   @Override
   public StyledString getStyledText(Object element) {
-    if (element instanceof IProject && AppEngineContentProvider.isStandard((IProject) element)) {
-      return getAppEngineStandardProjectText((IProject) element);
-    } else if (element instanceof AppEngineStandardProjectElement) {
-      return ((AppEngineStandardProjectElement) element).getStyledLabel();
+    if (element instanceof IProject && AppEngineContentProvider.isAppEngine((IProject) element)) {
+      return getAppEngineProjectText((IProject) element);
+    } else if (element instanceof AppEngineProjectElement) {
+      return ((AppEngineProjectElement) element).getStyledLabel();
     } else if (element instanceof AppEngineResourceElement) {
       return ((AppEngineResourceElement) element).getStyledLabel();
     }
@@ -72,59 +64,57 @@ public class AppEngineLabelProvider extends LabelProvider implements IStyledLabe
   }
 
   @VisibleForTesting
-  static StyledString getAppEngineStandardProjectText(IProject project) {
-    // FIXME: this is grotty; can we not get the content provider?
-    IFile appEngineWeb = WebProjectUtil.findInWebInf(project, new Path("appengine-web.xml"));
-    if (appEngineWeb == null || !appEngineWeb.exists()) {
-      // continue on to the next
-      return null;
-    }
-    StyledString result = new StyledString(project.getName());
-    try (InputStream input = appEngineWeb.getContents()) {
-      AppEngineDescriptor descriptor = AppEngineDescriptor.parse(input);
-      String qualifier = getVersionTuple(descriptor);
+  static StyledString getAppEngineProjectText(IProject project) {
+    try {
+      AppEngineProjectElement projectElement = AppEngineContentProvider.loadRepresentation(project);
+      StyledString result = new StyledString(project.getName());
+      String qualifier =
+          getVersionTuple(
+              projectElement.getProjectId(),
+              projectElement.getProjectVersion(),
+              projectElement.getServiceId());
       if (qualifier.length() > 0) {
         result.append(" [", StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
         result.append(qualifier.toString(), StyledString.QUALIFIER_STYLER);
         result.append("]", StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
       }
-    } catch (IOException | CoreException | SAXException | AppEngineException ex) {
+      return result;
+    } catch (AppEngineException ex) {
       // ignore
     }
-    return result;
+    return null; // carry onto the next label provider
   }
 
-  /** Returns a <em>project:service:version</em> tuple from the appengine-web descriptor. */
+  /** Returns a <em>project:service:version</em> tuple from the App Engine descriptor. */
   @VisibleForTesting
-  static String getVersionTuple(AppEngineDescriptor descriptor) throws AppEngineException {
+  static String getVersionTuple(String projectId, String projectVersion, String serviceId) {
     StringBuilder qualifier = new StringBuilder();
-    if (descriptor != null) {
-      if (!Strings.isNullOrEmpty(descriptor.getProjectId())) {
-        qualifier.append(descriptor.getProjectId());
+    if (!Strings.isNullOrEmpty(projectId)) {
+      qualifier.append(projectId);
+    }
+    if (!Strings.isNullOrEmpty(serviceId)) {
+      if (qualifier.length() > 0) {
+        qualifier.append(':');
       }
-      if (!Strings.isNullOrEmpty(descriptor.getServiceId())) {
-        if (qualifier.length() > 0) {
-          qualifier.append(':');
-        }
-        qualifier.append(descriptor.getServiceId());
+      qualifier.append(serviceId);
+    }
+    if (!Strings.isNullOrEmpty(projectVersion)) {
+      if (qualifier.length() > 0) {
+        qualifier.append(':');
       }
-      if (!Strings.isNullOrEmpty(descriptor.getProjectVersion())) {
-        if (qualifier.length() > 0) {
-          qualifier.append(':');
-        }
-        qualifier.append(descriptor.getProjectVersion());
-      }
+      qualifier.append(projectVersion);
     }
     return qualifier.toString();
   }
 
   @Override
   public Image getImage(Object element) {
-    if (element instanceof IProject && AppEngineContentProvider.isStandard((IProject) element)) {
+    if (element instanceof IProject && AppEngineContentProvider.isAppEngine((IProject) element)) {
       return resources.createImage(AppEngineImages.APPENGINE_IMAGE_DESCRIPTOR);
     } else if (element instanceof DatastoreIndexesDescriptor) {
       return resources.createImage(SharedImages.DATASTORE_GREY_IMAGE_DESCRIPTOR);
-    } else if (element instanceof AppEngineResourceElement) {
+    } else if (element instanceof AppEngineProjectElement
+        || element instanceof AppEngineResourceElement) {
       // todo Get better images for these resource elements
       // CronDescriptor could be a timer/clock?
       // DenialOfServiceDescriptor could be a do-not-enter?

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElement.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElement.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.project.AppYaml;
 import com.google.common.annotations.VisibleForTesting;
@@ -348,7 +349,7 @@ public class AppEngineProjectElement implements IAdaptable {
     // Check that each model element, if present, corresponds to the current configuration file.
     // Rebuild the element representation using the provided element creator, or remove
     // it, as required.
-    IFile configurationFile = WebProjectUtil.findInWebInf(project, new Path(baseName));
+    IFile configurationFile = AppEngineConfigurationUtil.findConfigurationFile(project, baseName);
     if (configurationFile == null || !configurationFile.exists()) {
       // remove the element e.g., file has disappeared
       return null;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElement.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/AppEngineProjectElement.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.eclipse.appengine.facets.ui.navigator.model;
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.project.AppYaml;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -91,17 +90,14 @@ public class AppEngineProjectElement implements IAdaptable {
   private static IFile findAppEngineDescriptor(IProject project) throws AppEngineException {
     // Which of app.yaml or appengine-web.xml should win?
 
-    IFile descriptorFile = WebProjectUtil.findInWebInf(project, new Path("appengine-web.xml"));
+    IFile descriptorFile =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("appengine-web.xml"));
     if (descriptorFile != null && descriptorFile.exists()) {
       return descriptorFile;
     }
 
-    // We don't have a well-defined story for where app.yaml lives, so first look for WEB-INF
-    descriptorFile = WebProjectUtil.findInWebInf(project, new Path("app.yaml"));
-    if (descriptorFile != null && descriptorFile.exists()) {
-      return descriptorFile;
-    }
-    descriptorFile = project.getFile(new Path("src/main/appengine/app.yaml"));
+    descriptorFile =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("app.yaml"));
     if (descriptorFile != null && descriptorFile.exists()) {
       return descriptorFile;
     }
@@ -349,7 +345,8 @@ public class AppEngineProjectElement implements IAdaptable {
     // Check that each model element, if present, corresponds to the current configuration file.
     // Rebuild the element representation using the provided element creator, or remove
     // it, as required.
-    IFile configurationFile = AppEngineConfigurationUtil.findConfigurationFile(project, baseName);
+    IFile configurationFile =
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path(baseName));
     if (configurationFile == null || !configurationFile.exists()) {
       // remove the element e.g., file has disappeared
       return null;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/CronDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/CronDescriptor.java
@@ -29,6 +29,7 @@ public class CronDescriptor extends AppEngineResourceElement {
 
   @Override
   public StyledString getStyledLabel() {
-    return new StyledString("Scheduled Tasks");
+    return new StyledString("Scheduled Tasks")
+        .append(" - " + getFile().getName(), StyledString.DECORATIONS_STYLER);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DatastoreIndexesDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DatastoreIndexesDescriptor.java
@@ -30,7 +30,8 @@ public class DatastoreIndexesDescriptor extends AppEngineResourceElement {
 
   @Override
   public StyledString getStyledLabel() {
-    return new StyledString("Datastore Indexes");
+    return new StyledString("Datastore Indexes")
+        .append(" - " + getFile().getName(), StyledString.DECORATIONS_STYLER);
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DenialOfServiceDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DenialOfServiceDescriptor.java
@@ -29,6 +29,7 @@ public class DenialOfServiceDescriptor extends AppEngineResourceElement {
 
   @Override
   public StyledString getStyledLabel() {
-    return new StyledString("Denial of Service Protection");
+    return new StyledString("Denial of Service Protection")
+        .append(" - " + getFile().getName(), StyledString.DECORATIONS_STYLER);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DispatchRoutingDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/DispatchRoutingDescriptor.java
@@ -29,7 +29,8 @@ public class DispatchRoutingDescriptor extends AppEngineResourceElement {
 
   @Override
   public StyledString getStyledLabel() {
-    return new StyledString("Dispatch Routing Rules");
+    return new StyledString("Dispatch Routing Rules")
+        .append(" - " + getFile().getName(), StyledString.DECORATIONS_STYLER);
   }
 
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/TaskQueuesDescriptor.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/TaskQueuesDescriptor.java
@@ -29,6 +29,7 @@ public class TaskQueuesDescriptor extends AppEngineResourceElement {
 
   @Override
   public StyledString getStyledLabel() {
-    return new StyledString("Task Queue Definitions");
+    return new StyledString("Task Queue Definitions")
+        .append(" - " + getFile().getName(), StyledString.DECORATIONS_STYLER);
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/DatastoreIndexUpdateData.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/DatastoreIndexUpdateData.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.localserver.server;
 
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -61,8 +61,10 @@ public class DatastoreIndexUpdateData {
       return null;
     }
     // datastore-indexes-auto.xml may be generated even if datastore-indexes.xml does not exist
-    IFile datastoreIndexesXml = WebProjectUtil.findInWebInf(defaultService.getProject(),
-        new org.eclipse.core.runtime.Path("datastore-indexes.xml"));
+    IFile datastoreIndexesXml =
+        AppEngineConfigurationUtil.findConfigurationFile(
+            defaultService.getProject(),
+            new org.eclipse.core.runtime.Path("datastore-indexes.xml"));
 
     if (datastoreIndexesXml != null && datastoreIndexesXml.exists()) {
       long sourceTimestamp = datastoreIndexesXml.getLocalTimeStamp();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/ModuleUtils.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.eclipse.appengine.localserver.server;
 import com.google.api.client.util.Preconditions;
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -48,7 +48,8 @@ public class ModuleUtils {
    */
   public static String getServiceId(IModule module) {
     IFile descriptorFile =
-        WebProjectUtil.findInWebInf(module.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            module.getProject(), new Path("appengine-web.xml"));
     if (descriptorFile != null) {
       try (InputStream contents = descriptorFile.getContents()) {
         AppEngineDescriptor descriptor = AppEngineDescriptor.parse(contents);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/DatastoreIndexesUpdatedStatusHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/DatastoreIndexesUpdatedStatusHandler.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.localserver.ui;
 
 import com.google.api.client.util.Preconditions;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.localserver.Messages;
 import com.google.cloud.tools.eclipse.appengine.localserver.server.DatastoreIndexUpdateData;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
@@ -126,9 +126,9 @@ public class DatastoreIndexesUpdatedStatusHandler implements IStatusHandler {
     InputStream contents =
         new ByteArrayInputStream(EMPTY_DATASTORE_INDEXES_XML.getBytes(StandardCharsets.UTF_8));
     IFile datastoreIndexesXml =
-        WebProjectUtil.createFileInWebInf(
+        AppEngineConfigurationUtil.createConfigurationFile(
             project,
-            new Path("datastore-indexes.xml"), //$NON-NLS-1$
+            new Path("datastore-indexes.xml"), // $NON-NLS-1$
             contents,
             false /* overwrite */,
             monitor);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/DatastoreIndexesUpdatedStatusHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/ui/DatastoreIndexesUpdatedStatusHandler.java
@@ -21,13 +21,11 @@ import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUti
 import com.google.cloud.tools.eclipse.appengine.localserver.Messages;
 import com.google.cloud.tools.eclipse.appengine.localserver.server.DatastoreIndexUpdateData;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.compare.BufferedContent;
@@ -123,13 +121,11 @@ public class DatastoreIndexesUpdatedStatusHandler implements IStatusHandler {
   /** Create a new empty {@code datastore-indexes.xml} for the given project. */
   private IFile createNewDatastoreIndexesXml(IProject project, IProgressMonitor monitor)
       throws CoreException {
-    InputStream contents =
-        new ByteArrayInputStream(EMPTY_DATASTORE_INDEXES_XML.getBytes(StandardCharsets.UTF_8));
     IFile datastoreIndexesXml =
         AppEngineConfigurationUtil.createConfigurationFile(
             project,
             new Path("datastore-indexes.xml"), // $NON-NLS-1$
-            contents,
+            EMPTY_DATASTORE_INDEXES_XML,
             false /* overwrite */,
             monitor);
     return datastoreIndexesXml;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetVersionChangeTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.fail;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.io.IOException;
@@ -124,7 +124,8 @@ public class AppEngineStandardFacetVersionChangeTest {
   private static AppEngineDescriptor parseDescriptor(IFacetedProject project)
       throws IOException, CoreException, SAXException {
     IFile descriptorFile =
-        WebProjectUtil.findInWebInf(project.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project.getProject(), new Path("appengine-web.xml"));
     assertNotNull("appengine-web.xml not found", descriptorFile);
     assertTrue("appengine-web.xml does not exist", descriptorFile.exists());
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineWebBuilderTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineWebBuilderTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.util.Collections;
@@ -84,8 +84,9 @@ public class AppEngineWebBuilderTest {
         .getFacetedProject();
     assertProjectHasBuilder();
 
-    IFile appEngineWebDescriptor = WebProjectUtil.findInWebInf(testProject.getProject(),
-        new Path("appengine-web.xml"));
+    IFile appEngineWebDescriptor =
+        AppEngineConfigurationUtil.findConfigurationFile(
+            testProject.getProject(), new Path("appengine-web.xml"));
     assertTrue("should have appengine-web.xml",
         appEngineWebDescriptor != null && appEngineWebDescriptor.exists());
 
@@ -109,7 +110,8 @@ public class AppEngineWebBuilderTest {
     assertProjectHasBuilder();
 
     IFile appEngineWebDescriptor =
-        WebProjectUtil.findInWebInf(testProject.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            testProject.getProject(), new Path("appengine-web.xml"));
     assertTrue("should have appengine-web.xml",
         appEngineWebDescriptor != null && appEngineWebDescriptor.exists());
 
@@ -130,7 +132,8 @@ public class AppEngineWebBuilderTest {
     assertProjectHasBuilder();
 
     IFile appEngineWebDescriptor =
-        WebProjectUtil.findInWebInf(testProject.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            testProject.getProject(), new Path("appengine-web.xml"));
     assertTrue("should have appengine-web.xml",
         appEngineWebDescriptor != null && appEngineWebDescriptor.exists());
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConversionTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConversionTests.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.convert.AppEngineStandardProjectConvertJob;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
@@ -389,7 +389,8 @@ public class ConversionTests {
   private void assertJava8Runtime(IFacetedProject project)
       throws IOException, SAXException, CoreException, AppEngineException {
     IFile appengineWebXml =
-        WebProjectUtil.findInWebInf(project.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project.getProject(), new Path("appengine-web.xml"));
     assertNotNull("appengine-web.xml is missing", appengineWebXml);
     assertTrue("appengine-web.xml does not exist", appengineWebXml.exists());
     try (InputStream contents = appengineWebXml.getContents()) {
@@ -409,7 +410,8 @@ public class ConversionTests {
   private void assertNoJava8Runtime(IFacetedProject project)
       throws IOException, SAXException, CoreException, AppEngineException {
     IFile appengineWebXml =
-        WebProjectUtil.findInWebInf(project.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project.getProject(), new Path("appengine-web.xml"));
     assertNotNull("appengine-web.xml is missing", appengineWebXml);
     assertTrue("appengine-web.xml does not exist", appengineWebXml.exists());
     try (InputStream contents = appengineWebXml.getContents()) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetChangeListener.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardFacetChangeListener.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.standard.java8;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
@@ -156,7 +156,8 @@ public class AppEngineStandardFacetChangeListener implements IFacetedProjectList
    */
   private static IFile findDescriptor(IFacetedProject project) {
     IFile descriptor =
-        WebProjectUtil.findInWebInf(project.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project.getProject(), new Path("appengine-web.xml"));
     return descriptor;
   }
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardJre8ProjectFacetDetector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineStandardJre8ProjectFacetDetector.java
@@ -18,9 +18,9 @@ package com.google.cloud.tools.eclipse.appengine.standard.java8;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.util.status.StatusUtil;
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,7 +60,8 @@ public class AppEngineStandardJre8ProjectFacetDetector extends ProjectFacetDetec
     }
 
     IFile appEngineWebXml =
-        WebProjectUtil.findInWebInf(workingCopy.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            workingCopy.getProject(), new Path("appengine-web.xml"));
     if (appEngineWebXml == null || !appEngineWebXml.exists()) {
       return;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineWebBuilder.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/AppEngineWebBuilder.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.standard.java8;
 
 import com.google.cloud.tools.appengine.AppEngineDescriptor;
 import com.google.cloud.tools.appengine.api.AppEngineException;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.util.MavenUtils;
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,7 +60,8 @@ public class AppEngineWebBuilder extends IncrementalProjectBuilder {
       return null;
     }
     IFile appEngineWebDescriptor =
-        WebProjectUtil.findInWebInf(project.getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project.getProject(), new Path("appengine-web.xml"));
     if (appEngineWebDescriptor == null || !appEngineWebDescriptor.exists()) {
       logger.warning(getProject() + ": no build required: missing appengine-web.xml");
       return null;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConvertToJava8RuntimeHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConvertToJava8RuntimeHandler.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.eclipse.appengine.standard.java8;
 
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.ui.util.ProjectFromSelectionHelper;
 import com.google.common.base.Preconditions;
 import java.util.List;
@@ -46,14 +46,15 @@ public class ConvertToJava8RuntimeHandler extends AbstractHandler {
   public Object execute(ExecutionEvent event) throws ExecutionException {
     List<IProject> projects = ProjectFromSelectionHelper.getProjects(event);
     Preconditions.checkArgument(!projects.isEmpty());
-    Job updateJob = new WorkspaceJob(Messages.getString("reconfiguringToJava8")) { //$NON-NLS-1$
+    Job updateJob = new WorkspaceJob(Messages.getString("reconfiguringToJava8")) { // $NON-NLS-1$
           @Override
           public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
             SubMonitor progress = SubMonitor.convert(monitor, projects.size());
             for (IProject project : projects) {
               progress.subTask(
-                  Messages.getString("reconfiguringProject", project.getName())); //$NON-NLS-1$
-              IFile appEngineWebXml = WebProjectUtil.findInWebInf(project, APPENGINE_DESCRIPTOR);
+                  Messages.getString("reconfiguringProject", project.getName())); // $NON-NLS-1$
+              IFile appEngineWebXml =
+                  AppEngineConfigurationUtil.findConfigurationFile(project, APPENGINE_DESCRIPTOR);
               if (appEngineWebXml != null) {
                 // add the <runtime> and the rest should be handled for us
                 AppEngineDescriptorTransform.addJava8Runtime(appEngineWebXml);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/m2e/AppEngineStandardProjectDetector.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8/src/com/google/cloud/tools/eclipse/appengine/standard/java8/m2e/AppEngineStandardProjectDetector.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.eclipse.appengine.standard.java8.m2e;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -41,7 +41,9 @@ public class AppEngineStandardProjectDetector extends AbstractProjectConfigurato
     if (facetedProject == null || facetedProject.hasProjectFacet(AppEngineStandardFacet.FACET)) {
       return;
     }
-    IFile appEngineWebXml = WebProjectUtil.findInWebInf(project, new Path("appengine-web.xml")); //$NON-NLS-1$
+    IFile appEngineWebXml =
+        AppEngineConfigurationUtil.findConfigurationFile(
+            project, new Path("appengine-web.xml")); // $NON-NLS-1$
     if (appEngineWebXml == null || !appEngineWebXml.exists()) {
       return;
     }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidationTest.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.eclipse.appengine.validation;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.project.ProjectUtils;
 import com.google.cloud.tools.eclipse.test.util.project.TestProjectCreator;
 import java.io.ByteArrayInputStream;
@@ -43,7 +43,7 @@ public class AppEngineWebXmlValidationTest {
   public void testStagingElementsInAppEngineWebXml() throws CoreException {
     IProject project = projectCreator.getProject();
     IFile appEngineWebXml =
-        WebProjectUtil.findInWebInf(project, new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(project, new Path("appengine-web.xml"));
     assertTrue(appEngineWebXml.exists());
 
     String contents = "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n"

--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/TestProjectCreator.java
@@ -18,9 +18,9 @@ package com.google.cloud.tools.eclipse.test.util.project;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineConfigurationUtil;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.FacetUtil;
-import com.google.cloud.tools.eclipse.appengine.facets.WebProjectUtil;
 import com.google.cloud.tools.eclipse.test.util.ThreadDumpingWatchdog;
 import com.google.cloud.tools.eclipse.util.ClasspathUtil;
 import com.google.common.base.Preconditions;
@@ -195,7 +195,8 @@ public final class TestProjectCreator extends ExternalResource {
 
   private void setAppEngineServiceId(String serviceId) throws CoreException {
     IFile appEngineWebXml =
-        WebProjectUtil.findInWebInf(getProject(), new Path("appengine-web.xml"));
+        AppEngineConfigurationUtil.findConfigurationFile(
+            getProject(), new Path("appengine-web.xml"));
     assertTrue("Project should have AppEngine Standard facet", appEngineWebXml.exists());
     String contents = "<appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>\n"
         + "<service>" + serviceId + "</service>\n</appengine-web-app>\n";

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/.classpath
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
+    <classpathentry kind="src" path="tests"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/third_party/com.google.cloud.tools.eclipse.jdt.launching/.classpath
+++ b/third_party/com.google.cloud.tools.eclipse.jdt.launching/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
-    <classpathentry kind="src" path="tests"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Adds support for `app.yaml` and the various App Engine `.yaml` configuration files.  This change moves support for resolving App Engine configuration files into a utility class called `AppEngineConfigurationUtil`; we were previously lumping these files into `WEB-INF`.  The idea is that this class can use the project facets and language types to determine the right place for these configuration files.

But you'll notice that this `AppEngineConfigurationUtil` class doesn't currently do any of the special logic.  I started down the path of adding special logic for App Engine standard vs flexible for determining where these configuration files should be looked up, but giving some of [@ludoch's musings about new configuration files](https://github.com/GoogleCloudPlatform/appengine-plugins-core/issues/671) I thought it was better to support a `src/main/appengine` _if present_, and figure out the rest later.  It checks if there's an `src/main/appengine` and tries to resolve the file there, and otherwise looks in the `WEB-INF`.  This works for our existing projects as AES projects don't have `src/main/appengine` and all files are placed in `WEB-INF`, and AEF projects were using `src/main/appengine` anyways.  This has a few knock-on effects:

  - App Engine `.yaml` configuration files will be found and showed when they are located in `WEB-INF`: this is unlikely.
  - AES projects with `src/main/appengine` will break on run or deployment since our launch and deployment processes do not currently resolving files from there.  This is an unlikely to happen in practice.  And such projects can easily be made to work with by mapping `src/main/appengine` to `WEB-INF` the project's _Deployment Assembly_.

We may want to teach our projects to place these App Engine configuration files to an alternative well-known location via the deployment assembly (e.g., `WEB-INF/appengine`)?  

Fixes #3091 
Fixes #3099