### PR TITLE
Wait on WTP's DependencyGraph update jobs to avoid AIOOBE on project tear-down

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.util/src/com/google/cloud/tools/eclipse/test/util/project/ProjectUtils.java
@@ -60,6 +60,7 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.wst.common.componentcore.internal.builder.DependencyGraphImpl;
 import org.eclipse.wst.validation.internal.operations.ValidationBuilder;
 import org.eclipse.wst.validation.internal.operations.ValidatorManager;
 import org.osgi.framework.Bundle;
@@ -367,6 +368,7 @@ public class ProjectUtils {
     Collections.addAll(jobs, jobManager.find("org.eclipse.wst.server.core.family"));
     Collections.addAll(jobs, jobManager.find("org.eclipse.wst.server.ui.family"));
     Collections.addAll(jobs, jobManager.find(ValidationBuilder.FAMILY_VALIDATION_JOB));
+    Collections.addAll(jobs, jobManager.find(DependencyGraphImpl.GRAPH_UPDATE_JOB_FAMILY));
     for (IProject project : projects) {
       Collections.addAll(jobs,
           jobManager.find(project.getName() + ValidatorManager.VALIDATOR_JOB_FAMILY));


### PR DESCRIPTION
The stacktraces for the odd `ArrayIndexOutOfBoundsException`s (#3277), which occur on project close and delete, seem to stem from the WTP `DependencyGraph` jobs that were causing us problems previously.  This PR causes our `ProjectUtils#waitForProjects()` to wait for these jobs too.  I've run the tests a couple of times and haven't seen a flake.