### PR TITLE
Set CLOUDSDK_PYTHON only after performing the Cloud SDK update

### DIFF
--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -8,14 +8,16 @@ set -o errexit
 # Display commands being run.
 set -o xtrace
 
-# More recent Cloud SDK requires Python 3.5 (b/194714889)
-export CLOUDSDK_PYTHON=python3.5
-
 gsutil -q cp "gs://ct4e-m2-repositories-for-kokoro/m2-cache.tar" - \
   | tar -C "${HOME}" -xf -
 
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
 gcloud components update --quiet
+
+# More recent Cloud SDK requires Python 3.5 (b/194714889)
+if [ -z "$CLOUDSDK_PYTHON" ]; then
+    export CLOUDSDK_PYTHON=python3.5
+fi
 gcloud components install app-engine-java --quiet
 
 echo "OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}"


### PR DESCRIPTION
The original installed Cloud SDK needs Python 2.  After being updated, it needs Python 3.