### PR TITLE
Fix Kokoro nightly release builds

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -108,6 +108,7 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
           }
         });
     SWTBotShell debugPage = bot.shell("Debug On Server");
+    assertNotNull(debugPage);
     debugPage.activate();
     SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
 

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -43,7 +43,9 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotToolbarButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
@@ -91,12 +93,22 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
     assertNotNull(testProject);
     SwtBotTestingUtilities.waitUntilMenuHasItem(
         bot, () -> bot.menu("Run").menu("Debug As"), endsWith("Debug on Server"));
-    SwtBotTestingUtilities.performAndWaitForWindowChange(
-        bot,
-        () -> {
-          bot.menu("Run").menu("Debug As").menu("1 Debug on Server").click();
-        });
 
+    bot.menu("Run").menu("Debug As").menu("1 Debug on Server").click();
+    bot.waitUntil(
+        new DefaultCondition() {
+          @Override
+          public boolean test() throws Exception {
+            return bot.shell("Debug On Server") != null;
+          }
+
+          @Override
+          public String getFailureMessage() {
+            return "Cannot find a shell with title 'Debug On Server'";
+          }
+        });
+    SWTBotShell debugPage = bot.shell("Debug On Server");
+    debugPage.activate();
     SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
 
     bot.perspectiveById("org.eclipse.debug.ui.DebugPerspective")

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -99,7 +99,7 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
         new DefaultCondition() {
           @Override
           public boolean test() throws Exception {
-            return bot.shell("Debug On Server") != null;
+            return bot.shell("Debug On Server").isOpen();
           }
 
           @Override

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/src/com/google/cloud/tools/eclipse/integration/appengine/DebugNativeAppEngineStandardProjectTest.java
@@ -43,7 +43,6 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
-import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotStyledText;
@@ -95,20 +94,8 @@ public class DebugNativeAppEngineStandardProjectTest extends BaseProjectTest {
         bot, () -> bot.menu("Run").menu("Debug As"), endsWith("Debug on Server"));
 
     bot.menu("Run").menu("Debug As").menu("1 Debug on Server").click();
-    bot.waitUntil(
-        new DefaultCondition() {
-          @Override
-          public boolean test() throws Exception {
-            return bot.shell("Debug On Server").isOpen();
-          }
-
-          @Override
-          public String getFailureMessage() {
-            return "Cannot find a shell with title 'Debug On Server'";
-          }
-        });
+    SwtBotTestingUtilities.waitUntilShellIsOpen(bot, "Debug On Server");
     SWTBotShell debugPage = bot.shell("Debug On Server");
-    assertNotNull(debugPage);
     debugPage.activate();
     SwtBotTestingUtilities.clickButtonAndWaitForWindowClose(bot, bot.button("Finish"));
 

--- a/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
+++ b/plugins/com.google.cloud.tools.eclipse.swtbot/src/com/google/cloud/tools/eclipse/swtbot/SwtBotTestingUtilities.java
@@ -127,6 +127,23 @@ public class SwtBotTestingUtilities {
   }
 
   /**
+   * Blocks the caller until the shell matching the text is open.
+   */
+  public static void waitUntilShellIsOpen(SWTBot bot, String text) {
+    bot.waitUntil(new DefaultCondition() {
+        @Override
+        public String getFailureMessage() {
+          return "Cannot find a shell with text '" + text + "'";
+        }
+
+        @Override
+        public boolean test() throws Exception {
+          return bot.shell(text).isOpen();
+        }
+      });
+  }
+
+  /**
    * Blocks the caller until the given shell is closed.
    */
   public static void waitUntilShellIsClosed(SWTBot bot, SWTBotShell shell) {


### PR DESCRIPTION
Since we changed our default from Photon to 2018-09, the integration test on the Kokoro Ubuntu nightly release builds have been failing. (OTOH, Kokoro Windows builds and local builds are OK.)

For whatever reason, the shell with the title "data - testapp_java8/src/main/java/app/engine/test/HelloAppEngine.java - Eclipse Platform" does no get deactivated when the "Debug On Server" window is open. I just tried a different approach to access the "Debug On Server" window.

Building with this branch worked.

Fixes #3596.