### PR TITLE
fix: correct ptos disable configuration in tests

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.deploy.test/pom.xml
@@ -16,14 +16,16 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <disablePrivacyTos>true</disablePrivacyTos>
+          </systemProperties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <systemProperties>
-            <disablePrivacyTos>true</disablePrivacyTos>
-          </systemProperties>
           <dependency-resolution>
             <extraRequirements>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.facets.test/pom.xml
@@ -16,14 +16,16 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <disablePrivacyTos>true</disablePrivacyTos>
+          </systemProperties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <systemProperties>
-            <disablePrivacyTos>true</disablePrivacyTos>
-          </systemProperties>
           <dependency-resolution>
             <extraRequirements>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.appengine.libraries.ui.test/pom.xml
@@ -16,14 +16,16 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+            <systemProperties>
+              <disablePrivacyTos>true</disablePrivacyTos>
+            </systemProperties>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <systemProperties>
-            <disablePrivacyTos>true</disablePrivacyTos>
-          </systemProperties>
           <dependency-resolution>
             <extraRequirements>
               <requirement>

--- a/plugins/com.google.cloud.tools.eclipse.googleapis.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.googleapis.test/pom.xml
@@ -16,6 +16,11 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+            <systemProperties>
+              <disablePrivacyTos>true</disablePrivacyTos>
+            </systemProperties>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/plugins/com.google.cloud.tools.eclipse.login.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/pom.xml
@@ -16,6 +16,11 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+            <systemProperties>
+              <disablePrivacyTos>true</disablePrivacyTos>
+            </systemProperties>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/plugins/com.google.cloud.tools.eclipse.ui.test/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.ui.test/pom.xml
@@ -17,10 +17,10 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
-        <systemProperties>
+          <systemProperties>
             <disablePrivacyTos>true</disablePrivacyTos>
-        </systemProperties>
-    </configuration>
+          </systemProperties>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
some poms had their `<disablePrivacyTos/>` tag in the wrong plugin configuration - moved them to `tycho-surefire-plugin`.
Suspected cause of 180 min timeout in latest release attempt