### PR TITLE
Remove incorrect warning

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -500,10 +500,6 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     launch.addDebugTarget(target);
     target.engage();
 
-    // todo: programArguments is currently ignored
-    if (!Strings.isNullOrEmpty(getProgramArguments(configuration))) {
-      logger.warning("App Engine Local Server currently ignores program arguments"); //$NON-NLS-1$
-    }
     try {
       DefaultRunConfiguration devServerRunConfiguration =
           generateServerRunConfiguration(configuration, server, mode);


### PR DESCRIPTION
The devappserver launch would issue a warning that the launch's _Program Arguments_ are ignored, but [they are now passed](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/blob/master/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java#L323) with #2184.