### PR TITLE
Update to commons-compress' changed BSN

### DIFF
--- a/eclipse/ide-target-platform/category.xml
+++ b/eclipse/ide-target-platform/category.xml
@@ -33,7 +33,7 @@
    <bundle id="com.google.guava" version="28.1.0.jre"/>
    <bundle id="com.google.gson" version="2.8.2"/>
    <bundle id="com.google.cloud.tools.appengine" version="0.0.0"/>
-   <bundle id="org.apache.commons.compress" version="0.0.0"/>
+   <bundle id="org.apache.commons.commons-compress" version="0.0.0"/>
    <bundle id="jackson-core-asl" version="1.9.13"/>
    <bundle id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
    <bundle id="org.yaml.snakeyaml" version="1.21"/>

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -40,7 +40,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.commons.compress"
+         id="org.apache.commons.commons-compress"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <!--
-        bundle: org.apache.commons.compress
+        bundle: org.apache.commons.commons-compress
         dependency used by appengine-plugins-core
       -->
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Update our 3rd-party feature with commons-compress' changed OSGi symbolic name.  Fortunately the package names haven't changed and so `appengine-plugins-core`/`com.google.cloud.tools.appengine` is unaffected.

Filed [COMPRESS-498](https://issues.apache.org/jira/browse/COMPRESS-498) about the name change, which seems to have been a mistake.