### PR TITLE
Use HTML comments to hide the helper text in our issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 Before reporting a possible bug:
 
 1. Please ensure you are running the latest version of CT4E with _Help > Check for Updates_.
@@ -6,10 +7,10 @@ Before reporting a possible bug:
 try deploying from the command line using `gcloud` or Maven. 
 If the problem does not go away, then the issue is very likely
 not with Cloud Tools for Eclipse.
-
+-->
 - Cloud Tools for Eclipse version:
-- Google Cloud SDK version: _(run `gcloud version`)_
-- Eclipse version: _(e.g, 4.5.2.v20160212-1500 or Neon.3)_
+- Google Cloud SDK version: <!-- run `gcloud version` -->
+- Eclipse version: <!-- e.g, 4.5.2.v20160212-1500 or Neon.3 -->
 - OS:
 - Java version:
 
@@ -19,4 +20,4 @@ not with Cloud Tools for Eclipse.
 
 **What did you see instead?**
 
-Screenshots and stack traces are helpful.
+<!-- Screenshots and stack traces are helpful. -->

--- a/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
@@ -39,19 +39,15 @@ public class BugReportCommandHandlerTest {
     assertEquals("github.com", url.getHost());
     assertEquals("/GoogleCloudPlatform/google-cloud-eclipse/issues/new", url.getPath());
 
-    // @formatter:off
     // check that values are properly filled in
     Pattern pattern =
         Pattern.compile(
             "body="
-                + "%3C!--%0ABefore\\+reporting\\+a\\+possible\\+bug%3A%0A%0A"
+                + "%3C%21--%0ABefore\\+reporting\\+a\\+possible\\+bug%3A%0A%0A"
                 + "1.\\+Please\\+ensure\\+you\\+are\\+running\\+the\\+latest\\+version\\+of\\+CT4E\\+with\\+_Help\\+%3E\\+Check\\+for\\+Updates_%0A"
                 + "2.\\+If\\+the\\+problem\\+occurs\\+when\\+you\\+deploy\\+or\\+after\\+the\\+application\\+has\\+been\\+deployed%2C\\+try\\+deploying\\+from\\+the\\+command\\+line\\+using\\+gcloud\\+or\\+Maven."
                 + "\\+If\\+the\\+problem\\+does\\+not\\+go\\+away%2C\\+then\\+the\\+issue\\+is\\+likely\\+not\\+with\\+Cloud\\+Tools\\+for\\+Eclipse.%0A--%3E%0A"
                 + "-\\+Cloud\\+Tools\\+for\\+Eclipse\\+version%3A\\+(?<toolVersion>.*)%0A"
-                // Must be a non-managed SDK in the testing environment; otherwise, it means a new
-                // SDK is
-                // being downloaded automatically during tests.
                 + "-\\+Google\\+Cloud\\+SDK\\+version%3A\\+(?<gcloudVersion>[\\d.]*)\\+%28non-managed%29%0A"
                 + "-\\+Eclipse\\+version%3A\\+(?<eclipseVersion>.*)%0A"
                 + "-\\+OS%3A\\+(?<os>.*)%0A"
@@ -59,8 +55,7 @@ public class BugReportCommandHandlerTest {
                 + "\\*\\*What\\+did\\+you\\+do%3F\\*\\*%0A%0A"
                 + "\\*\\*What\\+did\\+you\\+expect\\+to\\+see%3F\\*\\*%0A%0A"
                 + "\\*\\*What\\+did\\+you\\+see\\+instead%3F\\*\\*%0A%0A"
-                + "Screenshots\\+and\\+stacktraces\\+are\\+helpful.");
-    //@formatter:on
+                + "%3C%21--\\+Screenshots\\+and\\+stacktraces\\+are\\+helpful.\\+--%3E");
     String query = url.getQuery();
     Matcher matcher = pattern.matcher(query);
     assertTrue(query, matcher.matches());

--- a/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
@@ -39,25 +39,27 @@ public class BugReportCommandHandlerTest {
     assertEquals("github.com", url.getHost());
     assertEquals("/GoogleCloudPlatform/google-cloud-eclipse/issues/new", url.getPath());
 
-    //@formatter:off
+    // @formatter:off
     // check that values are properly filled in
-    Pattern pattern = Pattern.compile("body="
-        
-        + "Before\\+reporting\\+a\\+possible\\+bug%3A%0A%0A"
-        + "1.\\+Please\\+ensure\\+you\\+are\\+running\\+the\\+latest\\+version\\+of\\+CT4E\\+with\\+_Help\\+%3E\\+Check\\+for\\+Updates_%0A"
-        + "2.\\+If\\+the\\+problem\\+occurs\\+when\\+you\\+deploy\\+or\\+after\\+the\\+application\\+has\\+been\\+deployed%2C\\+try\\+deploying\\+from\\+the\\+command\\+line\\+using\\+gcloud\\+or\\+Maven."
-        + "\\+If\\+the\\+problem\\+does\\+not\\+go\\+away%2C\\+then\\+the\\+issue\\+is\\+likely\\+not\\+with\\+Cloud\\+Tools\\+for\\+Eclipse.%0A%0A"
-        + "-\\+Cloud\\+Tools\\+for\\+Eclipse\\+version%3A\\+(?<toolVersion>.*)%0A"
-        // Must be a non-managed SDK in the testing environment; otherwise, it means a new SDK is
-        // being downloaded automatically during tests.
-        + "-\\+Google\\+Cloud\\+SDK\\+version%3A\\+(?<gcloudVersion>[\\d.]*)\\+%28non-managed%29%0A"
-        + "-\\+Eclipse\\+version%3A\\+(?<eclipseVersion>.*)%0A"
-        + "-\\+OS%3A\\+(?<os>.*)%0A"
-        + "-\\+Java\\+version%3A\\+(?<javaVersion>.*)%0A%0A"
-        + "\\*\\*What\\+did\\+you\\+do%3F\\*\\*%0A%0A" 
-        + "\\*\\*What\\+did\\+you\\+expect\\+to\\+see%3F\\*\\*%0A%0A"
-        + "\\*\\*What\\+did\\+you\\+see\\+instead%3F\\*\\*%0A%0A" 
-        + "Screenshots\\+and\\+stacktraces\\+are\\+helpful.");
+    Pattern pattern =
+        Pattern.compile(
+            "body="
+                + "%3C!--%0ABefore\\+reporting\\+a\\+possible\\+bug%3A%0A%0A"
+                + "1.\\+Please\\+ensure\\+you\\+are\\+running\\+the\\+latest\\+version\\+of\\+CT4E\\+with\\+_Help\\+%3E\\+Check\\+for\\+Updates_%0A"
+                + "2.\\+If\\+the\\+problem\\+occurs\\+when\\+you\\+deploy\\+or\\+after\\+the\\+application\\+has\\+been\\+deployed%2C\\+try\\+deploying\\+from\\+the\\+command\\+line\\+using\\+gcloud\\+or\\+Maven."
+                + "\\+If\\+the\\+problem\\+does\\+not\\+go\\+away%2C\\+then\\+the\\+issue\\+is\\+likely\\+not\\+with\\+Cloud\\+Tools\\+for\\+Eclipse.%0A--%3E%0A"
+                + "-\\+Cloud\\+Tools\\+for\\+Eclipse\\+version%3A\\+(?<toolVersion>.*)%0A"
+                // Must be a non-managed SDK in the testing environment; otherwise, it means a new
+                // SDK is
+                // being downloaded automatically during tests.
+                + "-\\+Google\\+Cloud\\+SDK\\+version%3A\\+(?<gcloudVersion>[\\d.]*)\\+%28non-managed%29%0A"
+                + "-\\+Eclipse\\+version%3A\\+(?<eclipseVersion>.*)%0A"
+                + "-\\+OS%3A\\+(?<os>.*)%0A"
+                + "-\\+Java\\+version%3A\\+(?<javaVersion>.*)%0A%0A"
+                + "\\*\\*What\\+did\\+you\\+do%3F\\*\\*%0A%0A"
+                + "\\*\\*What\\+did\\+you\\+expect\\+to\\+see%3F\\*\\*%0A%0A"
+                + "\\*\\*What\\+did\\+you\\+see\\+instead%3F\\*\\*%0A%0A"
+                + "Screenshots\\+and\\+stacktraces\\+are\\+helpful.");
     //@formatter:on
     String query = url.getQuery();
     Matcher matcher = pattern.matcher(query);

--- a/plugins/com.google.cloud.tools.eclipse.bugreport/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.bugreport/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandler.java
@@ -34,29 +34,28 @@ public class BugReportCommandHandler extends AbstractHandler {
   private static final String BUG_REPORT_URL =
       "https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/new";
 
-  //@formatter:off
   // should be kept up to date with .github/ISSUE_TEMPLATE.md
   private static final String BODY_TEMPLATE =
-      "Before reporting a possible bug:\n\n" 
-      + "1. Please ensure you are running the latest version of CT4E with _Help > Check for Updates_\n"
-      + "2. If the problem occurs when you deploy or after the application has been deployed, "
-      + "try deploying from the command line using gcloud or Maven. "
-      + "If the problem does not go away, then the issue is likely "
-      + "not with Cloud Tools for Eclipse.\n\n"
-      + "- Cloud Tools for Eclipse version: {0}\n"
-      + "- Google Cloud SDK version: {1} {2}\n"
-      + "- Eclipse version: {3}\n"
-      + "- OS: {4} {5}\n"
-      + "- Java version: {6}\n"
-      + "\n"
-      + "**What did you do?**\n"
-      + "\n"
-      + "**What did you expect to see?**\n"
-      + "\n"
-      + "**What did you see instead?**\n"
-      + "\n"
-      + "Screenshots and stacktraces are helpful.";
-  //@formatter:on
+      "<!--"
+          + "Before reporting a possible bug:\n\n"
+          + "1. Please ensure you are running the latest version of CT4E with _Help > Check for Updates_\n"
+          + "2. If the problem occurs when you deploy or after the application has been deployed, "
+          + "try deploying from the command line using gcloud or Maven. "
+          + "If the problem does not go away, then the issue is likely "
+          + "not with Cloud Tools for Eclipse.\n-->\n"
+          + "- Cloud Tools for Eclipse version: {0}\n"
+          + "- Google Cloud SDK version: {1} {2}\n"
+          + "- Eclipse version: {3}\n"
+          + "- OS: {4} {5}\n"
+          + "- Java version: {6}\n"
+          + "\n"
+          + "**What did you do?**\n"
+          + "\n"
+          + "**What did you expect to see?**\n"
+          + "\n"
+          + "**What did you see instead?**\n"
+          + "\n"
+          + "<!-- Screenshots and stacktraces are helpful. -->";
 
   @Override
   public Object execute(ExecutionEvent event) throws ExecutionException {

--- a/plugins/com.google.cloud.tools.eclipse.bugreport/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandler.java
+++ b/plugins/com.google.cloud.tools.eclipse.bugreport/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandler.java
@@ -36,7 +36,7 @@ public class BugReportCommandHandler extends AbstractHandler {
 
   // should be kept up to date with .github/ISSUE_TEMPLATE.md
   private static final String BODY_TEMPLATE =
-      "<!--"
+      "<!--\n"
           + "Before reporting a possible bug:\n\n"
           + "1. Please ensure you are running the latest version of CT4E with _Help > Check for Updates_\n"
           + "2. If the problem occurs when you deploy or after the application has been deployed, "


### PR DESCRIPTION
Produces easier-to-read issue submissions.