### PR TITLE
Fix for Java 11.0.1

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.bugreport.test/src/com/google/cloud/tools/eclipse/bugreport/ui/BugReportCommandHandlerTest.java
@@ -67,7 +67,7 @@ public class BugReportCommandHandlerTest {
     String javaVersion = matcher.group("javaVersion");
 
     assertTrue(Pattern.compile("^\\d+\\.\\d+\\.\\d+").matcher(toolVersion).find());
-    assertThat(javaVersion, anyOf(startsWith("1.7."), startsWith("1.8."), is("11")));
+    assertThat(javaVersion, anyOf(startsWith("1.7."), startsWith("1.8."), is("11"), startsWith("11.")));
     assertThat(os, anyOf(startsWith("Linux"), startsWith("Mac"), startsWith("Windows")));
     assertTrue(Pattern.compile("^\\d+\\.\\d+").matcher(eclipseVersion).find());
     new CloudSdkVersion(gcloudVersion); // throws IllegalArgumentException if invalid


### PR DESCRIPTION
Fix build failures due to release of [JDK 11.0.1](http://jdk.java.net/11/).