### PR TITLE
Ensure intro/welcome content extensions have IDs and names

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.welcome.test/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.welcome.test/META-INF/MANIFEST.MF
@@ -8,4 +8,5 @@ Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: plugin
 Require-Bundle: com.google.cloud.tools.eclipse.test.dependencies
-Import-Package: com.google.cloud.tools.eclipse.test.util
+Import-Package: com.google.cloud.tools.eclipse.test.util,
+ com.google.common.base;version="[21.0.0,22.0.0)"

--- a/plugins/com.google.cloud.tools.eclipse.welcome.test/src/com/google/cloud/tools/eclipse/welcome/ContentXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.welcome.test/src/com/google/cloud/tools/eclipse/welcome/ContentXmlTest.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.eclipse.welcome;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -27,20 +29,43 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class ContentXmlTest {
 
   @Test
   public void testWellFormed() throws ParserConfigurationException, IOException, SAXException {
+    Document document = parseDocument("intro/cloud-tools-for-eclipse.xml");
+    assertEquals(4, document.getElementsByTagName("extensionContent").getLength());
+  }
+
+  @Test
+  public void testContributionsHaveId() throws ParserConfigurationException, IOException, SAXException {
+    Document document = parseDocument("intro/cloud-tools-for-eclipse.xml");
+    NodeList contributions = document.getElementsByTagName("extensionContent");
+    for(int i = 0 ; i < contributions.getLength(); i++) {
+      Element contribution = (Element)contributions.item(i);
+      assertEquals("extensionContent", contribution.getNodeName());
+      assertFalse(Strings.isNullOrEmpty(contribution.getAttribute("id")));
+      assertFalse(Strings.isNullOrEmpty(contribution.getAttribute("name")));
+      assertFalse(Strings.isNullOrEmpty(contribution.getAttribute("path")));
+      assertFalse(Strings.isNullOrEmpty(contribution.getAttribute("style")));
+    }
+  }
+
+  /** Parse the XML document within the plugin-under-test. */
+  private Document parseDocument(String filePath)
+      throws ParserConfigurationException, IOException, SAXException {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);
     DocumentBuilder builder = factory.newDocumentBuilder();
 
-    try (InputStream contentXml = Files.newInputStream(Paths.get(
-        "../com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml"))) {
+    try (InputStream contentXml =
+        Files.newInputStream(Paths.get("../com.google.cloud.tools.eclipse.welcome/" + filePath))) {
       Document document = builder.parse(contentXml);
-      assertEquals(4, document.getElementsByTagName("extensionContent").getLength());
+      return document;
     }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
+++ b/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <introContent>
-  <extensionContent path="overview/@" style="css/intro.css">
+  <extensionContent id="com.google.cloud.tools.eclipse.overview" name="Cloud Tools for Eclipse Overview"
+      path="overview/@" style="css/intro.css">
     <group style-id="content-group">
       <link id="cloud-tools-for-eclipse-link"
             label="Google Cloud Tools for Eclipse"
@@ -11,7 +12,8 @@
     </group>
   </extensionContent>
 
-  <extensionContent path="tutorials/@" style="css/intro.css">
+  <extensionContent id="com.google.cloud.tools.eclipse.tutorials" name="Cloud Tools for Eclipse Tutorials"
+      path="tutorials/@" style="css/intro.css">
     <group style-id="content-group" label="Google Cloud Tools for Eclipse">
       <link id="cloud-tools-for-eclipse-tutorial-link"
             label="App Engine Standard Environment"
@@ -34,7 +36,8 @@
     </group>
   </extensionContent>
 
-  <extensionContent path="whatsnew/@" style="css/intro.css">
+  <extensionContent id="com.google.cloud.tools.eclipse.whatsnew" name="What's New in Cloud Tools for Eclipse"
+      path="whatsnew/@" style="css/intro.css">
     <group style-id="content-group">
       <link id="cloud-tools-for-eclipse-whatsnew-link"
             label="Google Cloud Tools for Eclipse"
@@ -45,7 +48,8 @@
     </group>
   </extensionContent>
 
-  <extensionContent path="migrate/@" style="css/intro.css">
+  <extensionContent id="com.google.cloud.tools.eclipse.migration" name="Migrating to Cloud Tools for Eclipse"
+      path="migrate/@" style="css/intro.css">
     <group style-id="content-group">
       <link id="cloud-tools-for-eclipse-migration-link"
             label="Migration from the Google Plugin for Eclipse (GPE)"


### PR DESCRIPTION
The Eclipse Intro/Welcome support for highlighting new content requires that those new content extensions have IDs.  This PR adds unique IDs for each of our extensions, with tests.

## Overview
<img width="697" alt="screen shot 2018-07-09 at 2 25 14 pm" src="https://user-images.githubusercontent.com/202851/42469003-7659598a-8384-11e8-9bfc-4b48246c48d5.PNG">

## Tutorials
<img width="667" alt="screen shot 2018-07-09 at 2 25 45 pm" src="https://user-images.githubusercontent.com/202851/42469033-87edeba2-8384-11e8-986c-c4c71271c4d4.PNG">

## What's New
<img width="636" alt="screen shot 2018-07-09 at 2 26 04 pm" src="https://user-images.githubusercontent.com/202851/42469052-97f8b11c-8384-11e8-8feb-33169d54949c.PNG">

## Migrate
<img width="651" alt="screen shot 2018-07-09 at 2 25 57 pm" src="https://user-images.githubusercontent.com/202851/42469073-a943dc4e-8384-11e8-94d4-79ff4be15d06.PNG">
