### PR TITLE
Update appengine-web.xsd from Cloud SDK 228.0.0

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidationTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidationTest.java
@@ -40,7 +40,7 @@ public class AppEngineWebXmlValidationTest {
       JavaFacet.VERSION_1_7, WebFacetUtils.WEB_25, AppEngineStandardFacet.JRE7);
 
   @Test
-  public void testStagingElementsInAppEngineWebXml() throws CoreException {
+  public void testValidElementsInAppEngineWebXml() throws CoreException {
     IProject project = projectCreator.getProject();
     IFile appEngineWebXml =
         AppEngineConfigurationUtil.findConfigurationFile(project, new Path("appengine-web.xml"));
@@ -50,6 +50,9 @@ public class AppEngineWebXmlValidationTest {
         + "  <staging>\n"
         + "    <enable-jar-classes>true</enable-jar-classes>\n"
         + "  </staging>\n"
+        + "  <automatic-scaling>\n"
+        + "    <min-instances>0</min-instances>\n"
+        + "  </automatic-scaling>\n"
         + "</appengine-web-app>";
     InputStream in = new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
     appEngineWebXml.setContents(in, true, false, null);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidatorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation.test/src/com/google/cloud/tools/eclipse/appengine/validation/AppEngineWebXmlValidatorTest.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Node;
 public class AppEngineWebXmlValidatorTest {
   
   private Document document;
-  private AppEngineWebXmlValidator validator = new AppEngineWebXmlValidator();
+  private final AppEngineWebXmlValidator validator = new AppEngineWebXmlValidator();
 
   @Before
   public void setUp() throws ParserConfigurationException {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.validation/xsd/appengine-web.xsd
@@ -48,6 +48,11 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
+  <xs:complexType name="vpc-access-connector-type">
+    <xs:all>
+      <xs:element type="xs:string" name="name" maxOccurs="1" minOccurs="0"/>
+    </xs:all>
+  </xs:complexType>
   <xs:complexType name="appengine-web-appType">
     <xs:all>
       <xs:element type="xs:string" name="application" minOccurs="0"/>
@@ -86,11 +91,14 @@
       <xs:element type="xs:boolean" name="code-lock" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="xs:boolean" name="vm" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="xs:string" name="env" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:string" name="entrypoint" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="xs:string" name="runtime-channel" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="ns:classLoaderConfigType" name="class-loader-config" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="ns:urlStreamHandlerType" name="url-stream-handler" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="xs:boolean" name="use-google-connector-j" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="ns:api-configType" name="api-config" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
       <xs:element type="ns:staging-type" name="staging" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
+      <xs:element type="ns:vpc-access-connector-type" name="vpc-access-connector" minOccurs="0" xmlns:ns="http://appengine.google.com/ns/1.0"/>
     </xs:all>
   </xs:complexType>
   <xs:complexType name="api-configType">
@@ -136,7 +144,7 @@
       <xs:element type="xs:string" name="max-pending-latency" minOccurs="0"/>
       <xs:element type="xs:string" name="min-idle-instances" minOccurs="0"/>
       <xs:element type="xs:string" name="max-idle-instances" minOccurs="0"/>
-      <xs:element type="xs:positiveInteger" name="min-instances" minOccurs="0"/>
+      <xs:element type="xs:nonNegativeInteger" name="min-instances" minOccurs="0"/>
       <xs:element type="xs:positiveInteger" name="max-instances" minOccurs="0"/>
       <xs:element type="xs:double" name="target-cpu-utilization" minOccurs="0"/>
       <xs:element type="xs:double" name="target-throughput-utilization" minOccurs="0"/>


### PR DESCRIPTION
Fixes #3351.

XSD from Cloud SDK 228.0.0. `min-instances` will now allow 0.