### PR TITLE
Drop Eclipse JPT from target platforms to speed launches

### DIFF
--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GCP for Eclipse 2018-09" sequenceNumber="1544818598">
+<target name="GCP for Eclipse 2018-09" sequenceNumber="1547139029">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.9.0.v20180906-1121"/>
@@ -11,7 +11,6 @@
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.2.v20180904-2231"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201807122215"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20180504-0806"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20180504-0806"/>
       <unit id="org.eclipse.jetty.http" version="9.4.11.v20180605"/>

--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
@@ -22,7 +22,7 @@ location "http://download.eclipse.org/releases/2018-09/201809191002/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    org.eclipse.jpt.jpa.feature.feature.group
+    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
@@ -22,7 +22,6 @@ location "http://download.eclipse.org/releases/2018-09/201809191002/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="GCP for Eclipse 2018-12" sequenceNumber="1545243461">
+<target name="GCP for Eclipse 2018-12" sequenceNumber="1547139021">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.10.0.v20181206-1038"/>
@@ -11,7 +11,6 @@
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.1.20181128-2152"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.4.1.20181128-2152"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.2.v20180904-2231"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201807122215"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20180504-0806"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20180504-0806"/>
       <unit id="org.eclipse.jetty.http" version="9.4.14.v20181113"/>

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.tpd
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.tpd
@@ -22,7 +22,6 @@ location "http://download.eclipse.org/releases/2018-12/201812191000" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.tpd
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.tpd
@@ -22,7 +22,7 @@ location "http://download.eclipse.org/releases/2018-12/201812191000" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    org.eclipse.jpt.jpa.feature.feature.group
+    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -7,7 +7,7 @@
    <feature id="org.eclipse.m2e.wtp.feature" version="0.0.0"/>
    <feature id="org.eclipse.m2e.wtp.sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.mylyn.commons" version="0.0.0"/>
-   <feature id="org.eclipse.jpt.jpa.feature" version="0.0.0"/>
+   <!-- <feature id="org.eclipse.jpt.jpa.feature" version="0.0.0"/> -->
    <feature id="org.eclipse.swtbot.eclipse" version="0.0.0"/>
    <feature id="org.eclipse.jst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.jst.server_sdk.feature" version="0.0.0"/>

--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -7,7 +7,6 @@
    <feature id="org.eclipse.m2e.wtp.feature" version="0.0.0"/>
    <feature id="org.eclipse.m2e.wtp.sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.mylyn.commons" version="0.0.0"/>
-   <!-- <feature id="org.eclipse.jpt.jpa.feature" version="0.0.0"/> -->
    <feature id="org.eclipse.swtbot.eclipse" version="0.0.0"/>
    <feature id="org.eclipse.jst.web_sdk.feature" version="0.0.0"/>
    <feature id="org.eclipse.jst.server_sdk.feature" version="0.0.0"/>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.target
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Oxygen" sequenceNumber="1538156055">
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="GCP for Eclipse Oxygen" sequenceNumber="1547139016">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.7.3.v20180330-0919"/>
@@ -11,7 +11,6 @@
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.3.20170823-1905"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.3.3.20170823-1905"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.23.0.v20170503-0014"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201803161350"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.jetty.http" version="9.4.8.v20171121"/>

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -21,7 +21,6 @@ location "http://download.eclipse.org/releases/oxygen/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/oxygen/gcp-eclipse-oxygen.tpd
+++ b/eclipse/oxygen/gcp-eclipse-oxygen.tpd
@@ -21,7 +21,7 @@ location "http://download.eclipse.org/releases/oxygen/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    org.eclipse.jpt.jpa.feature.feature.group
+    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/photon/gcp-eclipse-photon.target
+++ b/eclipse/photon/gcp-eclipse-photon.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="GCP for Eclipse Photon" sequenceNumber="1538154714">
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="GCP for Eclipse Photon" sequenceNumber="1547139001">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180611-0826"/>
@@ -11,7 +11,6 @@
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.m2e.wtp.sdk.feature.feature.group" version="1.4.0.20180606-2005"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.0.v20180613-1658"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201803161350"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.epp.logging.aeri.feature.source.feature.group" version="2.0.7.v20170906-1327"/>
       <unit id="org.eclipse.jetty.http" version="9.4.10.v20180503"/>

--- a/eclipse/photon/gcp-eclipse-photon.tpd
+++ b/eclipse/photon/gcp-eclipse-photon.tpd
@@ -22,7 +22,7 @@ location "http://download.eclipse.org/releases/photon/201806271001/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    org.eclipse.jpt.jpa.feature.feature.group
+    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group

--- a/eclipse/photon/gcp-eclipse-photon.tpd
+++ b/eclipse/photon/gcp-eclipse-photon.tpd
@@ -22,7 +22,6 @@ location "http://download.eclipse.org/releases/photon/201806271001/" {
     org.eclipse.m2e.wtp.feature.feature.group
     org.eclipse.m2e.wtp.sdk.feature.feature.group
     org.eclipse.mylyn.commons.feature.group
-    //org.eclipse.jpt.jpa.feature.feature.group
 
     org.eclipse.epp.logging.aeri.feature.feature.group
     org.eclipse.epp.logging.aeri.feature.source.feature.group


### PR DESCRIPTION
We've been experiencing some real slow-downs when launching Eclipse with our target platforms.  From applying the techniques in [Eclipse bug 516664]( https://bugs.eclipse.org/bugs/show_bug.cgi?id=516664#c10), I discovered that the culprit is that we have Lucene 7.1 and 7.5 bundles in our target platforms, and as a result the Equinox resolver spends lots of time resolving the right package chains.

The Lucene bundles are pulled in from two different paths:

  - the `org.eclipse.help` feature,  required by the `org.eclipse.sdk` feature, pulls in `org.apache.lucene.*` bundles with version 7.1.0
  - the `org.eclipse.datatools.sqltools.result` bundle, part of JPT, requires the `org.apache.lucene.queryparser` bundle, which was only created for 7.5.0

Since we're not actually providing any JPT/JPA support, this patch drops the JPT feature from our target platforms.  As a result, only the Lucene from org.eclipse.help is pulled in.