### PR TITLE
Update download link to point to archive

### DIFF
--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
@@ -27,7 +27,7 @@
       <unit id="org.eclipse.wst.web_sdk.feature.feature.group" version="3.11.0.v201807251925"/>
       <unit id="org.eclipse.jst.enterprise_sdk.feature.feature.group" version="3.8.1.v201802202154"/>
       <unit id="org.eclipse.wst.server_adapters.sdk.feature.feature.group" version="3.2.601.v201802152148"/>
-      <repository location="http://download.eclipse.org/webtools/downloads/drops/R3.11.0/R-3.11.0-20180910170749/repository"/>
+      <repository location="https://archive.eclipse.org/webtools/downloads/drops/R3.11.0/R-3.11.0-20180910170749/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.0.1.201809121533"/>

--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.tpd
@@ -34,7 +34,7 @@ location "http://download.eclipse.org/releases/2018-09/201809191002/" {
 
 // WTP SDKs aren't exposed through the main release links
 // (composite at http://download.eclipse.org/webtools/repository/2018-09)
-location "http://download.eclipse.org/webtools/downloads/drops/R3.11.0/R-3.11.0-20180910170749/repository" {
+location "https://archive.eclipse.org/webtools/downloads/drops/R3.11.0/R-3.11.0-20180910170749/repository/" {
     org.eclipse.jst.web_sdk.feature.feature.group
     org.eclipse.jst.server_sdk.feature.feature.group
     org.eclipse.jst.common.fproj.enablement.jdt.sdk.feature.group


### PR DESCRIPTION
Version 3.11.0 was moved to archive. 