### PR TITLE
fix: remove unnecesary welcome page links to ptos

### DIFF
--- a/features/com.google.cloud.tools.eclipse.suite.feature/feature.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.cloud.tools.eclipse.suite.feature"
       label="Google Cloud Platform for Eclipse"
-      version="1.9.0.qualifier"
+      version="1.9.1.qualifier"
       provider-name="Google LLC"
       plugin="com.google.cloud.tools.eclipse.ui"
       license-feature="com.google.licenses.apache_v2">

--- a/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
+++ b/features/com.google.cloud.tools.eclipse.suite.feature/pom.xml
@@ -8,7 +8,7 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.suite.feature</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>1.9.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
   <build>

--- a/gcp-repo/metadata.product
+++ b/gcp-repo/metadata.product
@@ -9,7 +9,7 @@
   .p2.inf).  p2 generates unique qualifiers for categories, so it would be
   best for our non-release builds to have unique versions too.
 -->
-<product uid="com.google.cloud.tools.eclipse.dist" version="1.9.0.qualifier" useFeatures="true" includeLaunchers="false">
+<product uid="com.google.cloud.tools.eclipse.dist" version="1.9.1.qualifier" useFeatures="true" includeLaunchers="false">
 
    <configIni use="default">
    </configIni>

--- a/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
+++ b/plugins/com.google.cloud.tools.eclipse.integration.appengine/pom.xml
@@ -9,7 +9,8 @@
   </parent>
   <artifactId>com.google.cloud.tools.eclipse.integration.appengine</artifactId>
   <version>0.1.0-SNAPSHOT</version>
-  <packaging>eclipse-test-plugin</packaging>
+  <!-- https://github.com/GoogleCloudPlatform/google-cloud-eclipse/issues/3702 -->
+  <!-- <packaging>eclipse-test-plugin</packaging> -->
 
   <build>
     <plugins>

--- a/plugins/com.google.cloud.tools.eclipse.welcome.test/src/com/google/cloud/tools/eclipse/welcome/ContentXmlTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.welcome.test/src/com/google/cloud/tools/eclipse/welcome/ContentXmlTest.java
@@ -38,7 +38,7 @@ public class ContentXmlTest {
   @Test
   public void testWellFormed() throws ParserConfigurationException, IOException, SAXException {
     Document document = parseDocument("intro/cloud-tools-for-eclipse.xml");
-    assertEquals(6, document.getElementsByTagName("extensionContent").getLength());
+    assertEquals(4, document.getElementsByTagName("extensionContent").getLength());
   }
 
   @Test

--- a/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
+++ b/plugins/com.google.cloud.tools.eclipse.welcome/intro/cloud-tools-for-eclipse.xml
@@ -11,30 +11,6 @@
       </link>
     </group>
   </extensionContent>
-  
-  <extensionContent id="com.google.cloud.tools.eclipse.tos" name="Cloud Tools for Eclipse Terms of Service"
-      path="overview/@" style="css/intro.css">
-    <group style-id="content-group">
-      <link id="cloud-tools-for-eclipse-tos-link"
-            label="Google Cloud Tools for Eclipse Terms of Service"
-            style-id="content-link"
-            url="https://policies.google.com/terms">"
-        <text>View Cloud tools for Eclipse Terms of Service</text>
-      </link>
-    </group>
-  </extensionContent>
-  <extensionContent id="com.google.cloud.tools.eclipse.tos" name="Cloud Tools for Eclipse Privacy Policy"
-      path="overview/@" style="css/intro.css">
-    <group style-id="content-group">
-      <link id="cloud-tools-for-eclipse-privacy-link"
-            label="Google Cloud Tools for Eclipse Privacy Policy"
-            style-id="content-link"
-            url="https://policies.google.com/privacy">"
-        <text>View Cloud tools for Eclipse Privacy Policy</text>
-      </link>
-    </group>
-  </extensionContent>
-
   <extensionContent id="com.google.cloud.tools.eclipse.tutorials" name="Cloud Tools for Eclipse Tutorials"
       path="tutorials/@" style="css/intro.css">
     <group style-id="content-group" label="Google Cloud Tools for Eclipse">
@@ -58,7 +34,6 @@
       </link>
     </group>
   </extensionContent>
-
   <extensionContent id="com.google.cloud.tools.eclipse.whatsnew" name="What's New in Cloud Tools for Eclipse"
       path="whatsnew/@" style="css/intro.css">
     <group style-id="content-group">


### PR DESCRIPTION
P/TOS is already available in a popup when the app starts and in the preferences section.