### PR TITLE
Remove WTP DependencyGraph workarounds

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -35,7 +35,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.common.project.facet.core.JavaFacetInstallConfig;
 import org.eclipse.jst.j2ee.project.facet.IJ2EEFacetInstallDataModelProperties;
@@ -216,13 +215,7 @@ public class FacetUtil {
    * @throws CoreException if anything goes wrong while applying facet actions
    */
   public void install(IProgressMonitor monitor) throws CoreException {
-    SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
-
-    // Workaround deadlock bug described in Eclipse bug (https://bugs.eclipse.org/511793).
-    // There are graph update jobs triggered by the completion of the CreateProjectOperation
-    // above (from resource notifications) and from other resource changes from modifying the
-    // project facets. So we force the dependency graph to defer updates
-    facetedProject.modify(facetInstallSet, subMonitor.newChild(90));
+    facetedProject.modify(facetInstallSet, monitor);
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/FacetUtil.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
@@ -35,10 +34,8 @@ import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jst.common.project.facet.core.JavaFacet;
 import org.eclipse.jst.common.project.facet.core.JavaFacetInstallConfig;
 import org.eclipse.jst.j2ee.project.facet.IJ2EEFacetInstallDataModelProperties;
@@ -46,8 +43,6 @@ import org.eclipse.jst.j2ee.project.facet.IJ2EEModuleFacetInstallDataModelProper
 import org.eclipse.jst.j2ee.web.project.facet.IWebFacetInstallDataModelProperties;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetInstallDataModelProvider;
 import org.eclipse.jst.j2ee.web.project.facet.WebFacetUtils;
-import org.eclipse.wst.common.componentcore.internal.builder.DependencyGraphImpl;
-import org.eclipse.wst.common.componentcore.internal.builder.IDependencyGraph;
 import org.eclipse.wst.common.frameworks.datamodel.DataModelFactory;
 import org.eclipse.wst.common.frameworks.datamodel.IDataModel;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
@@ -59,7 +54,6 @@ import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 /**
  * Utility class for processing facets.
  */
-@SuppressWarnings("restriction") // For IDependencyGraph
 public class FacetUtil {
   private static final Logger logger = Logger.getLogger(FacetUtil.class.getName());
 
@@ -228,19 +222,7 @@ public class FacetUtil {
     // There are graph update jobs triggered by the completion of the CreateProjectOperation
     // above (from resource notifications) and from other resource changes from modifying the
     // project facets. So we force the dependency graph to defer updates
-    try {
-      IDependencyGraph.INSTANCE.preUpdate();
-      try {
-        Job.getJobManager().join(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY,
-            subMonitor.newChild(10));
-      } catch (OperationCanceledException | InterruptedException ex) {
-        logger.log(Level.WARNING, "Exception waiting for WTP Graph Update job", ex);
-      }
-
-      facetedProject.modify(facetInstallSet, subMonitor.newChild(90));
-    } finally {
-      IDependencyGraph.INSTANCE.postUpdate();
-    }
+    facetedProject.modify(facetInstallSet, subMonitor.newChild(90));
   }
 
   /**

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets/src/com/google/cloud/tools/eclipse/appengine/facets/StandardFacetInstallDelegate.java
@@ -33,13 +33,10 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jst.j2ee.refactor.listeners.J2EEElementChangedListener;
 import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IFacetedProject;
-import org.eclipse.wst.common.project.facet.core.IProjectFacet;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.eclipse.wst.common.project.facet.core.ProjectFacetsManager;
 
 public class StandardFacetInstallDelegate implements IDelegate {
-  private static final String JSDT_FACET_ID = "wst.jsdt.web";
-  private static final int MAX_JSDT_CHECK_RETRIES = 100;
 
   @Override
   public void execute(IProject project,
@@ -78,20 +75,6 @@ public class StandardFacetInstallDelegate implements IDelegate {
     @Override
     public boolean belongsTo(Object family) {
       return J2EEElementChangedListener.PROJECT_COMPONENT_UPDATE_JOB_FAMILY.equals(family);
-    }
-
-    private void waitUntilJsdtIsFixedFacet(IProgressMonitor monitor) throws InterruptedException {
-      try {
-        IProjectFacet jsdtFacet = ProjectFacetsManager.getProjectFacet(JSDT_FACET_ID);
-        for (int times = 0; !monitor.isCanceled() && times < MAX_JSDT_CHECK_RETRIES; times++) {
-          if (facetedProject.isFixedProjectFacet(jsdtFacet)) {
-            return;
-          }
-          Thread.sleep(100 /* ms */);
-        }
-      } catch (IllegalArgumentException ex) {
-        // JSDT facet itself doesn't exist. (Should not really happen.) Ignore and fall through.
-      }
     }
 
     @Override


### PR DESCRIPTION
Closes #3201: With #3233 we can remove the workarounds for [the WTP DependencyGraph bug](https://bugs.eclipse.org/511793), which was fixed for Oxygen.

This patch also removes some [unused methods and fields in `StandardFacetInstallDelegate`](
https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/3234#discussion_r212501279) leftover from removing `ConvertJobSuspender` (#3200).