### PR TITLE
Mute SourceAttacherJob in test logs

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/logback.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/logback.xml
@@ -9,6 +9,8 @@
   </appender>
 
   <logger name="com.google.cloud.tools" level="debug"/>
+  <logger name="com.google.cloud.tools.eclipse.appengine.libraries.SourceAttacherJob" level="warn"/>
+  
   <root level="info">
     <appender-ref ref="STDOUT" />
   </root>


### PR DESCRIPTION
Raise `SourceAttacherJob`'s logging level to avoid verbose logs.
Fixes #3561