### PR TITLE
Remove log4j from test bundle

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/build.properties
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.localserver.test/build.properties
@@ -4,6 +4,3 @@ bin.includes = META-INF/,\
                .,\
                projects/,\
                plugin.properties
-
-additional.bundles = org.apache.log4j
-jars.extra.classpath = platform:/plugin/org.apache.log4j


### PR DESCRIPTION
Apparently, this is unnecessary. All tests run fine without this.