### PR TITLE
chore: enable building in latest Eclipse

### DIFF
--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/pom.xml
@@ -10,15 +10,4 @@
   <artifactId>com.google.cloud.tools.eclipse.3rdparty.feature</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
-
-  <properties>
-    <!--
-      Workaround https://github.com/eclipse-tycho/tycho/issues/1377 where
-      loading the tycho-buildtimestamp-jgit provider causes build failures
-      in this feature with Tycho 2.7.x.  This feature isn't surfaced to
-      users and so the build number is of no significance.
-    -->
-    <tycho.buildtimestamp.provider/>
-  </properties>
-
 </project>

--- a/features/com.google.cloud.tools.eclipse.3rdparty.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.3rdparty.feature/pom.xml
@@ -10,4 +10,15 @@
   <artifactId>com.google.cloud.tools.eclipse.3rdparty.feature</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
+
+  <properties>
+    <!--
+      Workaround https://github.com/eclipse-tycho/tycho/issues/1377 where
+      loading the tycho-buildtimestamp-jgit provider causes build failures
+      in this feature with Tycho 2.7.x.  This feature isn't surfaced to
+      users and so the build number is of no significance.
+    -->
+    <tycho.buildtimestamp.provider/>
+  </properties>
+
 </project>

--- a/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.googleapis/pom.xml
@@ -150,5 +150,41 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!--
+        This plugin's configuration is used to store Eclipse m2e
+        settings only. It has no influence on the Maven build itself.
+        -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[2.8,)</versionRange>
+                    <goals>
+                      <goal>copy-dependencies</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <!-- cause copy-dependencies to run on any full workspace change -->
+                    <execute>
+                      <runOnIncremental>true</runOnIncremental>
+                      <runOnConfiguration>true</runOnConfiguration>
+                    </execute>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,11 @@
     <!-- Execution environment supported by Cloud Tools for Eclipse -->
     <requiredExecutionEnvironment>JavaSE-1.8</requiredExecutionEnvironment>
 
-    <tycho.version>2.7.5</tycho.version>
-    <tycho-extras.version>2.7.5</tycho-extras.version>
+    <!-- use Tycho 2.6.0 for builds to avoid triggering
+        https://github.com/eclipse-tycho/tycho/issues/1377 -->
+    <tycho.version>2.6.0</tycho.version>
+    <tycho-extras.version>2.6.0</tycho-extras.version>
+
     <product.version.qualifier.suffix/>  <!-- 0-length string by default -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>2018-09</eclipse.target> <!-- the default build -->
@@ -414,6 +417,28 @@
       </activation>
       <properties>
         <os-jvm-flags>-XstartOnFirstThread</os-jvm-flags>
+      </properties>
+    </profile>
+
+    <profile>
+      <!--
+        Tycho 2.7.4+ includes lifecycle mapping metadata to instruct
+        Eclipse/m2eclipse how to handle the various Tycho plugins.
+        But Tycho 2.7.4+ has a bug where loading the
+        tycho-buildtimestamp-jgit provider causes build failures
+        (https://github.com/eclipse-tycho/tycho/issues/1377),
+        so we can only use it when loading into m2eclipse.
+      -->
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <properties>
+        <tycho.version>2.7.5</tycho.version>
+        <tycho-extras.version>2.7.5</tycho-extras.version>
+        <tycho.buildtimestamp.provider/>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <!-- Execution environment supported by Cloud Tools for Eclipse -->
     <requiredExecutionEnvironment>JavaSE-1.8</requiredExecutionEnvironment>
 
-    <tycho.version>2.5.0</tycho.version>
-    <tycho-extras.version>2.5.0</tycho-extras.version>
+    <tycho.version>2.7.5</tycho.version>
+    <tycho-extras.version>2.7.5</tycho-extras.version>
     <product.version.qualifier.suffix/>  <!-- 0-length string by default -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.target>2018-09</eclipse.target> <!-- the default build -->


### PR DESCRIPTION
- Update to Tycho 2.6.0: we can't update to 2.7.5 due to eclipse-tycho/tycho/issues/1377
- But use an m2eclipse-specific profile to use Tycho 2.7.5 within the IDE as it includes lifecycle-mapping definitions for the tycho plugins and avoids the need for the now-defunct tycho configurator
- Configure the c.g.c.t.e.googleapis `copy-dependencies` to be executed on workspace change, and avoid the need for the maven-dependency-plugin configurator
