### PR TITLE
Migrate Clearcut client-side usage metrics

### DIFF
--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -17,11 +17,13 @@ gcloud components install app-engine-java --quiet
 
 echo "OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}"
 echo "OAUTH_CLIENT_SECRET: ${OAUTH_CLIENT_SECRET}"
+echo "FIRELOG_API_KEY: ${FIRELOG_API_KEY}"
 echo "PRODUCT_VERSION_SUFFIX: "${PRODUCT_VERSION_SUFFIX}
 
 # Exit if undefined (zero-length).
 test -n "${OAUTH_CLIENT_ID}"
 test -n "${OAUTH_CLIENT_SECRET}"
+test -n "${FIRELOG_API_KEY}"
 
 cd git/google-cloud-eclipse
 
@@ -34,5 +36,6 @@ TMPDIR= xvfb-run \
   mvn -V -B \
       -Doauth.client.id="${OAUTH_CLIENT_ID}" \
       -Doauth.client.secret="${OAUTH_CLIENT_SECRET}" \
+      -Dfirelog.api.key="${FIRELOG_API_KEY}" \
       ${PRODUCT_VERSION_SUFFIX:+-Dproduct.version.qualifier.suffix="'${PRODUCT_VERSION_SUFFIX}'"} \
     clean verify

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerPluginTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker.test/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManagerPluginTest.java
@@ -60,25 +60,24 @@ public class AnalyticsPingManagerPluginTest {
     PingEvent event = new PingEvent("SomeEvent", metadata, null);
     String json = pingManager.jsonEncode(event);
 
-    Type singletonRootType = new TypeToken<List<Map<String, ?>>>(){}.getType();
-    List<Map<String, ?>> singletonRoot = gson.fromJson(json, singletonRootType);
-    Map<String, ?> root = singletonRoot.get(0);
+    Type mapType = new TypeToken<Map<String, ?>>(){}.getType();
+    Map<String, ?> root = gson.fromJson(json, mapType);
 
-    Map<String, ?> clientInfo = ((List<Map<String, ?>>) root.get("client_info")).get(0);
+    Map<String, ?> clientInfo = (Map<String, ?>) root.get("client_info");
     Assert.assertEquals("DESKTOP", clientInfo.get("client_type"));  
-    Assert.assertEquals("CONCORD", root.get("log_source_name"));  
+    Assert.assertEquals("CONCORD", root.get("log_source"));
 
     long requestTimeMs = ((Double) root.get("request_time_ms")).longValue();
     Assert.assertTrue(requestTimeMs >= 1000000);
     
     Map<String, String> desktopClientInfo =
-        ((List<Map<String, String>>) clientInfo.get("desktop_client_info")).get(0);
+        (Map<String, String>) clientInfo.get("desktop_client_info");
     Assert.assertTrue(desktopClientInfo.get("os").length() > 1);
 
-    List<Object> logEvents = ((List<List<Object>>) root.get("log_event")).get(0);
+    List<Map<String, Object>> logEvents = (List<Map<String, Object>>) root.get("log_event");
     Assert.assertEquals(1, logEvents.size());
 
-    Map<String, Object> logEvent = (Map<String, Object>) logEvents.get(0);
+    Map<String, Object> logEvent = logEvents.get(0);
     long eventTimeMs = ((Double) logEvent.get("event_time_ms")).longValue();
     Assert.assertTrue(eventTimeMs >= 1000000);
 
@@ -88,7 +87,7 @@ public class AnalyticsPingManagerPluginTest {
     Type sourceExtensionJsonType = new TypeToken<Map<String, ?>>(){}.getType();
     Map<String, ?> source = gson.fromJson(sourceExtensionJson, sourceExtensionJsonType);
     Assert.assertEquals("CLOUD_TOOLS_FOR_ECLIPSE", source.get("console_type"));
-    Assert.assertEquals("clientId", source.get("client_machine_id"));
+    Assert.assertEquals("clientId", source.get("client_install_id"));
     Assert.assertEquals("SomeEvent", source.get("event_name"));
 
     List<Map<String, String>> eventMetadata =

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/.classpath
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="generated-sources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/build.properties
@@ -3,4 +3,5 @@ bin.includes = META-INF/,\
                plugin.xml,\
                plugin.properties,\
                .
-source.. = src/
+source.. = src/,\
+           generated-sources/

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/java-templates/com/google/cloud/tools/eclipse/usagetracker/Constants.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/java-templates/com/google/cloud/tools/eclipse/usagetracker/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/java-templates/com/google/cloud/tools/eclipse/usagetracker/Constants.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/java-templates/com/google/cloud/tools/eclipse/usagetracker/Constants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.usagetracker;
+
+/**
+ * Placeholder constants initialized at compile-time.
+ */
+public class Constants {
+
+  public static final String FIRELOG_API_KEY = "@firelog.api.key@";
+}

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/pom.xml
@@ -10,4 +10,26 @@
   <artifactId>com.google.cloud.tools.eclipse.usagetracker</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <sourceDirectory>${basedir}/java-templates</sourceDirectory>
+          <outputDirectory>${basedir}/generated-sources</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -317,7 +317,7 @@ public class AnalyticsPingManager {
     Map<String, Object> logEvent = new HashMap<>();
     logEvent.put("event_time_ms", System.currentTimeMillis());
     logEvent.put("sequence_position", sequencePosition++);  
-    logEvent.put("source_extension_json_proto3", sourceExtensionJsonString);
+    logEvent.put("source_extension_json", sourceExtensionJsonString);
     
     Map<String, Object> root = new HashMap<>();
     root.put("log_source", "CONCORD");

--- a/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
+++ b/plugins/com.google.cloud.tools.eclipse.usagetracker/src/com/google/cloud/tools/eclipse/usagetracker/AnalyticsPingManager.java
@@ -54,8 +54,7 @@ public class AnalyticsPingManager {
   private static final Logger logger = Logger.getLogger(AnalyticsPingManager.class.getName());
 
   private static final String FIRELOG_COLLECTION_URL =
-      "https://firebaselogging-pa.googleapis.com/v1/firelog/legacy/log?key="
-          + Constants.FIRELOG_API_KEY;
+      "https://firebaselogging-pa.googleapis.com/v1/firelog/legacy/log";
 
   private static AnalyticsPingManager instance;
 
@@ -92,8 +91,8 @@ public class AnalyticsPingManager {
   public static synchronized AnalyticsPingManager getInstance() {
     if (instance == null) {
       String collectionUrl = null;
-      if (!Platform.inDevelopmentMode()) {
-        collectionUrl = FIRELOG_COLLECTION_URL;
+      if (!Platform.inDevelopmentMode() && !Constants.FIRELOG_API_KEY.startsWith("@")) {
+        collectionUrl = FIRELOG_COLLECTION_URL + "?key=" + Constants.FIRELOG_API_KEY;
       }
       instance = new AnalyticsPingManager(collectionUrl, AnalyticsPreferences.getPreferenceNode(),
           new ConcurrentLinkedQueue<PingEvent>());


### PR DESCRIPTION
JSON changes:
   - Stop wrapping non-primitive types as a singleton list. This redundant wrapping didn't make sense at all, but Clearcut weirdness required it.
   - `log_source_name` --> `log_source`
   - ~~`source_extension_json` --> `source_extension_json_proto3` (doesn't seem necessary but following the latest sample)~~
   - `client_machine_id` --> `client_install_id` (this has been broken even with Clearcut)

Also restoring source generation for `Constants.java`. See https://github.com/GoogleCloudPlatform/google-cloud-eclipse/pull/3537/files to verify the reverted changes.

The local test server logs that the JSON is parsed correctly.
```
Request: "POST /v1/firelog/legacy/log?key=... HTTP/1.1"
[...] {
  client_info {
    client_type: DESKTOP
  }
  timestamp_millis: 1581013495216
  client_timestamp_millis: 1581013495071
  device_status {
  }
  network_connection_info {
  }
}
[...] {
  event_name: "appengine.new.project.wizard"
  event_metadata {
    key: "type"
    value: "native"
  }
  event_metadata {
    key: "ct4e-version"
    value: "0.0.0"
  }
  event_metadata {
    key: "eclipse-version"
    value: "4.9.0.v20180906-0745"
  }
  console_type: "CLOUD_TOOLS_FOR_ECLIPSE"
  client_install_id: "..."
}
```

(b/148875022#comment6)