### PR TITLE
Add library group for extra libraries to non-App Engine standard projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -200,7 +199,7 @@ public class CloudLibrariesInPluginXmlTest {
     Library objectifyLibrary = CloudLibraries.getLibrary("objectify6");
     assertThat(objectifyLibrary.getId(), is("objectify6"));
     assertThat(objectifyLibrary.getName(), is("Objectify"));
-    assertThat(objectifyLibrary.getGroups().get(0), is("flexible"));
+    assertThat(objectifyLibrary.getGroups().get(0), is("non-appengine-standard"));
     assertThat(objectifyLibrary.getSiteUri(),
         is(new URI("https://github.com/objectify/objectify/wiki")));
     assertTrue(objectifyLibrary.isExport());

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesTest.java
@@ -77,7 +77,7 @@ public class CloudLibrariesTest {
   @Test
   public void testGetLibraryObjectify6() {
     Library library = CloudLibraries.getLibrary("objectify6");
-    Assert.assertEquals("flexible", library.getGroups().get(0));
+    Assert.assertEquals("non-appengine-standard", library.getGroups().get(0));
     Assert.assertEquals("Objectify", library.getName());
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPageTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPageTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tools.eclipse.appengine.facets.AppEngineFlexWarFacet;
 import com.google.cloud.tools.eclipse.appengine.facets.AppEngineStandardFacet;
 import com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainer;
 import com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibraries;
@@ -115,6 +116,33 @@ public class CloudLibrariesPageTest {
     page.createControl(shellTestResource.getShell());
     assertThat(page.libraryGroups, 
         Matchers.not(Matchers.hasKey(CloudLibraries.APP_ENGINE_STANDARD_GROUP)));
+  }
+
+  @Test
+  public void testNonAppEngineLibraries_foundOnPlainJavaProject() {
+    IJavaProject javaProject = plainJavaProjectCreator.getJavaProject();
+    page.initialize(javaProject, null);
+    page.createControl(shellTestResource.getShell());
+    assertThat(page.libraryGroups, Matchers.hasKey(CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP));
+  }
+
+  @Test
+  public void testNonAppEngineLibraries_foundOnAppEngineFlexProject() {
+    IJavaProject javaProject = plainJavaProjectCreator
+        .withFacets(WebFacetUtils.WEB_31, AppEngineFlexWarFacet.FACET_VERSION).getJavaProject();
+    page.initialize(javaProject, null);
+    page.createControl(shellTestResource.getShell());
+    assertThat(page.libraryGroups, Matchers.hasKey(CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP));
+  }
+
+  @Test
+  public void testNonAppEngineLibraries_missingOnAppEngineStandardProject() {
+    IJavaProject javaProject = plainJavaProjectCreator
+        .withFacets(WebFacetUtils.WEB_25, AppEngineStandardFacet.JRE7).getJavaProject();
+    page.initialize(javaProject, null);
+    page.createControl(shellTestResource.getShell());
+    assertThat(page.libraryGroups,
+        Matchers.not(Matchers.hasKey(CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP)));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/FlexibleLibrariesSelectorGroupTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/FlexibleLibrariesSelectorGroupTest.java
@@ -49,7 +49,7 @@ public class FlexibleLibrariesSelectorGroupTest {
     shell = shellTestResource.getShell();
     shell.setLayout(new FillLayout());
     librariesSelector = new LibrarySelectorGroup(
-        shell, CloudLibraries.APP_ENGINE_FLEXIBLE_GROUP, "xxx"); //$NON-NLS-1$
+        shell, CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP, "xxx"); //$NON-NLS-1$
     shell.open();
     objectifyButton = getButton("objectify6");
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/CloudLibrariesPage.java
@@ -92,7 +92,7 @@ public class CloudLibrariesPage extends WizardPage
 
   @Override
   public void initialize(IJavaProject javaProject, IClasspathEntry[] currentEntries) {
-    this.project = javaProject;
+    project = javaProject;
     isMavenProject = MavenUtils.hasMavenNature(javaProject.getProject());
 
     // As we don't support multiple containers, we pretend to edit the existing container if
@@ -105,6 +105,9 @@ public class CloudLibrariesPage extends WizardPage
     if (AppEngineStandardFacet.getProjectFacetVersion(javaProject.getProject()) != null) {
       groups.put(CloudLibraries.APP_ENGINE_STANDARD_GROUP, 
           Messages.getString("appengine-title")); //$NON-NLS-1$
+    } else {
+      groups.put(CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP,
+          Messages.getString("non-appengine-title")); //$NON-NLS-1$
     }
     groups.put(CloudLibraries.CLIENT_APIS_GROUP, 
         Messages.getString("clientapis-title")); //$NON-NLS-1$

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/messages.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui/src/com/google/cloud/tools/eclipse/appengine/libraries/ui/messages.properties
@@ -2,3 +2,4 @@ apiclientlibrariespage-description=Additional jars for applications using Google
 cloud-platform-libraries-title=Google Cloud Platform Libraries
 appengine-title=App Engine Standard Libraries
 clientapis-title=Cloud Client Libraries for Java
+non-appengine-title=Other Libraries

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -64,7 +64,7 @@
     
     <library
           id="objectify6"
-          group="flexible"
+          group="non-appengine"
           name="Objectify"
           tooltip="%objectify.tooltip"
           dependencies="include"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/plugin.xml
@@ -64,7 +64,7 @@
     
     <library
           id="objectify6"
-          group="non-appengine"
+          group="non-appengine-standard"
           name="Objectify"
           tooltip="%objectify.tooltip"
           dependencies="include"

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
@@ -41,17 +41,17 @@ public class CloudLibraries {
   public static final String MASTER_CONTAINER_ID = "master-container";
 
   /**
-   * Library files for App Engine Standard environment applications; specifically
+   * Library files for App Engine standard environment applications; specifically
    * Objectify, App Engine API, and Google Cloud Endpoints.
    */
   public static final String APP_ENGINE_STANDARD_GROUP = "appengine"; //$NON-NLS-1$
 
   /**
-   * Library files for App Engine Flexible environment applications; specifically
-   * Objectify.
+   * Non-App Engine standard environment applications libraries files that do not fall into the
+   * category of Google Cloud Client Library for Java. Includes Objectify 6.
    */
-  public static final String APP_ENGINE_FLEXIBLE_GROUP = "flexible"; //$NON-NLS-1$  
-  
+  public static final String NON_APP_ENGINE_STANDARD_GROUP = "non-appengine"; //$NON-NLS-1$  
+
   /**
    * Library files for the Google Cloud Client Library for Java. E.g.
    * Stackdriver Logging, Cloud Datastore, Cloud Storage, Cloud Translation, etc.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
@@ -47,10 +47,10 @@ public class CloudLibraries {
   public static final String APP_ENGINE_STANDARD_GROUP = "appengine"; //$NON-NLS-1$
 
   /**
-   * Non-App Engine standard environment applications libraries files that do not fall into the
+   * Non-App Engine standard environment application libraries files that do not fall into the
    * category of Google Cloud Client Library for Java. Includes Objectify 6.
    */
-  public static final String NON_APP_ENGINE_STANDARD_GROUP = "non-appengine"; //$NON-NLS-1$  
+  public static final String NON_APP_ENGINE_STANDARD_GROUP = "non-appengine-standard"; //$NON-NLS-1$
 
   /**
    * Library files for the Google Cloud Client Library for Java. E.g.

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibraries.java
@@ -42,7 +42,7 @@ public class CloudLibraries {
 
   /**
    * Library files for App Engine standard environment applications; specifically
-   * Objectify, App Engine API, and Google Cloud Endpoints.
+   * Objectify 5, App Engine API 1.0 SDK, and Google Cloud Endpoints.
    */
   public static final String APP_ENGINE_STANDARD_GROUP = "appengine"; //$NON-NLS-1$
 

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexWizardPage.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/flex/AppEngineFlexWizardPage.java
@@ -39,7 +39,7 @@ public class AppEngineFlexWizardPage extends AppEngineWizardPage {
   
   @Override
   protected String getSupportedLibrariesGroup() {
-    return CloudLibraries.APP_ENGINE_FLEXIBLE_GROUP;
+    return CloudLibraries.NON_APP_ENGINE_STANDARD_GROUP;
   }
 
   @Override


### PR DESCRIPTION
Objectify 6 can be added to any non-App Engine standard projects, so I'm renaming the group name. (To be fair, I believe Objectify 6 can be used on App Engine standard if >= Java 8, but we are sticking to Objectify 5 for some technical reason.) In that light, it's really hard to give correct names to the field and the UI title. What do you think?

I'll add tests in the meantime.