### PR TITLE
Add WebListener to call ObjectifyService.init() for Objectify 6 when creating flex projects

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplatesTest.java
@@ -145,6 +145,36 @@ public class CodeTemplatesTest {
   }
 
   @Test
+  public void testMaterializeAppEngineStandardFiles_noObjectifyListenerWithObjectify5()
+      throws CoreException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setRuntimeId(AppEngineRuntime.STANDARD_JAVA_8.getId());
+    config.setAppEngineLibraries(Collections.singleton(new Library("objectify")));
+
+    CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
+    assertFalse(objectifyListenerClassExists());
+  }
+
+  @Test
+  public void testMaterializeAppEnginFlexFiles_noObjectifyListener()
+      throws CoreException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+
+    CodeTemplates.materializeAppEngineFlexFiles(project, config, monitor);
+    assertFalse(objectifyListenerClassExists());
+  }
+
+  @Test
+  public void testMaterializeAppEngineFlexFiles_objectifyListenerWithObjectify6()
+      throws CoreException {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(Collections.singleton(new Library("objectify6")));
+
+    CodeTemplates.materializeAppEngineFlexFiles(project, config, monitor);
+    assertTrue(objectifyListenerClassExists());
+  }
+
+  @Test
   public void testMaterializeAppEngineStandardFiles_noPomXml() throws CoreException {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     CodeTemplates.materializeAppEngineStandardFiles(project, config, monitor);
@@ -213,6 +243,32 @@ public class CodeTemplatesTest {
   }
 
   @Test
+  public void testIsObjectify6Selected_notSelected() {
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    assertFalse(CodeTemplates.isObjectify6Selected(config));
+  }
+
+  @Test
+  public void testIsObjectify6Selected_objectify5() {
+    List<Library> libraries = Arrays.asList(new Library("a-library"), new Library("objectify"));
+
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(libraries);
+
+    assertFalse(CodeTemplates.isObjectify6Selected(config));
+  }
+
+  @Test
+  public void testIsObjectify6Selected_objectify6() {
+    List<Library> libraries = Arrays.asList(new Library("objectify6"), new Library("a-library"));
+
+    AppEngineProjectConfig config = new AppEngineProjectConfig();
+    config.setAppEngineLibraries(libraries);
+
+    assertTrue(CodeTemplates.isObjectify6Selected(config));
+  }
+
+  @Test
   public void testIsStandardJava7RuntimeSelected_java7() {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setRuntimeId(null);  // null runtime corresponds to Java 7 runtime
@@ -224,6 +280,10 @@ public class CodeTemplatesTest {
     AppEngineProjectConfig config = new AppEngineProjectConfig();
     config.setRuntimeId("java8");
     assertFalse(CodeTemplates.isStandardJava7RuntimeSelected(config));
+  }
+
+  private boolean objectifyListenerClassExists() {
+    return project.getFile("src/main/java/ObjectifyWebListener.java").exists();
   }
 
   private boolean objectifyFilterClassExists() {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject/src/com/google/cloud/tools/eclipse/appengine/newproject/CodeTemplates.java
@@ -135,6 +135,12 @@ public class CodeTemplates {
       createChildFile("ObjectifyWebFilter.java", //$NON-NLS-1$
           Templates.OBJECTIFY_WEB_FILTER_TEMPLATE,
           mainPackageFolder, properties, subMonitor.split(5));
+
+      if (isObjectify6Selected(config)) {
+        createChildFile("ObjectifyWebListener.java", //$NON-NLS-1$
+            Templates.OBJECTIFY_WEB_LISTENER_TEMPLATE,
+            mainPackageFolder, properties, subMonitor.split(5));
+      }
     }
 
     return hello;
@@ -208,6 +214,13 @@ public class CodeTemplates {
             || "objectify6".equals(library.getId())); //$NON-NLS-1$
     List<Library> selectedLibraries = config.getAppEngineLibraries();
     return selectedLibraries.stream().anyMatch(isObjectify);
+  }
+
+  @VisibleForTesting
+  static boolean isObjectify6Selected(AppEngineProjectConfig config) {
+    Predicate<Library> isObjectify6 = library -> "objectify6".equals(library.getId()); //$NON-NLS-1$
+    List<Library> selectedLibraries = config.getAppEngineLibraries();
+    return selectedLibraries.stream().anyMatch(isObjectify6);
   }
 
   private static void createWebContents(IProject project, IProgressMonitor monitor)

--- a/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineRuntime.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.ui/src/com/google/cloud/tools/eclipse/appengine/ui/AppEngineRuntime.java
@@ -22,8 +22,8 @@ import java.util.EnumSet;
  * Description of the App Engine runtime environments.
  */
 public enum AppEngineRuntime {
-  STANDARD_JAVA_7(Messages.getString("appengine.runtimes.java7"), null), // $NON-NLS-1$
-  STANDARD_JAVA_8(Messages.getString("appengine.runtimes.java8"), "java8"); // $NON-NLS-1$ //$NON-NLS-2$
+  STANDARD_JAVA_7(Messages.getString("appengine.runtimes.java7"), null), //$NON-NLS-1$
+  STANDARD_JAVA_8(Messages.getString("appengine.runtimes.java8"), "java8"); //$NON-NLS-1$ //$NON-NLS-2$
 
   public static final EnumSet<AppEngineRuntime> STANDARD_RUNTIMES =
       EnumSet.of(STANDARD_JAVA_7, STANDARD_JAVA_8);

--- a/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/src/com/google/cloud/tools/eclipse/util/TemplatesTest.java
@@ -208,6 +208,24 @@ public class TemplatesTest {
     compareToFile("objectifyWebFilterWithoutPackage.txt");
   }
 
+  @Test
+  public void testCreateFileContent_objectifyWebListenerWithPackage()
+      throws CoreException, IOException {
+    dataMap.put("package", "com.example");
+    Templates.createFileContent(fileLocation, Templates.OBJECTIFY_WEB_LISTENER_TEMPLATE, dataMap);
+
+    compareToFile("objectifyWebListenerWithPackage.txt");
+  }
+
+  @Test
+  public void testCreateFileContent_objectifyWebListenerWithoutPackage()
+      throws CoreException, IOException {
+    dataMap.put("package", "");
+    Templates.createFileContent(fileLocation, Templates.OBJECTIFY_WEB_LISTENER_TEMPLATE, dataMap);
+
+    compareToFile("objectifyWebListenerWithoutPackage.txt");
+  }
+
   private static InputStream getDataFile(String fileName) throws IOException {
     Bundle bundle = FrameworkUtil.getBundle(TemplatesTest.class);
     URL expectedFileUrl = bundle.getResource("/testData/templates/appengine/" + fileName);

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebListenerWithPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebListenerWithPackage.txt
@@ -1,0 +1,22 @@
+package com.example;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import com.googlecode.objectify.ObjectifyService;
+
+@WebListener
+public class ObjectifyWebListener implements ServletContextListener {
+
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+    ObjectifyService.init();
+    // Here is also a great place to register your POJO entity classes.
+    // ObjectifyService.register(YourEntity.class);
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent event) {
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebListenerWithoutPackage.txt
+++ b/plugins/com.google.cloud.tools.eclipse.util.test/testData/templates/appengine/objectifyWebListenerWithoutPackage.txt
@@ -1,0 +1,20 @@
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import com.googlecode.objectify.ObjectifyService;
+
+@WebListener
+public class ObjectifyWebListener implements ServletContextListener {
+
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+    ObjectifyService.init();
+    // Here is also a great place to register your POJO entity classes.
+    // ObjectifyService.register(YourEntity.class);
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent event) {
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
+++ b/plugins/com.google.cloud.tools.eclipse.util/src/com/google/cloud/tools/eclipse/util/Templates.java
@@ -47,6 +47,7 @@ public class Templates {
   public static final String POM_XML_FLEX_TEMPLATE = "pom.xml.flex.ftl";
   public static final String LOGGING_PROPERTIES_TEMPLATE = "logging.properties.ftl";
   public static final String OBJECTIFY_WEB_FILTER_TEMPLATE = "ObjectifyWebFilter.java.ftl";
+  public static final String OBJECTIFY_WEB_LISTENER_TEMPLATE = "ObjectifyWebListener.java.ftl";
 
   private static Configuration configuration;
 

--- a/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/ObjectifyWebListener.java.ftl
+++ b/plugins/com.google.cloud.tools.eclipse.util/templates/appengine/ObjectifyWebListener.java.ftl
@@ -1,0 +1,22 @@
+<#if package != "">package ${package};
+
+</#if>import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import com.googlecode.objectify.ObjectifyService;
+
+@WebListener
+public class ObjectifyWebListener implements ServletContextListener {
+
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+    ObjectifyService.init();
+    // Here is also a great place to register your POJO entity classes.
+    // ObjectifyService.register(YourEntity.class);
+  }
+
+  @Override
+  public void contextDestroyed(ServletContextEvent event) {
+  }
+}


### PR DESCRIPTION
Fixes #3211.

Objectify 6 requires calling `ObjectifyService.init()`, and a Servlet context listener is recommended for a call site: https://github.com/objectify/objectify/wiki/Setup#initialize-the-objectifyservice-required-for-v6

The listener is added only when adding Objectify 6.