### PR TITLE
chore: adapt tests of `AccountSelector`

### DIFF
--- a/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
+++ b/plugins/com.google.cloud.tools.eclipse.login.test/src/com/google/cloud/tools/eclipse/login/ui/AccountSelectorTest.java
@@ -16,12 +16,18 @@
 
 package com.google.cloud.tools.eclipse.login.ui;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.tools.eclipse.googleapis.Account;
-import com.google.cloud.tools.eclipse.login.IGoogleLoginService;
+import com.google.cloud.tools.eclipse.googleapis.IGoogleApiFactory;
 import com.google.cloud.tools.eclipse.test.util.ui.ShellTestResource;
+import java.util.Optional;
 import org.eclipse.swt.widgets.Shell;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -37,14 +43,14 @@ public class AccountSelectorTest {
 
   @Rule public ShellTestResource shellTestResource = new ShellTestResource();
   private Shell shell;
-
-  @Mock private IGoogleLoginService loginService;
+  
   @Mock private Account account1;
   @Mock private Account account2;
   @Mock private Account account3;
   @Mock private Credential credential1;
   @Mock private Credential credential2;
   @Mock private Credential credential3;
+  @Mock private IGoogleApiFactory apiFactory;
 
   @Before
   public void setUp() {
@@ -55,283 +61,90 @@ public class AccountSelectorTest {
     when(account2.getOAuth2Credential()).thenReturn(credential2);
     when(account3.getEmail()).thenReturn("some-email-3@example.com");
     when(account3.getOAuth2Credential()).thenReturn(credential3);
+    setAccount(null);
+  }
+  
+  private void setAccount(Account account) {
+    if (account != null) {
+      when(apiFactory.getAccount()).thenReturn(Optional.of(account));
+      when(apiFactory.getCredential()).thenReturn(Optional.of(account.getOAuth2Credential()));
+    } else {
+      when(apiFactory.getAccount()).thenReturn(Optional.empty());
+      when(apiFactory.getCredential()).thenReturn(Optional.empty());
+    }
   }
  
   @Test
   public void testComboSetup_noAccount() {
-//    when(loginService.getAccounts()).thenReturn(new HashSet<Account>());
-//
-//    AccountSelector selector = new AccountSelector(shell, loginService);
-//    assertEquals(-1, selector.combo.getSelectionIndex());
-//    assertNull(selector.getSelectedCredential());
-//    assertTrue(selector.getSelectedEmail().isEmpty());
-//    assertEquals(1, selector.combo.getItemCount());
-//    assertEquals("<Sign into another account...>", selector.combo.getItem(0));
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
+    assertEquals(0, selector.getAccountCount());
+    assertNull(selector.getSelectedCredential());
+    assertTrue(selector.getSelectedEmail().isEmpty());
+    assertFalse(selector.isEmailAvailable("some-email-1@example.com"));
+    assertFalse(selector.isEmailAvailable("some-email-2@example.com"));
+    assertFalse(selector.isEmailAvailable("some-email-3@example.com"));
+    assertFalse(selector.isSignedIn());
   }
 
-  /**
   @Test
   public void testComboSetup_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
-
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(-1, selector.combo.getSelectionIndex());
+    setAccount(account1);
+    
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
+    assertNotNull(selector.getSelectedCredential());
+    assertFalse(selector.getSelectedEmail().isEmpty());
+    assertEquals(1, selector.getAccountCount());
+    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
+    assertTrue(selector.isEmailAvailable("some-email-1@example.com"));
+    assertTrue(selector.isSignedIn());
+    
+    setAccount(null);
+    
+    assertEquals(0, selector.getAccountCount());
     assertNull(selector.getSelectedCredential());
     assertTrue(selector.getSelectedEmail().isEmpty());
-    assertEquals(2, selector.combo.getItemCount());
-    assertEquals("some-email-1@example.com", selector.combo.getItem(0));
-    assertEquals("<Sign into another account...>", selector.combo.getItem(1));
-  }
-
-  @Test
-  public void testComboSetup_threeAccounts() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertNull(selector.getSelectedCredential());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-    assertEquals(4, selector.combo.getItemCount());
-    String allEmails =
-        selector.combo.getItem(0) + selector.combo.getItem(1) + selector.combo.getItem(2);
-    assertTrue(allEmails.contains("some-email-1@example.com"));
-    assertTrue(allEmails.contains("some-email-2@example.com"));
-    assertTrue(allEmails.contains("some-email-3@example.com"));
-    assertEquals("<Sign into another account...>", selector.combo.getItem(3));
+    assertFalse(selector.isEmailAvailable("some-email-1@example.com"));
+    assertFalse(selector.isEmailAvailable("some-email-2@example.com"));
+    assertFalse(selector.isEmailAvailable("some-email-3@example.com"));
+    assertFalse(selector.isSignedIn());
   }
 
 
   @Test
   public void testIsEmailAvailable_noAccount() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<Account>());
-
-    AccountSelector selector = new AccountSelector(shell, loginService);
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
     assertFalse(selector.isEmailAvailable(null));
     assertFalse(selector.isEmailAvailable(""));
-  }
-
-  @Test
-  public void testIsEmailAvailable_threeAccounts() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertFalse(selector.isEmailAvailable(null));
-    assertFalse(selector.isEmailAvailable(""));
-    assertTrue(selector.isEmailAvailable("some-email-1@example.com"));
-    assertTrue(selector.isEmailAvailable("some-email-2@example.com"));
-    assertTrue(selector.isEmailAvailable("some-email-3@example.com"));
   }
 
   @Test
   public void testGetSelectedCredential() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
 
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertNull(selector.getSelectedCredential());
-
-    int index = selector.combo.indexOf("some-email-2@example.com");
-    simulateSelect(selector, index);
-
-    assertEquals(index, selector.combo.getSelectionIndex());
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-    assertEquals("some-email-2@example.com", selector.combo.getItem(index));
-    assertEquals(credential2, selector.getSelectedCredential());
-  }
-
-  @Test
-  public void testSelectAccount_nonExistingEmailClearsSelection() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-
-    selector.selectAccount("some-email-2@example.com");
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-
-    selector.selectAccount("non-existing-email@example.com");
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testSelectAccount() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
     assertTrue(selector.getSelectedEmail().isEmpty());
     assertNull(selector.getSelectedCredential());
-
-    selector.selectAccount("some-email-2@example.com");
-
-    assertNotEquals(-1, selector.combo.getSelectionIndex());
+    
+    setAccount(account1);
+    
     assertEquals("some-email-2@example.com", selector.getSelectedEmail());
     assertEquals(credential2, selector.getSelectedCredential());
-  }
-
-  @Test
-  public void testSelectAccount_nonExistingEmail() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
+    
+    setAccount(null);
+    
     assertTrue(selector.getSelectedEmail().isEmpty());
-
-    selector.selectAccount("non-existing-email@example.com");
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testSelectAccount_nullOrEmptyEmail() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-
-    selector.selectAccount(null);
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-
-    selector.selectAccount("");
-
-    assertEquals(-1, selector.combo.getSelectionIndex());
-    assertTrue(selector.getSelectedEmail().isEmpty());
-  }
-
-  @Test
-  public void testLogin_itemAddedAtTopAndSelected() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    when(loginService.logIn()).thenReturn(account3);
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(3, selector.combo.getItemCount());
-
-    assertEquals("<Sign into another account...>", selector.combo.getItem(2));
-    simulateSelect(selector, 2);
-
-    assertEquals(4, selector.combo.getItemCount());
-    assertEquals("some-email-3@example.com", selector.getSelectedEmail());
-    assertEquals("some-email-3@example.com", selector.combo.getItem(0));
-    assertEquals(0, selector.combo.getSelectionIndex());
-    assertEquals(credential3, selector.getSelectedCredential());
-    assertEquals("<Sign into another account...>", selector.combo.getItem(3));
-  }
-
-  @Test
-  public void testLogin_existingEmail() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account1, account2, account3)));
-    when(loginService.logIn()).thenReturn(account1);
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(4, selector.combo.getItemCount());
-    assertEquals(-1, selector.combo.getSelectionIndex());
-
-    assertEquals("<Sign into another account...>", selector.combo.getItem(3));
-    simulateSelect(selector, 3);
-
-    assertEquals(4, selector.combo.getItemCount());
-    assertNotEquals(-1, selector.combo.getSelectionIndex());
-    assertEquals("some-email-1@example.com", selector.getSelectedEmail());
-    assertEquals("some-email-1@example.com", selector.combo.getText());
-    assertEquals(credential1, selector.getSelectedCredential());
-  }
-
-  @Test
-  public void testFailedLogin_reselectLoginLinkItem() {
-    when(loginService.getAccounts()).thenReturn(new HashSet<>(Arrays.asList(account1, account2)));
-    when(loginService.logIn()).thenReturn(null);
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(3, selector.combo.getItemCount());
-
-    simulateSelect(selector, 1);
-    assertEquals(1, selector.combo.getSelectionIndex());
-    assertNotNull(selector.getSelectedCredential());
-    assertFalse(selector.getSelectedEmail().isEmpty());
-
-    assertEquals("<Sign into another account...>", selector.combo.getItem(2));
-    simulateSelect(selector, 2);
-
-    assertEquals(3, selector.combo.getItemCount());
-    assertEquals(1, selector.combo.getSelectionIndex());
-    assertEquals(credential2, selector.getSelectedCredential());
-    assertEquals("some-email-2@example.com", selector.getSelectedEmail());
-    assertEquals("some-email-2@example.com", selector.combo.getText());
+    assertNull(selector.getSelectedCredential());
   }
 
   @Test
   public void testIsSignedIn_notSignedIn() {
-    AccountSelector selector = new AccountSelector(shell, loginService);
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
     assertFalse(selector.isSignedIn());
   }
 
   @Test
   public void testIsSignedIn_signedIn() {
-    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
-    AccountSelector selector = new AccountSelector(shell, loginService);
+    setAccount(account1);
+    AccountSelector selector = new AccountSelector(shell, apiFactory);
     assertTrue(selector.isSignedIn());
   }
-
-  @Test
-  public void testGetAccountCount() {
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(0, selector.getAccountCount());
-  }
-
-  @Test
-  public void testGetAccountCount_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(Collections.singleton(account1));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(1, selector.getAccountCount());
-  }
-
-  @Test
-  public void testGetAccountCount_threeAccounts() {
-    when(loginService.getAccounts()).thenReturn(
-        new HashSet<>(Arrays.asList(account1, account2, account3)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(3, selector.getAccountCount());
-  }
-
-  @Test
-  public void testInitialItemOrder() {
-    when(loginService.getAccounts())
-        .thenReturn(new HashSet<>(Arrays.asList(account3, account2, account1)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(4, selector.combo.getItemCount());
-    assertEquals(account1.getEmail(), selector.combo.getItem(0));
-    assertEquals(account2.getEmail(), selector.combo.getItem(1));
-    assertEquals(account3.getEmail(), selector.combo.getItem(2));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testGetFirstEmail_noAccount() {
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    selector.getFirstEmail();
-  }
-
-  @Test
-  public void testGetFirstEmail_oneAccount() {
-    when(loginService.getAccounts()).thenReturn(Collections.singleton(account2));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(account2.getEmail(), selector.getFirstEmail());
-  }
-
-  @Test
-  public void testGetFirstEmail_threeAccounts() {
-    when(loginService.getAccounts())
-       .thenReturn(new HashSet<>(Arrays.asList(account3, account2, account1)));
-    AccountSelector selector = new AccountSelector(shell, loginService);
-    assertEquals(account1.getEmail(), selector.getFirstEmail());  // Accounts are sorted.
-  }
-
-  private void simulateSelect(AccountSelector selector, int index) {
-    new SWTBotCombo(selector.combo).setSelection(index);
-  }
-  **/
 }

--- a/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
+++ b/plugins/com.google.cloud.tools.eclipse.login/src/com/google/cloud/tools/eclipse/login/ui/AccountSelector.java
@@ -83,8 +83,7 @@ public class AccountSelector extends Composite {
    * (By its contract, {@link Account} never carries a {@code null} {@link Credential}.)
    */
   public Credential getSelectedCredential() {
-    Optional<Account> account = getSelectedAccount();
-    return account.isPresent() ? account.get().getOAuth2Credential() : null;
+    return getSelectedAccount().map(Account::getOAuth2Credential).orElse(null);
   }
 
   /**


### PR DESCRIPTION
Fixes missing tests for `com.google.cloud.tools.eclipse.login.ui.AccountSelector`