### PR TITLE
Ensure JVM flags are propagated in LocalAppEngineServerLaunchConfigurationDelegate

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver/src/com/google/cloud/tools/eclipse/appengine/localserver/server/LocalAppEngineServerLaunchConfigurationDelegate.java
@@ -448,7 +448,8 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
           generateServerRunConfiguration(configuration, server, mode, runnables);
       if (ILaunchManager.DEBUG_MODE.equals(mode)) {
         int debugPort = getDebugPort();
-        setupDebugTarget(devServerRunConfiguration, launch, debugPort, monitor);
+        devServerRunConfiguration =
+            setupDebugTarget(devServerRunConfiguration, launch, debugPort, monitor);
       }
 
       IJavaProject javaProject = JavaCore.create(modules[0].getProject());
@@ -492,8 +493,13 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
         server.getName());
   }
 
-  private void setupDebugTarget(RunConfiguration devServerRunConfiguration, ILaunch launch,
-      int debugPort, IProgressMonitor monitor) throws CoreException {
+  /** Set up the debug target to connect to the remote JVM. Returns the updated RunConfiguration. */
+  private RunConfiguration setupDebugTarget(
+      RunConfiguration devServerRunConfiguration,
+      ILaunch launch,
+      int debugPort,
+      IProgressMonitor monitor)
+      throws CoreException {
     if (debugPort <= 0 || debugPort > 65535) {
       throw new IllegalArgumentException("Debug port is set to " + debugPort //$NON-NLS-1$
           + ", should be between 1-65535"); //$NON-NLS-1$
@@ -511,7 +517,8 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
         JavaRuntime.getVMConnector(IJavaLaunchConfigurationConstants.ID_SOCKET_LISTEN_VM_CONNECTOR);
     if (connector == null) {
       abort("Cannot find Socket Listening connector", null, 0); //$NON-NLS-1$
-      return; // keep JDT null analysis happy
+      // NOTREACHED
+      return null; // keep JDT null analysis happy
     }
 
     // Set JVM debugger connection parameters
@@ -523,6 +530,7 @@ public class LocalAppEngineServerLaunchConfigurationDelegate
     connectionParameters.put("timeout", Integer.toString(timeout)); //$NON-NLS-1$
     connectionParameters.put("connectionLimit", "0"); //$NON-NLS-1$ //$NON-NLS-2$
     connector.connect(connectionParameters, monitor, launch);
+    return devServerRunConfiguration;
   }
 
   private int getDebugPort() throws CoreException {

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -127,6 +127,14 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     assertEquals("Hello App Engine!",
         getUrlContents(new URL("http://localhost:8080/hello"), (int) SWTBotPreferences.TIMEOUT));
 
+    // Ensure debugger has connected by looking for well-known thread
+    assertNotNull(
+        SwtBotTreeUtilities.findItem(
+            bot, launchTree, item -> "Thread [main] (Running)".equals(item.getText())));
+
+    SwtBotTreeUtilities.waitUntilTreeContainsText(
+        bot, allItems[0], "App Engine Standard at localhost");
+
     {
       SWTBotView serversView = bot.viewById("org.eclipse.wst.server.ui.ServersView");
       serversView.show();

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -36,6 +36,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.swt.custom.StyledText;
@@ -60,15 +61,15 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
   private static final long TERMINATE_SERVER_TIMEOUT = 10000L;
 
-  @Rule
-  public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
+  @Rule public ThreadDumpingWatchdog timer = new ThreadDumpingWatchdog(2, TimeUnit.MINUTES);
 
   /**
    * Launch a native application in debug mode and verify that:
+   *
    * <ol>
-   * <li>it started,</li>
-   * <li>it can be terminated and removed from the launch list, and</li>
-   * <li>the process is actually terminated.</li>
+   *   <li>it started,
+   *   <li>it can be terminated and removed from the launch list, and
+   *   <li>the process is actually terminated.
    * </ol>
    */
   @Test
@@ -81,8 +82,9 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
     assertNoService(new URL("http://localhost:8080/hello"));
 
-    project = SwtBotAppEngineActions.createNativeWebAppProject(bot, "testapp_java8", null,
-        "app.engine.test", null /* runtime */);
+    project =
+        SwtBotAppEngineActions.createNativeWebAppProject(
+            bot, "testapp_java8", null, "app.engine.test", null /* runtime */);
     assertTrue(project.exists());
 
     SWTBotTreeItem testProject = SwtBotProjectActions.selectProject(bot, "testapp_java8");
@@ -97,8 +99,10 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
     SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
 
-    bot.perspectiveById("org.eclipse.debug.ui.DebugPerspective").activate(); // IDebugUIConstants.ID_DEBUG_PERSPECTIVE
-    SWTBotView debugView = bot.viewById("org.eclipse.debug.ui.DebugView"); // IDebugUIConstants.ID_DEBUG_VIEW
+    bot.perspectiveById("org.eclipse.debug.ui.DebugPerspective")
+        .activate(); // IDebugUIConstants.ID_DEBUG_PERSPECTIVE
+    SWTBotView debugView =
+        bot.viewById("org.eclipse.debug.ui.DebugView"); // IDebugUIConstants.ID_DEBUG_VIEW
     debugView.show();
 
     SWTBotTree launchTree =
@@ -112,25 +116,29 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
 
     SwtBotTreeUtilities.waitUntilTreeHasItems(bot, launchTree);
     SWTBotTreeItem[] allItems = launchTree.getAllItems();
-    SwtBotTreeUtilities.waitUntilTreeContainsText(bot, allItems[0],
-        "App Engine Standard at localhost");
+    SwtBotTreeUtilities.waitUntilTreeContainsText(
+        bot, allItems[0], "App Engine Standard at localhost");
 
-    SWTBotView consoleView = bot.viewById("org.eclipse.ui.console.ConsoleView"); // IConsoleConstants.ID_CONSOLE_VIEW
+    SWTBotView consoleView =
+        bot.viewById("org.eclipse.ui.console.ConsoleView"); // IConsoleConstants.ID_CONSOLE_VIEW
     consoleView.show();
     SwtBotTestingUtilities.waitUntilViewContentDescription(
         bot, consoleView, Matchers.containsString("App Engine Standard at localhost"));
     SWTBotStyledText consoleContents =
         new SWTBotStyledText(bot.widget(widgetOfType(StyledText.class), consoleView.getWidget()));
-    SwtBotTestingUtilities.waitUntilStyledTextContains(bot,
-        "Module instance default is running at http://localhost:8080", consoleContents);
+    SwtBotTestingUtilities.waitUntilStyledTextContains(
+        bot, "Module instance default is running at http://localhost:8080", consoleContents);
 
     // Server is now running
-    assertEquals("Hello App Engine!",
+    assertEquals(
+        "Hello App Engine!",
         getUrlContents(new URL("http://localhost:8080/hello"), (int) SWTBotPreferences.TIMEOUT));
 
     // Ensure debugger has connected by looking for well-known thread
     debugView.show();
-    assertTrue(SwtBotTreeUtilities.hasChild(bot, launchTree, is("Thread [main] (Running)")));
+    assertTrue(
+        SwtBotTreeUtilities.hasChild(
+            bot, launchTree, stringContainsInOrder(Arrays.asList("Thread", "(Running)"))));
 
     {
       SWTBotView serversView = bot.viewById("org.eclipse.wst.server.ui.ServersView");
@@ -154,21 +162,21 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     SwtBotTreeUtilities.waitUntilTreeTextMatches(
         bot, allItems[0], containsString("<terminated>"), TERMINATE_SERVER_TIMEOUT);
     assertNoService(new URL("http://localhost:8080/hello"));
-    assertTrue("App Engine console should mark as stopped",
+    assertTrue(
+        "App Engine console should mark as stopped",
         consoleView.getViewReference().getContentDescription().startsWith("<stopped>"));
     assertFalse("Stop Server button should be disabled", stopServerButton.isEnabled());
 
     // should also cause console to be discarded
     launchTree.contextMenu("Remove All Terminated").click();
     SwtBotTreeUtilities.waitUntilTreeHasNoItems(bot, launchTree);
-    assertThat("App Engine console should be removed",
+    assertThat(
+        "App Engine console should be removed",
         consoleView.getViewReference().getContentDescription(),
         Matchers.is("No consoles to display at this time."));
   }
 
-  /**
-   * Check that there is no remote service for the URL.
-   */
+  /** Check that there is no remote service for the URL. */
   private void assertNoService(URL url) {
     try {
       getUrlContents(url, 10);
@@ -198,5 +206,4 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     }
     return content.toString().trim();
   }
-
 }

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -129,10 +129,8 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
         getUrlContents(new URL("http://localhost:8080/hello"), (int) SWTBotPreferences.TIMEOUT));
 
     // Ensure debugger has connected by looking for well-known thread
+    debugView.show();
     assertTrue(SwtBotTreeUtilities.hasChild(bot, launchTree, is("Thread [main] (Running)")));
-
-    SwtBotTreeUtilities.waitUntilTreeContainsText(
-        bot, allItems[0], "App Engine Standard at localhost");
 
     {
       SWTBotView serversView = bot.viewById("org.eclipse.wst.server.ui.ServersView");

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.eclipse.integration.appengine;
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -128,9 +129,7 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
         getUrlContents(new URL("http://localhost:8080/hello"), (int) SWTBotPreferences.TIMEOUT));
 
     // Ensure debugger has connected by looking for well-known thread
-    assertNotNull(
-        SwtBotTreeUtilities.findItem(
-            bot, launchTree, item -> "Thread [main] (Running)".equals(item.getText())));
+    assertTrue(SwtBotTreeUtilities.hasChild(bot, launchTree, is("Thread [main] (Running)")));
 
     SwtBotTreeUtilities.waitUntilTreeContainsText(
         bot, allItems[0], "App Engine Standard at localhost");

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -238,13 +238,12 @@ public class SwtBotTreeUtilities {
   /** Expand the tree as necessary to find a child matching the given condition. */
   public static boolean hasChild(SWTWorkbenchBot bot, SWTBotTree tree, Matcher<String> textMatcher) {
     waitUntilTreeHasItems(bot, tree);
-    // perform breadth-first search; execute directly in SWT thread as we can
-    // be affected by tree changes due to thread changes
+    // perform breadth-first search; execute directly in SWT thread as the tree may otherwise
+    // be affected by thread changes
     Result<Boolean> query =
         () -> {
           TreeItem[] items = tree.widget.getItems();
           for (TreeItem item : items) {
-            System.out.println("Debug Item: " + item.getText());
             if (textMatcher.matches(item.getText())) {
               return true;
             }
@@ -254,11 +253,11 @@ public class SwtBotTreeUtilities {
           while (!stack.isEmpty()) {
             TreeItem parent = stack.removeFirst();
             items = parent.getItems();
+            // detect the situation identified in
+            // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2569
             assertFalse(
-                "need workaround for https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2569",
-                items.length == 1 && "".equals(items[0].getText()));
+                "workaround may be required", items.length == 1 && "".equals(items[0].getText()));
             for (TreeItem item : items) {
-              System.out.println("Debug Item: " + item.getText());
               if (textMatcher.matches(item.getText())) {
                 return true;
               }

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -244,6 +244,7 @@ public class SwtBotTreeUtilities {
         () -> {
           TreeItem[] items = tree.widget.getItems();
           for (TreeItem item : items) {
+            System.out.println("Debug Item: " + item.getText());
             if (textMatcher.matches(item.getText())) {
               return true;
             }
@@ -257,6 +258,7 @@ public class SwtBotTreeUtilities {
                 "need workaround for https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2569",
                 items.length == 1 && "".equals(items[0].getText()));
             for (TreeItem item : items) {
+              System.out.println("Debug Item: " + item.getText());
               if (textMatcher.matches(item.getText())) {
                 return true;
               }

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -238,6 +238,7 @@ public class SwtBotTreeUtilities {
     waitUntilTreeHasItems(bot, tree);
     SWTBotTreeItem[] items = tree.getAllItems();
     for (SWTBotTreeItem item : items) {
+      System.out.println("findItem: checking top-level item: " + item.getText());
       if (condition.test(item)) {
         return item;
       }
@@ -255,6 +256,7 @@ public class SwtBotTreeUtilities {
         items = parent.getItems();
       }
       for (SWTBotTreeItem item : items) {
+        System.out.println("findItem: checking child item: " + item.getText());
         if (condition.test(item)) {
           return item;
         }

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTreeUtilities.java
@@ -253,8 +253,9 @@ public class SwtBotTreeUtilities {
           while (!stack.isEmpty()) {
             TreeItem parent = stack.removeFirst();
             items = parent.getItems();
-            // detect the situation identified in
+            // If this assertion fails, it may be due to
             // https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2569
+            // and may require applying the workaround to collapse and re-expand the node
             assertFalse(
                 "workaround may be required", items.length == 1 && "".equals(items[0].getText()));
             for (TreeItem item : items) {

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
           <configuration>
             <runOrder>hourly</runOrder>
             <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
+            <trimStackTrace>false</trimStackTrace>
             <!--
               - maven.artifact.threads=1 to workaround repository corruption seen in
                 https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/2284


### PR DESCRIPTION
Fixes #3482

`LocalAppEngineServerLaunchConfigurationDelegate#setupDebugTarget()` changes the `RunConfiguration` to add JVM command options to enable JDWP.  But with `RunConfiguration` becoming immutable, these changes were not propagated back to the caller `launch()`.

This patch changes `LocalAppEngineServerLaunchConfigurationDelegate#setupDebugTarget()` to return the updated `RunConfiguration`, which is picked up by `launch()`.  It also adds a check to `DebugNativeAppEngineStandardProjectTest` to check that the _main_ thread is found: no threading information will be available unless the debugger was able to connect to the remote JVM via JDWP.