### PR TITLE
Perform GCP library resolving in background job

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat/src/com/google/cloud/tools/eclipse/appengine/compat/cte13/CloudToolsEclipseProjectUpdater.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat/src/com/google/cloud/tools/eclipse/appengine/compat/cte13/CloudToolsEclipseProjectUpdater.java
@@ -35,6 +35,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -72,9 +74,12 @@ public class CloudToolsEclipseProjectUpdater {
    * Upgrade this specific project.
    */
   public static IStatus updateProject(IProject project, SubMonitor progress) {
-    progress.beginTask(Messages.getString("updating.project", project.getName()), 50); //$NON-NLS-1$
+    progress.beginTask(
+        Messages.getString("updating.project", project.getName()), 51); // $NON-NLS-1$
     IJavaProject javaProject = JavaCore.create(project);
 
+    ISchedulingRule rule = BuildPath.resolvingRule(javaProject);
+    Job.getJobManager().beginRule(rule, progress.newChild(1));
     try {
       // Identify the different libraries that should be added and classpath entries to be preserved
       List<IClasspathEntry> remainingEntries = new ArrayList<>();
@@ -127,6 +132,8 @@ public class CloudToolsEclipseProjectUpdater {
     } catch (CoreException ex) {
       return StatusUtil.error(CloudToolsEclipseProjectUpdater.class,
           Messages.getString("unable.to.update.project", project.getName()), ex); //$NON-NLS-1$
+    } finally {
+      Job.getJobManager().endRule(rule);
     }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -115,8 +115,8 @@ public class LibraryClasspathContainerInitializerTest {
   }
 
   @Test
-  public void testInitialize_ifSerializerReturnsNullResolverServiceIsCalled() throws IOException,
-                                                                                     CoreException {
+  public void testInitialize_ifSerializerReturnsNullContainerResolvedFromScratch()
+      throws IOException, CoreException {
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(null);
 
     boolean[] called = new boolean[] {false};
@@ -134,7 +134,7 @@ public class LibraryClasspathContainerInitializerTest {
     containerInitializer.initialize(new Path(TEST_CONTAINER_PATH + "/second.segment"),
                                     testProject.getJavaProject());
     assertTrue(called[0]);
-    verifyContainerWasNotResolvedFromScratch();
+    verifyResolveServiceResolveContainerNotCalled();
   }
 
   @Test(expected = CoreException.class)
@@ -171,7 +171,7 @@ public class LibraryClasspathContainerInitializerTest {
     assertFalse(called[0]);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
     assertTrue(called[0]);
-    verifyContainerWasNotResolvedFromScratch();
+    verifyResolveServiceResolveContainerNotCalled();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class LibraryClasspathContainerInitializerTest {
     assertFalse(called[0]);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
     assertTrue(called[0]);
-    verifyContainerWasNotResolvedFromScratch();
+    verifyResolveServiceResolveContainerNotCalled();
   }
 
   @Test
@@ -228,7 +228,7 @@ public class LibraryClasspathContainerInitializerTest {
     
     for (IClasspathEntry resolvedEntry : resolvedClasspath) {
       if (resolvedEntry.getPath().toOSString().equals(artifactFile.getAbsolutePath())) {
-        verifyContainerWasNotResolvedFromScratch();
+        verifyResolveServiceResolveContainerNotCalled();
         return;
       }
     }
@@ -259,7 +259,7 @@ public class LibraryClasspathContainerInitializerTest {
       if (resolvedEntry.getPath().toOSString().equals(artifactFile.getAbsolutePath())) {
         assertThat(resolvedEntry.getSourceAttachmentPath().toOSString(),
             is(sourceArtifactFile.getAbsolutePath()));
-        verifyContainerWasNotResolvedFromScratch();
+        verifyResolveServiceResolveContainerNotCalled();
         return;
       }
     }
@@ -278,12 +278,7 @@ public class LibraryClasspathContainerInitializerTest {
         containerInitializer.getComparisonID(new Path(TEST_CONTAINER_PATH + "/2"), null));
   }
 
-  private IStatus verifyContainerResolvedFromScratch() {
-    return verify(resolverService).resolveContainer(any(IJavaProject.class), any(IPath.class),
-                                                    any(IProgressMonitor.class));
-  }
-
-  private IStatus verifyContainerWasNotResolvedFromScratch() {
+  private IStatus verifyResolveServiceResolveContainerNotCalled() {
     return verify(resolverService, never()).resolveContainer(any(IJavaProject.class),
         any(IPath.class), any(IProgressMonitor.class));
   }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -40,6 +41,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -116,11 +118,23 @@ public class LibraryClasspathContainerInitializerTest {
   public void testInitialize_ifSerializerReturnsNullResolverServiceIsCalled() throws IOException,
                                                                                      CoreException {
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(null);
+
+    boolean[] called = new boolean[] {false};
     LibraryClasspathContainerInitializer containerInitializer =
-        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
+        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService) {
+
+          @Override
+          public void requestClasspathContainerUpdate(
+              IPath containerPath, IJavaProject project, IClasspathContainer containerSuggestion)
+              throws CoreException {
+            called[0] = true;
+          }
+        };
+    assertFalse(called[0]);
     containerInitializer.initialize(new Path(TEST_CONTAINER_PATH + "/second.segment"),
                                     testProject.getJavaProject());
-    verifyContainerResolvedFromScratch();
+    assertTrue(called[0]);
+    verifyContainerWasNotResolvedFromScratch();
   }
 
   @Test(expected = CoreException.class)
@@ -144,11 +158,20 @@ public class LibraryClasspathContainerInitializerTest {
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
 
+    boolean[] called = new boolean[] {false};
     LibraryClasspathContainerInitializer containerInitializer =
-        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
+        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService) {
+          @Override
+          public void requestClasspathContainerUpdate(
+              IPath containerPath, IJavaProject project, IClasspathContainer containerSuggestion)
+              throws CoreException {
+            called[0] = true;
+          }
+        };
+    assertFalse(called[0]);
     containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
-
-    verifyContainerResolvedFromScratch();
+    assertTrue(called[0]);
+    verifyContainerWasNotResolvedFromScratch();
   }
 
   @Test
@@ -165,11 +188,21 @@ public class LibraryClasspathContainerInitializerTest {
     when(container.getClasspathEntries()).thenReturn(entries);
     when(serializer.loadContainer(any(IJavaProject.class), any(IPath.class))).thenReturn(container);
 
+    boolean[] called = new boolean[] {false};
     LibraryClasspathContainerInitializer containerInitializer =
-        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService);
-    containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
+        new LibraryClasspathContainerInitializer(TEST_CONTAINER_PATH, serializer, resolverService) {
 
-    verifyContainerResolvedFromScratch();
+          @Override
+          public void requestClasspathContainerUpdate(
+              IPath containerPath, IJavaProject project, IClasspathContainer containerSuggestion)
+              throws CoreException {
+            called[0] = true;
+          }
+        };
+    assertFalse(called[0]);
+    containerInitializer.initialize(new Path(TEST_LIBRARY_PATH), testProject.getJavaProject());
+    assertTrue(called[0]);
+    verifyContainerWasNotResolvedFromScratch();
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJobTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.appengine.libraries;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.jdt.core.IJavaProject;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LibraryClasspathContainerResolverJobTest {
+
+  @Test
+  public void testBelongsTo() {
+    ISchedulingRule rule = Mockito.mock(ISchedulingRule.class);
+    ILibraryClasspathContainerResolverService service =
+        Mockito.mock(ILibraryClasspathContainerResolverService.class);
+    IJavaProject javaProject = Mockito.mock(IJavaProject.class);
+    LibraryClasspathContainerResolverJob fixture =
+        new LibraryClasspathContainerResolverJob(rule, service, javaProject);
+
+    assertTrue(fixture.belongsTo(ResourcesPlugin.FAMILY_MANUAL_BUILD));
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJobTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJobTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.tools.eclipse.util.jobs.MutexRule;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.jdt.core.IJavaProject;
@@ -28,7 +29,7 @@ public class LibraryClasspathContainerResolverJobTest {
 
   @Test
   public void testBelongsTo() {
-    ISchedulingRule rule = Mockito.mock(ISchedulingRule.class);
+    ISchedulingRule rule = new MutexRule("LibraryClasspathContainerResolverJobTest");
     ILibraryClasspathContainerResolverService service =
         Mockito.mock(ILibraryClasspathContainerResolverService.class);
     IJavaProject javaProject = Mockito.mock(IJavaProject.class);

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
@@ -79,9 +79,9 @@ public class LibraryClasspathContainerInitializer extends ClasspathContainerInit
             new IJavaProject[] {project},
             new IClasspathContainer[] {container},
             new NullProgressMonitor());
-      } else {
-        resolverService.resolveContainer(project, containerPath, new NullProgressMonitor());
+        return;
       }
+      requestClasspathContainerUpdate(containerPath, project, null);
     } catch (IOException ex) {
       throw new CoreException(
           StatusUtil.error(this, "Failed to load persisted container descriptor", ex));

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerInitializer.java
@@ -126,11 +126,7 @@ public class LibraryClasspathContainerInitializer extends ClasspathContainerInit
         new LibraryClasspathContainerResolverJob(
             BuildPath.resolvingRule(project), resolverService, project);
     job.setUser(true);
-    // Usually called from an initialize() request in response to adding a new libraries
-    // classpath entry to a project for the first time.  This classpath entry is not added
-    // until the initialize() is complete.  So schedule this job 1ms from now to ensure
-    // we return before it starts.
-    job.schedule(1);
+    job.schedule();
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJob.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.appengine.libraries;
 
 import com.google.common.base.Preconditions;
 import java.util.logging.Logger;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -54,4 +55,12 @@ public class LibraryClasspathContainerResolverJob extends Job {
     }
     return resolverService.resolveAll(javaProject, monitor);
   }
+
+  @Override
+  public boolean belongsTo(Object family) {
+    // so we seem part of builds, and make tests happy
+    return family == ResourcesPlugin.FAMILY_MANUAL_BUILD;
+  }
+  
+  
 }

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJob.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/LibraryClasspathContainerResolverJob.java
@@ -58,7 +58,8 @@ public class LibraryClasspathContainerResolverJob extends Job {
 
   @Override
   public boolean belongsTo(Object family) {
-    // so we seem part of builds, and make tests happy
+    // Consider container resolution as part of builds.  Simplifies
+    // our tests using {@code ProjectUtils.waitForProjects()}.
     return family == ResourcesPlugin.FAMILY_MANUAL_BUILD;
   }
   

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/LibraryClasspathContainerSerializer.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/persistence/LibraryClasspathContainerSerializer.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.eclipse.appengine.libraries.persistence;
 
 import com.google.cloud.tools.eclipse.appengine.libraries.LibraryClasspathContainer;
+import com.google.cloud.tools.eclipse.util.io.ResourceUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -212,7 +213,7 @@ public class LibraryClasspathContainerSerializer {
       IFolder folder =
           settingsFolder.getFolder(FrameworkUtil.getBundle(getClass()).getSymbolicName());
       if (!folder.exists() && create) {
-        folder.create(true, true, null);
+        ResourceUtils.createFolders(folder, null);
       }
       IFile containerFile = folder.getFile(id + ".container"); //$NON-NLS-1$
       return containerFile;

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries/src/com/google/cloud/tools/eclipse/appengine/libraries/repository/LibraryClasspathContainerResolverService.java
@@ -109,7 +109,7 @@ public class LibraryClasspathContainerResolverService
     ISchedulingRule currentRule = Job.getJobManager().currentRule();
     Preconditions.checkState(
         currentRule == null || currentRule.contains(getSchedulingRule()),
-        "current scheduling rule is insufficient");
+        "current scheduling rule is insufficient: " + currentRule);
 
     LinkedHashSet<IClasspathEntry> resolvedEntries = new LinkedHashSet<>();
     for (String libraryId : libraryIds) {

--- a/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.newproject.test/src/com/google/cloud/tools/eclipse/appengine/newproject/standard/CreateAppEngineStandardWtpProjectTest.java
@@ -88,6 +88,7 @@ public class CreateAppEngineStandardWtpProjectTest extends CreateAppEngineWtpPro
     } finally {
       Job.getJobManager().endRule(rule);
     }
+    ProjectUtils.waitForProjects(project);
 
     assertTrue(project.hasNature(JavaCore.NATURE_ID));
     assertAppEngineApiSdkOnClasspath();


### PR DESCRIPTION
Cause `LibraryClasspathContainerInitializer` to delegate library resolving to a background job.  This turns `LibraryClasspathContainerInitializer#initialize` into a much more light-weight operation.  

This change in high-level terms:
  - `LibraryClasspathContainerInitializer` no longer downloads and resolves artifacts in the requesting thread.  If the container is not properly resolved, it kicks off a `LibraryClasspathContainerResolverJob` via its `requestClasspathContainerUpdate()` method.  This job resolves required dependencies and then updates the classpath container on the project, which triggers an update of the project.
    - so `LibraryClasspathContainerResolverService#resolveAll()` should never be called from `LibraryClasspathContainerInitializer`, and hence the `LibraryClasspathContainerInitializerTest` changes
  - `CloudToolsEclipseProjectUpdater`, the old-project importer-and-rewriter, is changed to operate under a project lock to ensure project-rewriting is serialized with our `LibraryClasspathContainerResolverJob`'s resolving jars
  - `LibraryClasspathContainerResolverJob` now considers itself as a _manual build job_ so that our `ProjectUtils.waitForProjects()` test utility will wait for any resolution to complete
  - `LibraryClasspathContainerSerializer` can encounter situations where the project `.settings` directory doesn't exist.

This change fixes #3449 as any errors that occur in the resolution are surfaced to the user as part of the job (#3449).

This change avoids the deadlock situation in #3456 as delegating resolution to `LibraryClasspathContainerResolverJob` means the classpath resolution is not blocked while we download/resolve  library.  So we should be safe from the deadlock situation encountered in #3456.

Fixes #3449 
Fixes #3456