### PR TITLE
update readme with supported Eclipse versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Maven for building Eclipse bundles and features.
 
 4. The [Eclipse IDE](https://www.eclipse.org/downloads/eclipse-packages/).
    It's easiest to use the _Eclipse IDE for Java EE Developers_ package. You must use
-   Eclipse 4.9 or later.  We use _target platforms_ to support building
+   Eclipse 4.9 - 4.21 (versions since 4.22 are currently not supported).  We use _target platforms_ to support building
    for earlier versions of Eclipse.  You also need the following:
 
    1. The [M2Eclipse plugin](http://www.eclipse.org/m2e/) (also called m2e) is


### PR DESCRIPTION
update readme with info to reflect that Eclipse 4.22 and later are currently not supported. Eclipse latest is currently on 4.24 now and 4.25 will come out soon.
Related issues got filed in #3659, #3660, #3678; attempts to fix in #3661 but no progress since.
Suggest adding this to readme and removing when this issue actually get fixed.