### PR TITLE
Redirect Eclipse logs during tests to SLF4j/Logback

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/.project
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/.project
@@ -25,6 +25,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.slf4j.bridge.jul;bundle-version="[1.7.10,2)",
  javax.annotation
 Service-Component: OSGI-INF/logservice.xml 
-Import-Package: org.eclipse.equinox.log;version="1.1.0",
+Import-Package: org.eclipse.equinox.log;version="1.0",
  org.osgi.framework,
  org.osgi.service.log;version="1.4.0",
  org.slf4j.impl;version="[1.7.10,2)"

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.slf4j.apis.jcl;bundle-version="[1.7.10,2)",
  org.slf4j.bridge.jul;bundle-version="[1.7.10,2)",
  javax.annotation
-Service-Component: OSGI-INF/logservice.xml 
+Service-Component: OSGI-INF/logservice.xml
 Import-Package: org.eclipse.equinox.log;version="1.0",
  org.osgi.framework,
  org.osgi.service.log;version="1.4.0",

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/META-INF/MANIFEST.MF
@@ -20,7 +20,10 @@ Require-Bundle: org.junit;bundle-version="[4.12.0,4.12.1)";visibility:=reexport,
  org.slf4j.apis.jcl;bundle-version="[1.7.10,2)",
  org.slf4j.bridge.jul;bundle-version="[1.7.10,2)",
  javax.annotation
-Import-Package: org.osgi.framework,
+Service-Component: OSGI-INF/logservice.xml 
+Import-Package: org.eclipse.equinox.log;version="1.1.0",
+ org.osgi.framework,
+ org.osgi.service.log;version="1.4.0",
  org.slf4j.impl;version="[1.7.10,2)"
 Export-Package: org.mockito;provider=google;version="1.10.19";
   uses:="org.mockito.invocation,

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/OSGI-INF/logservice.xml
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/OSGI-INF/logservice.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="com.google.cloud.tools.eclipse.logging.osgi_slf4j">
+  <implementation class="com.google.cloud.tools.eclipse.test.dependencies.EclipseLoggingAdapter" />
+  <service>
+     <provide interface="org.osgi.service.log.LoggerFactory" />
+     <provide interface="org.eclipse.equinox.log.ExtendedLogService"/>
+     <provide interface="org.osgi.service.log.LogService"/>
+  </service>
+  <property name="service.ranking" type="Integer" value="10000000"/>
+</scr:component>

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
@@ -3,9 +3,9 @@ output.. = target/classes/
 # NB: only include the lib/.jars actually required as lib/ will include referenced bundles
 # including broken hamcrest-1.1
 bin.includes = META-INF/,\
+               OSGI-INF/,\
                lib/mockito-core-1.10.19.jar,\
                lib/objenesis-2.2.jar,\
                logback.xml,\
                plugin.properties,\
-               .,\
-               OSGI-INF/
+               .

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/build.properties
@@ -7,4 +7,5 @@ bin.includes = META-INF/,\
                lib/objenesis-2.2.jar,\
                logback.xml,\
                plugin.properties,\
-               .
+               .,\
+               OSGI-INF/

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/EclipseLoggingAdapter.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/EclipseLoggingAdapter.java
@@ -19,11 +19,12 @@ package com.google.cloud.tools.eclipse.test.dependencies;
 import org.eclipse.equinox.log.ExtendedLogService;
 import org.eclipse.equinox.log.Logger;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.ServiceReference;
-import org.osgi.service.log.LogService;
 import org.osgi.service.log.LoggerFactory;
 
-/** An SLF4j facade for OSGi LoggerFactory and Eclipse ExtendedLogService */
+/**
+ * An SLF4j facade for OSGi {@link LoggerFactory} and Eclipse {@link ExtendedLogService}. This class
+ * is intended to be a replacement for other ExtendedLogService implementations.
+ */
 public class EclipseLoggingAdapter extends LoggerDelegate
     implements LoggerFactory, ExtendedLogService {
 
@@ -44,78 +45,6 @@ public class EclipseLoggingAdapter extends LoggerDelegate
   @Override
   public Logger getLogger(Bundle bundle, String loggerName) {
     return new LoggerDelegate(org.slf4j.LoggerFactory.getLogger(bundle.getSymbolicName()));
-  }
-
-  @Override
-  public void log(int level, String message) {
-    log(level, message, null);
-  }
-
-  @Override
-  public void log(int level, String message, Throwable exception) {
-    log(null, level, message, exception);
-  }
-
-  @Override
-  public void log(ServiceReference<?> sr, int level, String message) {
-    log(level, message);
-  }
-
-  @Override
-  public void log(ServiceReference<?> sr, int level, String message, Throwable exception) {
-    log(level, message, exception);
-  }
-
-  @Override
-  public void log(Object context, int level, String message) {
-    log(context, level, message, null);
-  }
-
-  private Logger getLogger(Object context) {
-    if (context instanceof Class) {
-      return getLogger((Class) context);
-    } else if (context != null) {
-      return getLogger(context.getClass());
-    }
-    return this;
-  }
-
-  @Override
-  public void log(Object context, int level, String message, Throwable exception) {
-    Logger logger = getLogger(context);
-    switch (level) {
-      case LogService.LOG_ERROR:
-        logger.error(message, exception);
-        break;
-      case LogService.LOG_WARNING:
-        logger.warn(message, exception);
-        break;
-      case LogService.LOG_INFO:
-        logger.info(message, exception);
-        break;
-      case LogService.LOG_DEBUG:
-        logger.debug(message, exception);
-        break;
-      default:
-        logger.debug(message, exception);
-        break;
-    }
-  }
-
-  @Override
-  public boolean isLoggable(int level) {
-    switch (level) {
-      case LogService.LOG_ERROR:
-        return isErrorEnabled();
-      case LogService.LOG_WARNING:
-        return isWarnEnabled();
-      case LogService.LOG_INFO:
-        return isInfoEnabled();
-      case LogService.LOG_DEBUG:
-        return isDebugEnabled();
-      default:
-        return false;
-    }
   }
 
   @Override

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/EclipseLoggingAdapter.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/EclipseLoggingAdapter.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.test.dependencies;
+
+import org.eclipse.equinox.log.ExtendedLogService;
+import org.eclipse.equinox.log.Logger;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
+import org.osgi.service.log.LoggerFactory;
+
+/** An SLF4j facade for OSGi LoggerFactory and Eclipse ExtendedLogService */
+public class EclipseLoggingAdapter extends LoggerDelegate
+    implements LoggerFactory, ExtendedLogService {
+
+  public EclipseLoggingAdapter() {
+    super(org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME));
+  }
+
+  @Override
+  public Logger getLogger(String name) {
+    return new LoggerDelegate(org.slf4j.LoggerFactory.getLogger(name));
+  }
+
+  @Override
+  public Logger getLogger(Class<?> clazz) {
+    return new LoggerDelegate(org.slf4j.LoggerFactory.getLogger(clazz));
+  }
+
+  @Override
+  public Logger getLogger(Bundle bundle, String loggerName) {
+    return new LoggerDelegate(org.slf4j.LoggerFactory.getLogger(bundle.getSymbolicName()));
+  }
+
+  @Override
+  public void log(int level, String message) {
+    log(level, message, null);
+  }
+
+  @Override
+  public void log(int level, String message, Throwable exception) {
+    log(null, level, message, exception);
+  }
+
+  @Override
+  public void log(ServiceReference<?> sr, int level, String message) {
+    log(level, message);
+  }
+
+  @Override
+  public void log(ServiceReference<?> sr, int level, String message, Throwable exception) {
+    log(level, message, exception);
+  }
+
+  @Override
+  public void log(Object context, int level, String message) {
+    log(context, level, message, null);
+  }
+
+  private Logger getLogger(Object context) {
+    if (context instanceof Class) {
+      return getLogger((Class) context);
+    } else if (context != null) {
+      return getLogger(context.getClass());
+    }
+    return this;
+  }
+
+  @Override
+  public void log(Object context, int level, String message, Throwable exception) {
+    Logger logger = getLogger(context);
+    switch (level) {
+      case LogService.LOG_ERROR:
+        logger.error(message, exception);
+        break;
+      case LogService.LOG_WARNING:
+        logger.warn(message, exception);
+        break;
+      case LogService.LOG_INFO:
+        logger.info(message, exception);
+        break;
+      case LogService.LOG_DEBUG:
+        logger.debug(message, exception);
+        break;
+      default:
+        logger.debug(message, exception);
+        break;
+    }
+  }
+
+  @Override
+  public boolean isLoggable(int level) {
+    switch (level) {
+      case LogService.LOG_ERROR:
+        return isErrorEnabled();
+      case LogService.LOG_WARNING:
+        return isWarnEnabled();
+      case LogService.LOG_INFO:
+        return isInfoEnabled();
+      case LogService.LOG_DEBUG:
+        return isDebugEnabled();
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public <L extends org.osgi.service.log.Logger> L getLogger(String name, Class<L> loggerType) {
+    if (loggerType == org.osgi.service.log.Logger.class) {
+      return loggerType.cast(getLogger(name));
+    }
+    return null;
+  }
+
+  @Override
+  public <L extends org.osgi.service.log.Logger> L getLogger(Class<?> clazz, Class<L> loggerType) {
+    if (loggerType == org.osgi.service.log.Logger.class) {
+      return loggerType.cast(getLogger(clazz));
+    }
+    return null;
+  }
+
+  @Override
+  public <L extends org.osgi.service.log.Logger> L getLogger(
+      Bundle bundle, String name, Class<L> loggerType) {
+    if (loggerType == org.osgi.service.log.Logger.class) {
+      return loggerType.cast(getLogger(bundle, name));
+    }
+    return null;
+  }
+}

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LoggerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LoggerDelegate.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.eclipse.test.dependencies;
 
 import org.eclipse.equinox.log.Logger;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
 import org.osgi.service.log.LoggerConsumer;
 
 class LoggerDelegate implements Logger {
@@ -214,43 +215,69 @@ class LoggerDelegate implements Logger {
 
   @Override
   public void log(int level, String message) {
-    // TODO Auto-generated method stub
-    
+    log(level, message, null);
   }
 
   @Override
   public void log(int level, String message, Throwable exception) {
-    // TODO Auto-generated method stub
-    
+    log(null, level, message, exception);
   }
 
   @Override
   public void log(ServiceReference<?> sr, int level, String message) {
-    // TODO Auto-generated method stub
-    
+    log(level, message);
   }
 
   @Override
   public void log(ServiceReference<?> sr, int level, String message, Throwable exception) {
-    // TODO Auto-generated method stub
-    
+    log(level, message, exception);
   }
 
   @Override
   public void log(Object context, int level, String message) {
-    // TODO Auto-generated method stub
-    
+    log(context, level, message, null);
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void log(Object context, int level, String message, Throwable exception) {
-    // TODO Auto-generated method stub
-    
+    // Oddly LogService#LOG_xxx are deprecated in favour of LogLevel enum, but
+    // the LogLevel enum does not provide integer mappings.
+    switch (level) {
+      case LogService.LOG_ERROR:
+        logger.error(message, exception);
+        break;
+      case LogService.LOG_WARNING:
+        logger.warn(message, exception);
+        break;
+      case LogService.LOG_INFO:
+        logger.info(message, exception);
+        break;
+      case LogService.LOG_DEBUG:
+        logger.debug(message, exception);
+        break;
+      default:
+        logger.debug(message, exception);
+        break;
+    }
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public boolean isLoggable(int level) {
-    // TODO Auto-generated method stub
-    return false;
+    // Oddly LogService#LOG_xxx are deprecated in favour of LogLevel enum, but
+    // the LogLevel enum does not provide integer mappings.
+    switch (level) {
+      case LogService.LOG_ERROR:
+        return isErrorEnabled();
+      case LogService.LOG_WARNING:
+        return isWarnEnabled();
+      case LogService.LOG_INFO:
+        return isInfoEnabled();
+      case LogService.LOG_DEBUG:
+        return isDebugEnabled();
+      default:
+        return false;
+    }
   }
 }

--- a/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LoggerDelegate.java
+++ b/plugins/com.google.cloud.tools.eclipse.test.dependencies/src/com/google/cloud/tools/eclipse/test/dependencies/LoggerDelegate.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.eclipse.test.dependencies;
+
+import org.eclipse.equinox.log.Logger;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LoggerConsumer;
+
+class LoggerDelegate implements Logger {
+  private org.slf4j.Logger logger;
+
+  LoggerDelegate(org.slf4j.Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public String getName() {
+    return logger.getName();
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  @Override
+  public void trace(String message) {
+    logger.trace(message);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    logger.trace(format, arg);
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    logger.trace(format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    logger.trace(format, arguments);
+  }
+
+  @Override
+  public <E extends Exception> void trace(LoggerConsumer<E> consumer) throws E {
+    if (isTraceEnabled()) {
+      consumer.accept(this);
+    }
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override
+  public void debug(String message) {
+    logger.debug(message);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    logger.debug(format, arg);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    logger.debug(format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    logger.debug(format, arguments);
+  }
+
+  @Override
+  public <E extends Exception> void debug(LoggerConsumer<E> consumer) throws E {
+    if (isDebugEnabled()) {
+      consumer.accept(this);
+    }
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  @Override
+  public void info(String message) {
+    logger.info(message);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    logger.info(format, arg);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    logger.info(format, arg1, arg2);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    logger.info(format, arguments);
+  }
+
+  @Override
+  public <E extends Exception> void info(LoggerConsumer<E> consumer) throws E {
+    if (isInfoEnabled()) {
+      consumer.accept(this);
+    }
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+
+  @Override
+  public void warn(String message) {
+    logger.warn(message);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    logger.warn(format, arg);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    logger.warn(format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    logger.warn(format, arguments);
+  }
+
+  @Override
+  public <E extends Exception> void warn(LoggerConsumer<E> consumer) throws E {
+    if (isWarnEnabled()) {
+      consumer.accept(this);
+    }
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+
+  @Override
+  public void error(String message) {
+    logger.error(message);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    logger.error(format, arg);
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    logger.error(format, arg1, arg2);
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    logger.error(format, arguments);
+  }
+
+  @Override
+  public <E extends Exception> void error(LoggerConsumer<E> consumer) throws E {
+    if (isErrorEnabled()) {
+      consumer.accept(this);
+    }
+  }
+
+  @Override
+  public void audit(String message) {
+    logger.info(message);
+  }
+
+  @Override
+  public void audit(String format, Object arg) {
+    logger.info(format, arg);
+  }
+
+  @Override
+  public void audit(String format, Object arg1, Object arg2) {
+    logger.info(format, arg1, arg2);
+  }
+
+  @Override
+  public void audit(String format, Object... arguments) {
+    logger.info(format, arguments);
+  }
+
+  @Override
+  public void log(int level, String message) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void log(int level, String message, Throwable exception) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void log(ServiceReference<?> sr, int level, String message) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void log(ServiceReference<?> sr, int level, String message, Throwable exception) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void log(Object context, int level, String message) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public void log(Object context, int level, String message, Throwable exception) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public boolean isLoggable(int level) {
+    // TODO Auto-generated method stub
+    return false;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -345,9 +345,10 @@
               ${os-jvm-flags}
             </argLine>
             <bundleStartLevel>
+              <!-- use level 3 to ensure we start after other org.eclipse.equinox.* bundles -->
               <bundle>
                  <id>com.google.cloud.tools.eclipse.test.dependencies</id>
-                 <level>1</level>
+                 <level>3</level>
                  <autoStart>true</autoStart>
               </bundle>
            </bundleStartLevel>


### PR DESCRIPTION
Our .test.dependencies bundle is set up to redirect java.util.logging to SLF4j/Logback.  This PR redirects Eclipse's logger too, in the hopes that more compact logging will allow #3528 (which introduces the 2019-09 and now 2019-12 platforms) to succeed.

The Eclipse logger implements the `org.eclipse.equinox.ExtendedLogService` interface, which itself extends `org.osgi.service.log.LogService`.  OSGi has since included a new SLF4j-like LoggerFactory/Logger setup. 