### PR TITLE
Fix Kokoro build by removing gcloud workaround

### DIFF
--- a/kokoro/ubuntu/new_release.sh
+++ b/kokoro/ubuntu/new_release.sh
@@ -12,10 +12,6 @@ gsutil -q cp "gs://ct4e-m2-repositories-for-kokoro/m2-cache.tar" - \
   | tar -C "${HOME}" -xf -
 
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
-# Workaround for https://issuetracker.google.com/119096137, until gcloud in
-# the Kokoro base image gets updated to make the issue obsolete.
-gcloud components remove container-builder-local
-
 gcloud components update --quiet
 gcloud components install app-engine-java --quiet
 


### PR DESCRIPTION
```
+ gcloud components remove container-builder-local
ERROR: (gcloud.components.remove) The following components are not currently installed [container-builder-local]


[ID: 9163144] Build finished after 9 secs, exit value: 1
```