### PR TITLE
Change Travis build to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: java
+dist: xenial
+services:
+  - xvfb
 addons:
   apt:
     packages:
@@ -9,6 +12,7 @@ before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 install: 
   # use mvn ≥ 3.3.9 to ensure faulty test exit states fail the build (#1276)
+  # todo: mvn 3.6.3 should work with tycho
   - mvn -B -N io.takari:maven:wrapper -Dmaven=3.5.4
   # download and install Cloud SDK (may be cached)
   - build/install-cloudsdk.sh 241.0.0 $HOME
@@ -18,18 +22,14 @@ matrix:
   include:
     - name: "Eclipse Photon (4.8) on Java 8"
       jdk: oraclejdk8
-      dist: trusty
       env: MAVEN_FLAGS='-Pjacoco'
     - name: "Eclipse 2018-09 (4.9) on Java 8"
       jdk: oraclejdk8
-      dist: trusty
       env: ECLIPSE_TARGET=2018-09
     - name: "Eclipse 2018-09 (4.9) on Java 11"
       jdk: openjdk11
-      dist: trusty
       env: ECLIPSE_TARGET=2018-09 MAVEN_FLAGS='--toolchains=.travisci/toolchains.xml'
     - name: "Eclipse 2018-12 (4.10) on Java 11"
-      dist: trusty
       jdk: openjdk11
       env: ECLIPSE_TARGET=2018-12 MAVEN_FLAGS='--toolchains=.travisci/toolchains.xml'
 env:
@@ -43,8 +43,6 @@ env:
     - DISPLAY=:99.0
     - GCS_BUILD_BUCKET=gs://travis_artifacts
 before_script:
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - metacity --sm-disable --replace &
   - sleep 3 # give metacity some time to start
 script: ./mvnw -V -B --fail-at-end verify ${MAVEN_FLAGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
       env: ECLIPSE_TARGET=photon MAVEN_FLAGS='-Pjacoco'
     - name: "Eclipse 2018-09 (4.9) on Java 8"
       jdk: openjdk8
-      env: ECLIPSE_TARGET=2018-09
     - name: "Eclipse 2018-09 (4.9) on Java 11"
       jdk: openjdk11
       env: MAVEN_FLAGS='--toolchains=.travisci/toolchains.xml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ install:
 matrix:
   include:
     - name: "Eclipse Photon (4.8) on Java 8"
-      jdk: oraclejdk8
+      jdk: openjdk8
       env: MAVEN_FLAGS='-Pjacoco'
     - name: "Eclipse 2018-09 (4.9) on Java 8"
-      jdk: oraclejdk8
+      jdk: openjdk8
       env: ECLIPSE_TARGET=2018-09
     - name: "Eclipse 2018-09 (4.9) on Java 11"
       jdk: openjdk11

--- a/.travisci/toolchains.xml
+++ b/.travisci/toolchains.xml
@@ -25,7 +25,7 @@
       <vendor>openjdk</vendor>
     </provides>
     <configuration>
-      <jdkHome>/home/travis/openjdk11</jdkHome>
+      <jdkHome>/usr/local/lib/jvm/openjdk11</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>

--- a/.travisci/toolchains.xml
+++ b/.travisci/toolchains.xml
@@ -10,10 +10,10 @@
     <provides>
       <id>JavaSE-1.8</id>
       <version>1.8</version>
-      <vendor>oracle</vendor>
+      <vendor>openjdk</vendor>
     </provides>
     <configuration>
-      <jdkHome>/usr/lib/jvm/java-8-oracle/jre</jdkHome>
+      <jdkHome>/usr/lib/jvm/java-8-openjdk-amd64/jre</jdkHome>
     </configuration>
   </toolchain>
   <toolchain>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <!-- Execution environment supported by Cloud Tools for Eclipse -->
     <requiredExecutionEnvironment>JavaSE-1.8</requiredExecutionEnvironment>
 
-    <tycho.version>1.3.0</tycho.version>
-    <tycho-extras.version>1.3.0</tycho-extras.version>
+    <tycho.version>1.5.0</tycho.version>
+    <tycho-extras.version>1.5.0</tycho-extras.version>
     <product.version.qualifier.suffix/>  <!-- 0-length string by default -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>photon</eclipse.target> <!-- the default build -->


### PR DESCRIPTION
This PR changes the Travis build from using the Trusty distribution (now EOL) to the Xenial distribution (Ubuntu 16.04 LTS) to pick up more up-to-date JREs.  The hope is that these later JREs may have fixes for the occasional hangs that our Eclipse 2018-09 on Java 8 builds are suffering.  There are a few changes:

  - Uses the new `xvfb` service to launch xvfb automagically.
  - The `oraclejdk8` is not available in Xenial, so we use `openjdk8` instead.
  - It also switches to using Tycho 1.5.0, in case the hangs are caused in p2.