### PR TITLE
Fix user profile picture URL

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanelTest.java
@@ -17,26 +17,34 @@
 package com.google.cloud.tools.eclipse.login.ui;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
 import com.google.cloud.tools.login.Account;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -61,6 +69,7 @@ public class AccountsPanelTest {
     when(account1.getName()).thenReturn("Alice");
     when(account2.getName()).thenReturn(null);
     when(account3.getName()).thenReturn("Charlie");
+    when(account1.getAvatarUrl()).thenReturn("https://avatar.url/account1");
   }
 
   @Test
@@ -123,6 +132,23 @@ public class AccountsPanelTest {
     assertEquals(1, namesEmails.emails.size());
     assertEquals("bob@example.com", namesEmails.emails.get(0));
     assertTrue(namesEmails.names.get(0).isEmpty());
+  }
+
+  @Test
+  public void testAccountsArea_avatarImageUrl() throws MalformedURLException {
+    setUpLoginService(Arrays.asList(account1));
+
+    AccountsPanel panel = new AccountsPanel(null, loginService, imageLoader);
+    panel.createDialogArea(shell);
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(imageLoader).loadImage(captor.capture(), any());
+    assertEquals(1, captor.getAllValues().size());
+
+    Pattern urlPattern = Pattern.compile("^https://avatar.url/account1=s([0-9]+)$");
+    Matcher matcher = urlPattern.matcher(captor.getValue());
+    assertTrue(matcher.find());
+    assertThat(Integer.valueOf(matcher.group(1)), Matchers.greaterThan(0));
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
@@ -66,7 +66,6 @@ public class AccountsPanel extends PopupDialog {
     this.imageLoader = imageLoader;
   }
 
-
   @Override
   protected Color getBackground() {
     return getShell().getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND);

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
@@ -113,7 +113,7 @@ public class AccountsPanel extends PopupDialog {
 
       if (account.getAvatarUrl() != null) {
         try {
-          imageLoader.loadImage(account.getAvatarUrl() + "?sz=" + avatarSize, avatar);
+          imageLoader.loadImage(account.getAvatarUrl() + "=s" + avatarSize, avatar);
         } catch (MalformedURLException ex) {
           logger.log(Level.WARNING, "malformed avatar image URL", ex);
         }

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/LabelImageLoader.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/LabelImageLoader.java
@@ -42,7 +42,8 @@ public class LabelImageLoader {
    *
    * Must be called in the UI context.
    */
-  void loadImage(String imageUrl, Label label) throws MalformedURLException {
+  @VisibleForTesting
+  public void loadImage(String imageUrl, Label label) throws MalformedURLException {
     Preconditions.checkNotNull(imageUrl);
 
     ImageData imageData = cache.get(imageUrl);


### PR DESCRIPTION
Fixes #3570.

For the image

https://lh3.googleusercontent.com/a-/AAuE7mBeBrCk1V_scMJv6_OOR68BaWs2OZ9OTE0byc94

we should request the size in the new URL format by appending `=s[size]`, e.g.,

https://lh3.googleusercontent.com/a-/AAuE7mBeBrCk1V_scMJv6_OOR68BaWs2OZ9OTE0byc94=s45

Clicking on the latter URL returns a small image.