### PR TITLE
Handle avatar URLs with existing resize directives

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanelTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanelTest.java
@@ -168,6 +168,13 @@ public class AccountsPanelTest {
     assertTrue(namesEmails.names.contains("Charlie"));
   }
 
+  @Test
+  public void testResizedImageUrl() {
+    assertEquals("https://lh3/xxxx=s48", AccountsPanel.resizedImageUrl("https://lh3/xxxx", 48));
+    assertEquals(
+        "https://lh3/xxxx=s48", AccountsPanel.resizedImageUrl("https://lh3/xxxx=s96-c", 48));
+  }
+
   private void setUpLoginService(List<Account> accounts) {
     when(loginService.hasAccounts()).thenReturn(!accounts.isEmpty());
     when(loginService.getAccounts()).thenReturn(new HashSet<>(accounts));

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountsPanel.java
@@ -112,12 +112,29 @@ public class AccountsPanel extends PopupDialog {
 
       if (account.getAvatarUrl() != null) {
         try {
-          imageLoader.loadImage(account.getAvatarUrl() + "=s" + avatarSize, avatar);
+          String url = resizedImageUrl(account.getAvatarUrl(), avatarSize);
+          imageLoader.loadImage(url, avatar);
         } catch (MalformedURLException ex) {
           logger.log(Level.WARNING, "malformed avatar image URL", ex);
         }
       }
     }
+  }
+
+  /**
+   * Apply a resize directive to an Google avatar URL, replacing any previous resize directives.
+   *
+   * @param avatarUrl the URL
+   * @param avatarSize the desired image size
+   * @return an amended URL
+   */
+  @VisibleForTesting
+  static String resizedImageUrl(String avatarUrl, int avatarSize) {
+    int index = avatarUrl.lastIndexOf('=');
+    if (index > 0) {
+      avatarUrl = avatarUrl.substring(0, index);
+    }
+    return avatarUrl + "=s" + avatarSize;
   }
 
   private void createButtons(Composite container) {


### PR DESCRIPTION
Fixes #3636 

Strip off any image sizing directives from the avatar URL.  Assumes that the avatar long-codes don't normally include an `=`.

<img width="289" alt="Screen Shot 2021-05-21 at 11 00 33 PM" src="https://user-images.githubusercontent.com/202851/119212779-96028c00-ba88-11eb-86b3-4889160f17d4.png">

---

I'm not sure why but the account info is returning an empty name; it was working earlier on a different machine.  The login confirmation page doesn't show any information requests for name or email:

<img width="435" alt="Screen Shot 2021-05-21 at 11 22 34 PM" src="https://user-images.githubusercontent.com/202851/119213218-8769a400-ba8b-11eb-99d5-30a655906800.png">

I don't know if this is different from before though.