### PR TITLE
Update .m2 cache TAR name

### DIFF
--- a/kokoro/ubuntu/jar_signing.sh
+++ b/kokoro/ubuntu/jar_signing.sh
@@ -4,9 +4,9 @@
 #
 
 # Fail on any error.
-set -e
+set -o errexit
 # Display commands being run.
-set -x
+set -o xtrace
 
 echo "KOKORO_GFILE_DIR: ${KOKORO_GFILE_DIR}"
 ls -l "${KOKORO_GFILE_DIR}"

--- a/kokoro/ubuntu/new_release.sh
+++ b/kokoro/ubuntu/new_release.sh
@@ -4,11 +4,11 @@
 #
 
 # Fail on any error.
-set -e
+set -o errexit
 # Display commands being run.
-set -x
+set -o xtrace
 
-gsutil -q cp "gs://ct4e-m2-repositories-for-kokoro/m2-oxygen.tar" - \
+gsutil -q cp "gs://ct4e-m2-repositories-for-kokoro/m2-cache.tar" - \
   | tar -C "${HOME}" -xf -
 
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true


### PR DESCRIPTION
Using the new cache (built a while ago by [these instructions](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/wiki/Building-and-Running-Tests-in-Docker)) for release too.