### PR TITLE
chore: update python version in release.sh

### DIFF
--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -15,7 +15,7 @@ gcloud components update --quiet
 
 # More recent Cloud SDK requires Python 3.5 (b/194714889)
 if [ -z "$CLOUDSDK_PYTHON" ]; then
-    export CLOUDSDK_PYTHON=python3.5
+    export CLOUDSDK_PYTHON=python3.12
 fi
 gcloud components install app-engine-java --quiet
 

--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -13,7 +13,7 @@ gsutil -q cp "gs://ct4e-m2-repositories-for-kokoro/m2-cache.tar" - \
 export CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
 gcloud components update --quiet
 
-# More recent Cloud SDK requires Python 3.5 (b/194714889)
+# More recent Cloud SDK requires Python 3.8 - 3.12
 if [ -z "$CLOUDSDK_PYTHON" ]; then
     export CLOUDSDK_PYTHON=python3.12
 fi


### PR DESCRIPTION
fixes release workflow:

```
ERROR: gcloud failed to load. You are running gcloud with Python 3.5, which is no longer supported by gcloud.
Install a compatible version of Python 3.8-3.12 and set the CLOUDSDK_PYTHON environment variable to point to it.
```