### PR TITLE
test: fix breakages in tests found during update to Tycho 2.5.0

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeClassicMigratorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.compat.test/src/com/google/cloud/tools/eclipse/appengine/compat/gpe/GpeClassicMigratorTest.java
@@ -57,7 +57,9 @@ public class GpeClassicMigratorTest {
 
   @After
   public void tearDown() throws CoreException {
-    gpeProject.delete(true /* force */,  monitor);
+    if (gpeProject != null) {
+      gpeProject.delete(true /* force */,  monitor);
+    }
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/src/com/google/cloud/tools/eclipse/appengine/facets/ui/navigator/model/ModelRefreshTests.java
@@ -311,10 +311,8 @@ public class ModelRefreshTests {
                   webroot, newWebRoot.getProjectRelativePath(), null);
               ProjectUtils.waitForProjects(project);
             });
-    assertEquals(1, changed.size());
-    assertEquals(
-        project.getFile(".settings/org.eclipse.wst.common.component"),
-        Iterables.getOnlyElement(changed));
+    assertThat(changed,
+        Matchers.hasItem(project.getFile(".settings/org.eclipse.wst.common.component")));
     assertTrue(projectElement.resourcesChanged(changed));
 
     AppEngineResourceElement[] newElements = projectElement.getConfigurations();

--- a/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConversionTests.java
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.standard.java8.test/src/com/google/cloud/tools/eclipse/appengine/standard/java8/ConversionTests.java
@@ -126,7 +126,7 @@ public class ConversionTests {
   @Test
   public void appEngineWebWithNoRuntime()
       throws CoreException, IOException, InterruptedException, SAXException, AppEngineException {
-    IFacetedProject project = projectCreator.getFacetedProject();
+    IFacetedProject project = projectCreator.withFacets().getFacetedProject();
     createAppEngineWebWithNoRuntime(project);
 
     Job conversionJob = new AppEngineStandardProjectConvertJob(project);
@@ -244,7 +244,7 @@ public class ConversionTests {
   @Test
   public void appEngineWebWithJava8Runtime()
       throws CoreException, IOException, InterruptedException, SAXException, AppEngineException {
-    IFacetedProject project = projectCreator.getFacetedProject();
+    IFacetedProject project = projectCreator.withFacets().getFacetedProject();
     createAppEngineWebWithJava8Runtime(project);
 
     Job conversionJob = new AppEngineStandardProjectConvertJob(project);


### PR DESCRIPTION
The update to Tycho 2.5.0 revealed a few mistaken assumptions in the tests — at least, they no longer hold, perhaps because of Tycho's switch to  using the Equinox bundle resolver.  Separating these fixes from #3663 to ensure we're not breaking anything currently.
- `GpeClassicMigratorTest`: NPE seen in tearDown if the test failed to create a project
- `ModelRefreshTests`: perhaps due to the bundle resolving, we now see changes to additional files other than the facet definition file in `org.eclipse.wst.common.component`
- `ConversionTests`: assumed a faceted project was created, even though we didn't ask for it. I'm not sure how this wasn't failing previously!