### PR TITLE
Try to find unit testing dependencies in an archive

### DIFF
--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
+++ b/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
+++ b/eclipse/eclipse-2018-12/gcp-eclipse-2018-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
+++ b/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
+++ b/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
+++ b/eclipse/eclipse-2019-09/gcp-eclipse-2019-09.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
+++ b/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
+++ b/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
+++ b/eclipse/eclipse-2019-12/gcp-eclipse-2019-12.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
+++ b/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
+++ b/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>

--- a/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
+++ b/eclipse/eclipse-2020-03/gcp-eclipse-2020-03.target
@@ -42,7 +42,7 @@
       <unit id="org.slf4j.apis.log4j" version="1.7.30.v20200204-2150"/>
       <unit id="org.slf4j.bridge.jul" version="1.7.30.v20200204-2150"/>
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.dadacoalition.yedit.feature.feature.group" version="1.0.20.201509041456-RELEASE"/>


### PR DESCRIPTION
Some of the old libraries seem to have moved away from the "latest" directories and are only available in dated archives. 

I've re-ran the last successful build, and it has these types of errors:
```
com.google.cloud.tools.eclipse.test.util: Failed to resolve target definition /home/runner/work/google-cloud-eclipse/google-cloud-eclipse/eclipse/eclipse-2018-09/gcp-eclipse-2018-09.target: Could not find "org.hamcrest.integration/1.3.0.v201305210900" in the repositories of the current location
```

Updating the target files to a dated folder fixes this issue, but updating the target files manually is not ideal.

To do it "properly", I installed an old version of Eclipse to match one of our integration test versions (4.15, from 2020-03), but I was not able to generate targets from TPD file, since it tries to load dependencies from `latest-R`. 