### PR TITLE
remove Java 7 toolchain

### DIFF
--- a/.travisci/toolchains.xml
+++ b/.travisci/toolchains.xml
@@ -8,17 +8,6 @@
   <toolchain>
     <type>jdk</type>
     <provides>
-      <id>JavaSE-1.7</id>
-      <version>1.7</version>
-      <vendor>oracle</vendor>
-    </provides>
-    <configuration>
-      <jdkHome>/usr/lib/jvm/java-7-openjdk-amd64/jre</jdkHome>
-    </configuration>
-  </toolchain>
-  <toolchain>
-    <type>jdk</type>
-    <provides>
       <id>JavaSE-1.8</id>
       <version>1.8</version>
       <vendor>oracle</vendor>

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ These settings require configuring
 to point to appropriate JRE installations.  Tycho further requires
 that a toolchain defines an `id` for the specified _Execution
 Environment_ identifier.  For example, a `~/.m2/toolchains.xml` to
-configure Maven on macOS for Java 7, 8, and 11 toolchains might be:
+configure Maven on macOS for 8, and 11 toolchains might be:
 
 ```xml
 <?xml version="1.0" encoding="UTF8"?>
@@ -365,21 +365,10 @@ configure Maven on macOS for Java 7, 8, and 11 toolchains might be:
       <jdkHome>/Library/Java/JavaVirtualMachines/jdk1.8.0_181.jdk/Contents/Home/jre</jdkHome>
     </configuration>
   </toolchain>
-  <toolchain>
-    <type>jdk</type>
-    <provides>
-      <id>JavaSE-1.7</id>
-      <version>1.7</version>
-      <vendor>oracle</vendor>
-    </provides>
-    <configuration>
-      <jdkHome>/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/jre</jdkHome>
-    </configuration>
-  </toolchain>
 </toolchains>
 ```
 
-Note that _jdkHome_ for `JavaSE-1.7` and `JavaSE-1.8` specifies the
+Note that _jdkHome_ for `JavaSE-1.8` specifies the
 `jre/` directory: Tycho sets the default boot classpath to
 _jdkHome_`/lib/*`, _jdkHome_`/lib/ext/*`, and _jdkHome_`/lib/endorsed/*`.
 For many JDKs, including Oracle's JDK and the OpenJDK *prior to Java 9*, those

--- a/third_party/com.google.cloud.tools.eclipse.jst.server.core/META-INF/MANIFEST.MF
+++ b/third_party/com.google.cloud.tools.eclipse.jst.server.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: com.google.cloud.tools.eclipse.jst.server.core
 Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.google.cloud.tools.eclipse.jst.server.core
 Import-Package: org.eclipse.core.runtime;version="3.5.0",


### PR DESCRIPTION
fixes #3483 @briandealwis 

FYI I couldn't even compile on my new laptop because it didn't have Java 7, and there's no easy way to install this. 