### PR TITLE
Update Objectify version in CloudLibrariesInPluginXmlTest

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.test/src/com/google/cloud/tools/eclipse/appengine/libraries/model/CloudLibrariesInPluginXmlTest.java
@@ -168,7 +168,7 @@ public class CloudLibrariesInPluginXmlTest {
     assertThat(objectifyMavenCoordinates.getArtifactId(), is("objectify"));
     DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(
         objectifyMavenCoordinates.getVersion());
-    assertEquals(new DefaultArtifactVersion("6.0.5"), artifactVersion);
+    assertEquals(new DefaultArtifactVersion("6.0.6"), artifactVersion);
     assertThat(objectifyMavenCoordinates.getType(), is("jar"));
     assertNull(objectifyMavenCoordinates.getClassifier());
 


### PR DESCRIPTION
The test fails probably because we have Objectify 6.0.6 published like yesterday.
```
Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.609 s <<< FAILURE! - in com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibrariesInPluginXmlTest
testObjectifyLibraryConfig(com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibrariesInPluginXmlTest)  Time elapsed: 0.472 s  <<< FAILURE!
java.lang.AssertionError: expected:<6.0.5> but was:<6.0.6>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at com.google.cloud.tools.eclipse.appengine.libraries.model.CloudLibrariesInPluginXmlTest.testObjectifyLibraryConfig(CloudLibrariesInPluginXmlTest.java:171)
```