### PR TITLE
Add com.google.guava.failureaccess to 3rdparty feature

### DIFF
--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/feature.xml
@@ -54,6 +54,13 @@
          unpack="false"/>
 
    <plugin
+         id="com.google.guava.failureaccess"
+         download-size="0"
+         install-size="0"
+         version="1.0.1"
+         unpack="false"/>
+
+   <plugin
          id="com.google.gson"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
No need to add to `eclipse/ide-target-repository/category.xml` as `failureaccess` is already being resolved by p2 when creating the `ide-target-repository`.